### PR TITLE
Visitor stub for crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,4 @@ extern crate log;
 
 pub mod callbacks;
 pub mod utils;
+pub mod visitors;

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use rustc::hir::{self, itemlikevisit, ImplItemKind, ItemKind, TraitItemKind, TraitMethod};
+use rustc::ty::TyCtxt;
+use rustc_driver::driver;
+
+/// Holds the state for the crate visitor.
+pub struct CrateVisitor<'a, 'tcx: 'a> {
+    pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
+    pub state: &'a driver::CompileState<'a, 'tcx>,
+}
+
+/// Provides methods that are called by Crate.visit_all_item_likes whenever it traverses
+/// to an item like node. We use this to identify functions and methods that might have
+/// code to analyze.
+impl<'a, 'tcx: 'a, 'hir> itemlikevisit::ItemLikeVisitor<'hir> for CrateVisitor<'a, 'tcx> {
+    fn visit_item(&mut self, item: &'hir hir::Item) {
+        if let ItemKind::Fn(.., body_id) = item.node {
+            let did = self.tcx.hir.body_owner_def_id(body_id);
+            info!("analyzing {}", self.tcx.def_path_debug_str(did));
+        }
+    }
+    fn visit_trait_item(&mut self, trait_item: &'hir hir::TraitItem) {
+        if let TraitItemKind::Method(.., TraitMethod::Provided(body_id)) = trait_item.node {
+            let did = self.tcx.hir.body_owner_def_id(body_id);
+            info!("analyzing {}", self.tcx.def_path_debug_str(did));
+        }
+    }
+    fn visit_impl_item(&mut self, impl_item: &'hir hir::ImplItem) {
+        if let ImplItemKind::Method(.., body_id) = impl_item.node {
+            let did = self.tcx.hir.body_owner_def_id(body_id);
+            info!("analyzing {}", self.tcx.def_path_debug_str(did));
+        }
+    }
+}
+
+// todo: remove this once issue #10 is resolved.
+trait TestTrait {
+    #[cfg_attr(tarpaulin, skip)]
+    fn test_method() {}
+}


### PR DESCRIPTION
## Description

Create a visitor with methods that is invoked  by Crate.visit_all_item_likes whenever it traverses
to an item like node in the crate being compiled.

The method implementations filters out any items that do not correspond to functions/methods with bodies and logs a message for each remaining item.

Partial implementation of the work item described in #11 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

This is covered by existing tests, provided that a dummy trait is added to the Mirai code base, which currently does not have any trait definitions.
