### PR TITLE
Stubs for visiting MIR nodes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - tests/.*
+  - src/main.rs

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,11 @@ cache:
 
 before_cache:
   # install code coverage tool
-  #  - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin
+  - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin
 
 before_script:
 # Compute the rust version we use. We do not use "language: rust" to have more control here.
-- |
-  if [ "$TRAVIS_EVENT_TYPE" = cron ]; then
-    RUST_TOOLCHAIN=nightly
-  else
-    RUST_TOOLCHAIN=$(cat rust-version)
-  fi
+- RUST_TOOLCHAIN=nightly
 # install Rust
 - curl https://build.travis-ci.org/files/rustup-init.sh -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
 - export PATH=$HOME/.cargo/bin:$PATH

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -97,19 +97,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -205,8 +205,8 @@ dependencies = [
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
-"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
+"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -76,5 +76,9 @@ sources.
 
 ## Testing
 
-For now we test mirai by running it on itself, by doing `cargo build` in the mirai directory while setting the 
-`RUSTC_WRAPPER` environment variable to `mirai`.
+Testing is done via `cargo test`. We favor integration tests over unit tests and require every pull request to have 100%
+test coverage. The code coverage tool (`cargo tarpaulin`) is still buggy, so this may not always be possible, but all
+exceptions should be called out and explained in the pull request test plan.
+
+For the time being (see issue #10), we provide a separate test method in integration_tests.rs for each test input in
+the [tests/run-pass](https://github.com/facebookexperimental/MIRAI/blob/master/tests/run-pass) directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate rustc_codegen_utils;
 extern crate rustc_driver;
 extern crate rustc_metadata;
 extern crate syntax;
+extern crate syntax_pos;
 
 #[macro_use]
 extern crate log;

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -3,36 +3,457 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use rustc::hir::{self, itemlikevisit, ImplItemKind, ItemKind, TraitItemKind, TraitMethod};
+use rustc::hir;
+use rustc::mir;
 use rustc::ty::TyCtxt;
-use rustc_driver::driver;
+use std::borrow::Borrow;
+use syntax_pos;
 
-/// Holds the state for the crate visitor.
-pub struct CrateVisitor<'a, 'tcx: 'a> {
+/// Holds the state for the MIR test visitor.
+pub struct MirTestVisitor<'a, 'tcx: 'a> {
     pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    pub state: &'a driver::CompileState<'a, 'tcx>,
+    pub def_id: hir::def_id::DefId,
+    pub mir: &'a mir::Mir<'tcx>,
 }
 
-/// Provides methods that are called by Crate.visit_all_item_likes whenever it traverses
-/// to an item like node. We use this to identify functions and methods that might have
-/// code to analyze.
-impl<'a, 'tcx: 'a, 'hir> itemlikevisit::ItemLikeVisitor<'hir> for CrateVisitor<'a, 'tcx> {
-    fn visit_item(&mut self, item: &'hir hir::Item) {
-        if let ItemKind::Fn(.., body_id) = item.node {
-            let did = self.tcx.hir.body_owner_def_id(body_id);
-            info!("analyzing {}", self.tcx.def_path_debug_str(did));
+/// A visitor that simply traverses enough of the MIR associated with a particular code body
+/// so that we can test a call to every default implementation of the MirVisitor trait.
+impl<'a, 'tcx: 'a> MirVisitor<'a, 'tcx> for MirTestVisitor<'a, 'tcx> {
+    /// Visits each basic block in order of occurrence.
+    fn visit_body(&self) {
+        debug!("visit_body({:?})", self.def_id);
+
+        for bb in self.mir.basic_blocks().indices() {
+            self.visit_basic_block(bb);
         }
     }
-    fn visit_trait_item(&mut self, trait_item: &'hir hir::TraitItem) {
-        if let TraitItemKind::Method(.., TraitMethod::Provided(body_id)) = trait_item.node {
-            let did = self.tcx.hir.body_owner_def_id(body_id);
-            info!("analyzing {}", self.tcx.def_path_debug_str(did));
+
+    /// Returns the collection of statements and the terminator corresponding to the given basic block.
+    fn basic_block_data(&self, bb: mir::BasicBlock) -> &mir::BasicBlockData {
+        &self.mir[bb]
+    }
+}
+
+/// Defines visitor methods for all of the things that constitute a MIR representation of a code body.
+pub trait MirVisitor<'a, 'tcx> {
+    /// Visits the basic blocks in the body in an order determined by the implementor of this trait.
+    fn visit_body(&self);
+
+    /// Returns the collection of statements and the terminator corresponding to the given basic block.
+    fn basic_block_data(&self, bb: mir::BasicBlock) -> &mir::BasicBlockData;
+
+    /// Visit each statement in order and then visits the terminator.
+    fn visit_basic_block(&self, bb: mir::BasicBlock) {
+        debug!("visit_basic_block({:?})", bb);
+
+        let mir::BasicBlockData {
+            ref statements,
+            ref terminator,
+            ..
+        } = self.basic_block_data(bb);
+        let mut location = bb.start_location();
+        let terminator_index = statements.len();
+
+        while location.statement_index < terminator_index {
+            self.visit_statement(location, &statements[location.statement_index]);
+            location.statement_index += 1;
+        }
+
+        if let Some(mir::Terminator {
+            ref source_info,
+            ref kind,
+        }) = *terminator
+        {
+            self.visit_terminator(*source_info, kind);
         }
     }
-    fn visit_impl_item(&mut self, impl_item: &'hir hir::ImplItem) {
-        if let ImplItemKind::Method(.., body_id) = impl_item.node {
-            let did = self.tcx.hir.body_owner_def_id(body_id);
-            info!("analyzing {}", self.tcx.def_path_debug_str(did));
+
+    /// Calls a specialized visitor for each kind of statement.
+    fn visit_statement(&self, _location: mir::Location, statement: &mir::Statement) {
+        let mir::Statement { kind, source_info } = statement;
+        debug!("{:?}", source_info);
+        match kind {
+            mir::StatementKind::Assign(place, rvalue) => self.visit_assign(place, rvalue.borrow()),
+            mir::StatementKind::FakeRead(..) => unreachable!(),
+            mir::StatementKind::SetDiscriminant {
+                place,
+                variant_index,
+            } => self.visit_set_discriminant(place, *variant_index),
+            mir::StatementKind::StorageLive(local) => self.visit_storage_live(*local),
+            mir::StatementKind::StorageDead(local) => self.visit_storage_dead(*local),
+            mir::StatementKind::InlineAsm {
+                asm,
+                outputs,
+                inputs,
+            } => self.visit_inline_asm(asm, outputs, inputs),
+            mir::StatementKind::Retag { fn_entry, place } => self.visit_retag(*fn_entry, place),
+            mir::StatementKind::EscapeToRaw(ref operands) => self.visit_escape_to_raw(operands),
+            mir::StatementKind::AscribeUserType(..) => unreachable!(),
+            mir::StatementKind::Nop => return,
         }
+    }
+
+    /// Write the RHS Rvalue to the LHS Place.
+    fn visit_assign(&self, place: &mir::Place, rvalue: &mir::Rvalue) {
+        debug!(
+            "default visit_assign(place: {:?}, rvalue: {:?})",
+            place, rvalue
+        );
+        self.visit_rvalue(rvalue)
+    }
+
+    /// Write the discriminant for a variant to the enum Place.
+    fn visit_set_discriminant(
+        &self,
+        place: &mir::Place,
+        variant_index: rustc::ty::layout::VariantIdx,
+    ) {
+        debug!(
+            "default visit_set_discriminant(place: {:?}, variant_index: {:?})",
+            place, variant_index
+        );
+    }
+
+    /// Start a live range for the storage of the local.
+    fn visit_storage_live(&self, local: mir::Local) {
+        debug!("default visit_storage_live(local: {:?})", local);
+    }
+
+    /// End the current live range for the storage of the local.
+    fn visit_storage_dead(&self, local: mir::Local) {
+        debug!("default visit_storage_dead(local: {:?})", local);
+    }
+
+    /// Execute a piece of inline Assembly.
+    fn visit_inline_asm(
+        &self,
+        asm: &hir::InlineAsm,
+        outputs: &[mir::Place],
+        inputs: &[(syntax_pos::Span, mir::Operand)],
+    ) {
+        debug!(
+            "default visit_inline_asm(asm: {:?}, outputs: {:?}, inputs: {:?})",
+            asm, outputs, inputs
+        );
+    }
+
+    /// Retag references in the given place, ensuring they got fresh tags.  This is
+    /// part of the Stacked Borrows model. These statements are currently only interpreted
+    /// by miri and only generated when "-Z mir-emit-retag" is passed.
+    /// See <https://internals.rust-lang.org/t/stacked-borrows-an-aliasing-model-for-rust/8153/>
+    /// for more details.
+    fn visit_retag(&self, fn_entry: bool, place: &mir::Place) {
+        debug!(
+            "default visit_set_discriminant(fn_entry: {:?}, place: {:?})",
+            fn_entry, place
+        );
+    }
+
+    /// Escape the given reference to a raw pointer, so that it can be accessed
+    /// without precise provenance tracking. These statements are currently only interpreted
+    /// by miri and only generated when "-Z mir-emit-retag" is passed.
+    /// See <https://internals.rust-lang.org/t/stacked-borrows-an-aliasing-model-for-rust/8153/>
+    /// for more details.
+    fn visit_escape_to_raw(&self, operand: &mir::Operand) {
+        debug!("default visit_escape_to_raw(operand: {:?})", operand);
+    }
+
+    /// Calls a specialized visitor for each kind of terminator.
+    fn visit_terminator(&self, source_info: mir::SourceInfo, kind: &mir::TerminatorKind) {
+        debug!("{:?}", source_info);
+        match kind {
+            mir::TerminatorKind::Goto { target } => self.visit_goto(*target),
+            mir::TerminatorKind::SwitchInt {
+                discr,
+                switch_ty,
+                values,
+                targets,
+            } => self.visit_switch_int(discr, switch_ty, values, targets),
+            mir::TerminatorKind::Resume => self.visit_resume(),
+            mir::TerminatorKind::Abort => unreachable!(),
+            mir::TerminatorKind::Return => self.visit_return(),
+            mir::TerminatorKind::Unreachable => self.visit_unreachable(),
+            mir::TerminatorKind::Drop {
+                location,
+                target,
+                unwind,
+            } => self.visit_drop(location, *target, *unwind),
+            mir::TerminatorKind::DropAndReplace { .. } => unreachable!(),
+            mir::TerminatorKind::Call {
+                func,
+                args,
+                destination,
+                cleanup,
+                from_hir_call,
+            } => self.visit_call(func, args, destination, *cleanup, *from_hir_call),
+            mir::TerminatorKind::Assert {
+                cond,
+                expected,
+                msg,
+                target,
+                cleanup,
+            } => self.visit_assert(cond, *expected, msg, *target, *cleanup),
+            mir::TerminatorKind::Yield { .. } => unreachable!(),
+            mir::TerminatorKind::GeneratorDrop => unreachable!(),
+            mir::TerminatorKind::FalseEdges { .. } => unreachable!(),
+            mir::TerminatorKind::FalseUnwind { .. } => unreachable!(),
+        }
+    }
+
+    /// block should have one successor in the graph; we jump there
+    fn visit_goto(&self, target: mir::BasicBlock) {
+        debug!("default visit_goto(local: {:?})", target);
+    }
+
+    /// `discr` evaluates to an integer; jump depending on its value
+    /// to one of the targets, and otherwise fallback to last element of `targets`.
+    ///
+    /// # Arguments
+    /// * `discr` - Discriminant value being tested
+    /// * `switch_ty` - type of value being tested
+    /// * `values` - Possible values. The locations to branch to in each case
+    /// are found in the corresponding indices from the `targets` vector.
+    /// * `targets` - Possible branch sites. The last element of this vector is used
+    /// for the otherwise branch, so targets.len() == values.len() + 1 should hold.
+    fn visit_switch_int(
+        &self,
+        discr: &mir::Operand,
+        switch_ty: rustc::ty::Ty,
+        values: &[u128],
+        targets: &[mir::BasicBlock],
+    ) {
+        debug!(
+            "default visit_switch_int(discr: {:?}, switch_ty: {:?}, values: {:?}, targets: {:?})",
+            discr, switch_ty, values, targets
+        );
+    }
+
+    /// Indicates that the landing pad is finished and unwinding should
+    /// continue. Emitted by build::scope::diverge_cleanup.
+    fn visit_resume(&self) {
+        debug!("default visit_resume()");
+    }
+
+    /// Indicates a normal return. The return place should have
+    /// been filled in by now. This should occur at most once.
+    fn visit_return(&self) {
+        debug!("default visit_return()");
+    }
+
+    /// Indicates a terminator that can never be reached.
+    fn visit_unreachable(&self) {
+        debug!("default visit_unreachable()");
+    }
+
+    /// Drop the Place
+    fn visit_drop(
+        &self,
+        location: &mir::Place,
+        target: mir::BasicBlock,
+        unwind: Option<mir::BasicBlock>,
+    ) {
+        debug!(
+            "default visit_drop(location: {:?}, outputs: {:?}, inputs: {:?})",
+            location, target, unwind
+        );
+    }
+
+    /// Block ends with a call of a converging function
+    ///
+    /// #Arguments
+    /// * `func` - The function that’s being called
+    /// * `args` - Arguments the function is called with.
+    /// These are owned by the callee, which is free to modify them.
+    /// This allows the memory occupied by "by-value" arguments to be
+    /// reused across function calls without duplicating the contents.
+    /// * `destination` - Destination for the return value. If some, the call is converging.
+    /// * `cleanup` - Cleanups to be done if the call unwinds.
+    /// * `from_hir_call` - Whether this is from a call in HIR, rather than from an overloaded
+    /// operator. True for overloaded function call.
+    fn visit_call(
+        &self,
+        func: &mir::Operand,
+        args: &[mir::Operand],
+        destination: &Option<(mir::Place, mir::BasicBlock)>,
+        cleanup: Option<mir::BasicBlock>,
+        from_hir_call: bool,
+    ) {
+        debug!("default visit_call(func: {:?}, args: {:?}, destination: {:?}, cleanup: {:?}, from_hir_call: {:?})", func, args, destination, cleanup, from_hir_call);
+    }
+
+    /// Jump to the target if the condition has the expected value,
+    /// otherwise panic with a message and a cleanup target.
+    fn visit_assert(
+        &self,
+        cond: &mir::Operand,
+        expected: bool,
+        msg: &mir::AssertMessage,
+        target: mir::BasicBlock,
+        cleanup: Option<mir::BasicBlock>,
+    ) {
+        debug!("default visit_assert(cond: {:?}, expected: {:?}, msg: {:?}, target: {:?}, cleanup: {:?})", cond, expected, msg, target, cleanup);
+    }
+
+    /// Calls a specialized visitor for each kind of Rvalue
+    fn visit_rvalue(&self, rvalue: &mir::Rvalue) {
+        match rvalue {
+            mir::Rvalue::Use(operand) => self.visit_use(operand),
+            mir::Rvalue::Repeat(operand, count) => self.visit_repeat(operand, *count),
+            mir::Rvalue::Ref(region, borrow_kind, place) => {
+                self.visit_ref(region, *borrow_kind, place)
+            }
+            mir::Rvalue::Len(place) => self.visit_len(place),
+            mir::Rvalue::Cast(cast_kind, operand, ty) => self.visit_cast(*cast_kind, operand, ty),
+            mir::Rvalue::BinaryOp(bin_op, left_operand, right_operand) => {
+                self.visit_binary_op(*bin_op, left_operand, right_operand)
+            }
+            mir::Rvalue::CheckedBinaryOp(bin_op, left_operand, right_operand) => {
+                self.visit_checked_binary_op(*bin_op, left_operand, right_operand)
+            }
+            mir::Rvalue::NullaryOp(null_op, ty) => self.visit_nullary_op(*null_op, ty),
+            mir::Rvalue::UnaryOp(unary_op, operand) => self.visit_unary_op(*unary_op, operand),
+            mir::Rvalue::Discriminant(place) => self.visit_discriminant(place),
+            mir::Rvalue::Aggregate(aggregate_kinds, operands) => {
+                self.visit_aggregate(aggregate_kinds, operands)
+            }
+        }
+    }
+
+    /// x (either a move or copy, depending on type of x)
+    fn visit_use(&self, operand: &mir::Operand) {
+        debug!("default visit_use(operand: {:?})", operand);
+        self.visit_operand(operand);
+    }
+
+    /// [x; 32]
+    fn visit_repeat(&self, operand: &mir::Operand, count: u64) {
+        debug!(
+            "default visit_repeat(operand: {:?}, count: {:?})",
+            operand, count
+        );
+        self.visit_operand(operand);
+    }
+
+    /// &x or &mut x
+    fn visit_ref(
+        &self,
+        region: rustc::ty::Region,
+        borrow_kind: mir::BorrowKind,
+        place: &mir::Place,
+    ) {
+        debug!(
+            "default visit_ref(region: {:?}, borrow_kind: {:?}, place: {:?})",
+            region, borrow_kind, place
+        );
+    }
+
+    /// length of a [X] or [X;n] value.
+    fn visit_len(&self, place: &mir::Place) {
+        debug!("default visit_len(place: {:?})", place);
+    }
+
+    /// cast converts the operand to the given ty.
+    fn visit_cast(&self, cast_kind: mir::CastKind, operand: &mir::Operand, ty: rustc::ty::Ty) {
+        debug!(
+            "default visit_cast(cast_kind: {:?}, operand: {:?}, ty: {:?})",
+            cast_kind, operand, ty
+        );
+        self.visit_operand(operand);
+    }
+
+    /// Apply the given binary operator to the two operands.
+    fn visit_binary_op(
+        &self,
+        bin_op: mir::BinOp,
+        left_operand: &mir::Operand,
+        right_operand: &mir::Operand,
+    ) {
+        debug!(
+            "default visit_binary_op(bin_op: {:?}, left_operand: {:?}, right_operand: {:?})",
+            bin_op, left_operand, right_operand
+        );
+        self.visit_operand(left_operand);
+        self.visit_operand(right_operand);
+    }
+
+    /// Apply the given binary operator to the two operands, with overflow checking where appropriate.
+    fn visit_checked_binary_op(
+        &self,
+        bin_op: mir::BinOp,
+        left_operand: &mir::Operand,
+        right_operand: &mir::Operand,
+    ) {
+        debug!("default visit_checked_binary_op(bin_op: {:?}, left_operand: {:?}, right_operand: {:?})", bin_op, left_operand, right_operand);
+        self.visit_operand(left_operand);
+        self.visit_operand(right_operand);
+    }
+
+    /// Create a value based on the given type.
+    fn visit_nullary_op(&self, null_op: mir::NullOp, ty: rustc::ty::Ty) {
+        debug!(
+            "default visit_nullary_op(null_op: {:?}, ty: {:?})",
+            null_op, ty
+        );
+    }
+
+    /// Apply the given unary operator to the operand.
+    fn visit_unary_op(&self, un_op: mir::UnOp, operand: &mir::Operand) {
+        debug!(
+            "default visit_unary_op(un_op: {:?}, operand: {:?})",
+            un_op, operand
+        );
+        self.visit_operand(operand);
+    }
+
+    /// Read the discriminant of an ADT.
+    ///
+    /// Undefined (i.e. no effort is made to make it defined, but there’s no reason why it cannot
+    /// be defined to return, say, a 0) if ADT is not an enum.
+    fn visit_discriminant(&self, place: &mir::Place) {
+        debug!("default visit_discriminant(place: {:?})", place);
+    }
+
+    /// Create an aggregate value, like a tuple or struct.  This is
+    /// only needed because we want to distinguish `dest = Foo { x:
+    /// ..., y: ... }` from `dest.x = ...; dest.y = ...;` in the case
+    /// that `Foo` has a destructor. These rvalues can be optimized
+    /// away after type-checking and before lowering.
+    fn visit_aggregate(&self, aggregate_kinds: &mir::AggregateKind, operands: &[mir::Operand]) {
+        debug!(
+            "default visit_aggregate(aggregate_kinds: {:?}, operands: {:?})",
+            aggregate_kinds, operands
+        );
+    }
+
+    /// These are values that can appear inside an rvalue. They are intentionally
+    /// limited to prevent rvalues from being nested in one another.
+    fn visit_operand(&self, operand: &mir::Operand) {
+        match operand {
+            mir::Operand::Copy(place) => self.visit_copy(place),
+            mir::Operand::Move(place) => self.visit_move(place),
+            mir::Operand::Constant(constant) => self.visit_constant(constant),
+        }
+    }
+
+    /// Copy: The value must be available for use afterwards.
+    ///
+    /// This implies that the type of the place must be `Copy`; this is true
+    /// by construction during build, but also checked by the MIR type checker.
+    fn visit_copy(&self, place: &mir::Place) {
+        debug!("default visit_copy(place: {:?})", place);
+    }
+
+    /// Move: The value (including old borrows of it) will not be used again.
+    ///
+    /// Safe for values of all types (modulo future developments towards `?Move`).
+    /// Correct usage patterns are enforced by the borrow checker for safe code.
+    /// `Copy` may be converted to `Move` to enable "last-use" optimizations.
+    fn visit_move(&self, place: &mir::Place) {
+        debug!("default visit_move(place: {:?})", place);
+    }
+
+    /// Synthesizes a constant value.
+    fn visit_constant(&self, constant: &mir::Constant) {
+        debug!("default visit_constant(constant: {:?})", constant);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -35,6 +35,12 @@ fn invoke_driver() {
             String::from(std::env::temp_dir().to_str().unwrap()),
             String::from("--sysroot"),
             utils::find_sysroot(),
+            String::from("-Z"),
+            String::from("span_free_formats"),
+            String::from("-Z"),
+            String::from("mir-emit-retag"),
+            String::from("-Z"),
+            String::from("mir-opt-level=0"),
         ];
 
         rustc_driver::run_compiler(

--- a/tests/run-pass/crate_traversal.rs
+++ b/tests/run-pass/crate_traversal.rs
@@ -1,16 +1,164 @@
-// A small trait to test crate traversal
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
-trait TestTrait {
-    fn test_method() {}
+// statements and expressions that exercise all visitor code paths
+
+#![allow(const_err)]
+#![allow(unused)]
+#![feature(asm)]
+#![feature(box_syntax)]
+#![feature(generators)]
+
+use std::mem;
+
+pub trait TestTrait {
+    fn test_method() {
+        let _loc = [1];
+        let loc2 = [ 0; 512 ];
+    }
 }
 
-struct TestStruct {
-     test_field: i64
+pub struct TestStruct {
+    pub test_field: i64
 }
 
 impl TestStruct {
-    fn test_function() {}
-    fn test_method(&self) {}
+    pub fn test_function() {}
+    pub fn test_method(&self) {}
+}
+
+pub unsafe fn test1() {
+    #[derive(Copy, Clone)]
+    enum Void {}
+    union A { a: (), v: Void }
+    let a = A { a: () };
+    match a.v {
+    }
+}
+
+fn test2() {
+    let z = 0;
+    let _x = {
+        &z
+    };
+}
+
+fn test3() {
+    let nodrop_x = false;
+    let _nodrop_y;
+
+    // Since boolean does not require drop, this can be a simple
+    // assignment:
+    _nodrop_y = nodrop_x;
+
+    let drop_x : Option<Box<u32>> = None;
+    let _drop_y;
+
+    // Since the type of `drop_y` has drop, we generate a `replace`
+    // terminator:
+    _drop_y = drop_x;
+}
+
+fn test4() {
+    let mut should_break = false;
+    loop {
+        if should_break {
+            break;
+        }
+        should_break = true;
+    }
+}
+
+unsafe fn test5() {
+    asm!("NOP")
+}
+
+fn test6() {
+    println!("{}", bar());
+}
+
+#[inline(always)]
+fn foo(x: &i32, y: &i32) -> bool {
+    *x == *y
+}
+
+fn bar() -> bool {
+    let f = foo;
+    f(&1, &-1)
+}
+
+fn test7() {
+    loop {
+        let beacon = {
+            match true {
+                false => 4,
+                true => break,
+            }
+        };
+        drop(&beacon);
+    }
+}
+
+fn test8(x: &mut i32, y: &mut i32) -> i32 {
+  *x = 42;
+  *y = 7;
+  *x // Will load 42! We can optimize away the load.
+}
+
+struct Test(i32);
+
+impl Test {
+    // Make sure we run the pass on a method, not just on bare functions.
+    fn foo<'x>(&self, x: &'x mut i32) -> &'x mut i32 { x }
+    fn foo_shr<'x>(&self, x: &'x i32) -> &'x i32 { x }
+}
+
+fn test9() {
+    let mut x = 0;
+    {
+        let v = Test(0).foo(&mut x); // just making sure we do not panic when there is a tuple struct ctor
+        let w = { v }; // assignment
+        let w = w; // reborrow
+        // escape-to-raw (mut)
+        let _w = w as *mut _;
+    }
+
+    // Also test closures
+    let c: fn(&i32) -> &i32 = |x: &i32| -> &i32 { let _y = x; x };
+    let _w = c(&x);
+
+    // need to call `foo_shr` or it doesn't even get generated
+    Test(0).foo_shr(&0);
+
+    // escape-to-raw (shr)
+    let _w = _w as *const _;
+}
+
+fn test10() {
+    let _a = || {
+        yield;
+        let a = String::new();
+        a.len()
+    };
+}
+
+fn test11(arr: &[String]){
+    let e = &arr[1];
+}
+
+fn test12() {
+    let x = 200u8 * 4;
+}
+
+fn test13(i: i64) {
+    let x = box -i;
+}
+
+fn test14(a: i32, b: i32) -> Option<i32> {
+    Some(a.checked_add(1)?.checked_mul(3_i32.checked_add(b)?)?)
 }
 
 fn main() {}


### PR DESCRIPTION
## Description

Flesh out the visitor class to include stubs for MIR nodes.

Fixes #11

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

tests/run-pass/crate_traversal.rs has been fleshed out with bodies that cause all the new visitor methods to get called.

