### PR TITLE
Use a specially crafted source file for the integration test

### DIFF
--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -36,9 +36,3 @@ impl<'a, 'tcx: 'a, 'hir> itemlikevisit::ItemLikeVisitor<'hir> for CrateVisitor<'
         }
     }
 }
-
-// todo: remove this once issue #10 is resolved.
-trait TestTrait {
-    #[cfg_attr(tarpaulin, skip)]
-    fn test_method() {}
-}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26,7 +26,7 @@ fn invoke_driver() {
     rustc_driver::run(|| {
         let command_line_arguments: Vec<String> = vec![
             String::from("--crate-name mirai"),
-            String::from("src/lib.rs"),
+            String::from("tests/run-pass/crate_traversal.rs"),
             String::from("--crate-type"),
             String::from("lib"),
             String::from("-C"),

--- a/tests/run-pass/crate_traversal.rs
+++ b/tests/run-pass/crate_traversal.rs
@@ -1,0 +1,16 @@
+// A small trait to test crate traversal
+
+trait TestTrait {
+    fn test_method() {}
+}
+
+struct TestStruct {
+     test_field: i64
+}
+
+impl TestStruct {
+    fn test_function() {}
+    fn test_method(&self) {}
+}
+
+fn main() {}


### PR DESCRIPTION
## Description

To get code coverage of the visitor functions we need a test file that includes constructs that may not be used in the sources of Mirai itself.

It would be good to have many test files and to use something like [compiletest-rs](https://crates.io/crates/compiletest_rs), but as described in issue #10 the simple way to do that does not provide code coverage information.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?
cargo test
