### PR TITLE
Update the developer guide and tweak log output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,12 @@ addons:
   apt:
     packages:
     - libssl-dev
-
-language: generic
-
-cache:
-  # Cache the global cargo directory and the local binary dependencies
-  directories:
-  - /home/travis/.cargo
-  - target/debug/deps
+language: rust
+rust:
+- nightly
+cache: cargo
 
 before_script:
-# Compute the rust version we use. We do not use "language: rust" to have more control here.
-- RUST_TOOLCHAIN=nightly
-# install Rust
-- curl https://build.travis-ci.org/files/rustup-init.sh -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
-- export PATH=$HOME/.cargo/bin:$PATH
-- rustc --version
 # install formatter
 - rustup component add rustfmt-preview
 # install linter
@@ -46,7 +36,6 @@ script:
 - cargo clean -p mirai
 - RUSTC_WRAPPER=mirai cargo build
 - cargo uninstall mirai
-
-after_success:
-- MIRAI_LOG=info cargo tarpaulin --out Xml
+- cargo clean -p mirai
+- cargo tarpaulin -v --skip-clean --out Xml
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,10 @@ addons:
 language: generic
 
 cache:
-  # Cache the global cargo directory, but NOT the local `target` directory which
-  # we cannot reuse anyway when the nightly changes (and it grows quite large
-  # over time).
+  # Cache the global cargo directory and the local binary dependencies
   directories:
   - /home/travis/.cargo
-
-before_cache:
-  # install code coverage tool
-  - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin
+  - target/debug/deps
 
 before_script:
 # Compute the rust version we use. We do not use "language: rust" to have more control here.
@@ -31,6 +26,8 @@ before_script:
 - rustup component add rustfmt-preview
 # install linter
 - rustup component add clippy-preview
+# install code coverage tool
+- RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin || true
 
 script:
 # Exit immediately if a command exits with a non-zero status.
@@ -44,11 +41,12 @@ script:
 # Run unit and integration tests
 - cargo test
 # Run mirai on itself
-- cargo install --force --path .
-- cargo clean
-- export RUSTC_WRAPPER=mirai
-- cargo build
+- cargo uninstall mirai || true
+- cargo install --debug --path .
+- cargo clean -p mirai
+- RUSTC_WRAPPER=mirai cargo build
+- cargo uninstall mirai
 
 after_success:
-- cargo tarpaulin --out Xml
+- MIRAI_LOG=info cargo tarpaulin --out Xml
 - bash <(curl -s https://codecov.io/bash)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +267,7 @@ dependencies = [
  "rpds 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -319,6 +334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rayon"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +398,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +455,15 @@ dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -551,6 +593,8 @@ dependencies = [
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
@@ -571,12 +615,14 @@ dependencies = [
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
+"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rocksdb 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39be726e556e6f21d54d21cdf1be9f6df30c0411a5856c1abf3f4bb12498f2ed"
 "checksum rpds 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d41235ae795ad106da2c4f3dbdd09537062b14a15ee4754d4c9f4eeb69b4ad8b"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
@@ -584,6 +630,7 @@ dependencies = [
 "checksum serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)" = "477b13b646f5b5b56fc95bedfc3b550d12141ce84f466f6c44b9a17589923885"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
+"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ rocksdb = "0.10"
 rpds = { version = "0.5", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
+tempdir = "0.3"

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -35,7 +35,7 @@ actually use Clion for editing, VSCode for debugging and Nuclide for doing sourc
 Running `cargo build` will produce a binary at `target/debug/mirai`.
  
 Unfortunately cargo build sets the dynamic library load path (rpath) that is linked into the binary to a path that is
-invalid a when the binary is run. If you run the binary via cargo `cargo run -- <args>` then cargo overrides the bad
+invalid when the binary is run. If you run the binary via cargo `cargo run -- <args>` then cargo overrides the bad
 rpath by providing the correct path in the environment variable `DYLD_LIBRARY_PATH`.
  
 If you run without using cargo, you'll need to set the variable yourself, or you can create a handy alias for the binary
@@ -75,7 +75,7 @@ configurations property of the content of the launch.json file in the .vscode di
     },
 ```
 
-Note that VSCode runs cargo to build mirai (if necessary) and get's the location of the binary from cargo. When
+Note that VSCode runs cargo to build mirai (if necessary) and gets the location of the binary from cargo. When
 actually debugging, however, it runs the binary directly, so it is necessary to set DYLD_LIBRARY_PATH. VSCode config
 files don't support things like `$(rustc --print sysroot)`, hence the more brittle expression above.
 

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -32,15 +32,21 @@ actually use Clion for editing, VSCode for debugging and Nuclide for doing sourc
 
 ## Running
 
-Running `cargo build` will produce a binary at `target/debug/mirai`. Create a handy alias for the binary with
-
-`alias mirai="DYLD_LIBRARY_PATH=~/.rustup/toolchains/nightly-x86_64-apple-darwin/lib ~/mirai/target/debug/mirai"`
-
-Afterward, you can run the mirai binary as if it were rustc.
+Running `cargo build` will produce a binary at `target/debug/mirai`.
  
-To run mirai via cargo, first do `cargo install --force --path  ~/mirai` then set the `RUSTC_WRAPPER` environment
-variable to `mirai`. Note that Cargo takes care of the library path so the alias is not needed unless you want
-to run mirai directly. 
+Unfortunately cargo build sets the dynamic library load path (rpath) that is linked into the binary to a path that is
+invalid a when the binary is run. If you run the binary via cargo `cargo run -- <args>` then cargo overrides the bad
+rpath by providing the correct path in the environment variable `DYLD_LIBRARY_PATH`.
+ 
+If you run without using cargo, you'll need to set the variable yourself, or you can create a handy alias for the binary
+with
+
+`alias mirai="DYLD_LIBRARY_PATH=$(rustc --print sysroot)/lib ~/mirai/target/debug/mirai"`
+
+You can then run mirai as if it were rustc, because it is in fact rustc, just with an added plug in.
+ 
+To run mirai via cargo, as if it were rustc, first do `cargo install --force --path  ~/mirai` then set the
+`RUSTC_WRAPPER` environment variable to `mirai`.
 
 ## Debugging
 
@@ -68,6 +74,12 @@ configurations property of the content of the launch.json file in the .vscode di
         "cwd": "${workspaceFolder}",
     },
 ```
+
+Note that VSCode runs cargo to build mirai (if necessary) and get's the location of the binary from cargo. When
+actually debugging, however, it runs the binary directly, so it is necessary to set DYLD_LIBRARY_PATH. VSCode config
+files don't support things like `$(rustc --print sysroot)`, hence the more brittle expression above.
+
+## Debugging rustc
 
 Since Mirai makes use of a private and unstable API with sparse documentation, it can be very helpful to debug
 Mirai while seeing the actual rustc sources in the debugger. By default, this does not happen. To make it happen, see 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -20,6 +20,7 @@ use visitors::MirVisitor;
 pub struct MiraiCallbacks {
     /// Use these to just defer to the Rust compiler's implementations.
     default_calls: RustcDefaultCalls,
+    output_directory: PathBuf,
 }
 
 /// Provides a default constructor
@@ -27,6 +28,7 @@ impl MiraiCallbacks {
     pub fn new() -> MiraiCallbacks {
         MiraiCallbacks {
             default_calls: RustcDefaultCalls,
+            output_directory: PathBuf::default(),
         }
     }
 }
@@ -75,6 +77,12 @@ impl<'a> CompilerCalls<'a> for MiraiCallbacks {
             Input::File(path_buf) => info!("Processing input file: {}", path_buf.display()),
             Input::Str { input, .. } => info!("Processing input string: {}", input),
         }
+        match output_directory {
+            None => self
+                .output_directory
+                .push(std::env::temp_dir().to_str().unwrap()),
+            Some(path_buf) => self.output_directory.push(path_buf.as_path()),
+        }
         self.default_calls.late_callback(
             codegen_backend,
             matches,
@@ -96,7 +104,8 @@ impl<'a> CompilerCalls<'a> for MiraiCallbacks {
         _matches: &::getopts::Matches,
     ) -> driver::CompileController<'a> {
         let mut controller = driver::CompileController::basic();
-        controller.after_analysis.callback = Box::new(move |state| after_analysis(state));
+        controller.after_analysis.callback =
+            Box::new(move |state| after_analysis(state, &mut self.output_directory.clone()));
         // Note: the callback is only invoked if the compiler discovers no errors beforehand.
         controller
     }
@@ -105,10 +114,13 @@ impl<'a> CompilerCalls<'a> for MiraiCallbacks {
 /// Called after the compiler has completed all analysis passes and before it lowers MIR to LLVM IR.
 /// At this point the compiler is ready to tell us all it knows and we can proceed to do abstract
 /// interpretation of all of the functions that will end up in the compiler output.
-fn after_analysis(state: &mut driver::CompileState) {
+fn after_analysis(state: &mut driver::CompileState, output_directory: &mut PathBuf) {
     let tcx = state.tcx.unwrap();
     let crate_name: &str = state.crate_name.unwrap();
-    let summary_store_path: String = String::from(".summary_store.rocksdb");
+    output_directory.set_file_name(".summary_store");
+    output_directory.set_extension("rocksdb");
+    let summary_store_path = String::from(output_directory.to_str().unwrap());
+    info!("storing summaries at {}", summary_store_path);
     let mut persistent_summary_cache =
         summaries::PersistentSummaryCache::new(&tcx, crate_name, summary_store_path);
     for def_id in tcx.body_owners() {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -113,7 +113,7 @@ fn after_analysis(state: &mut driver::CompileState) {
         summaries::PersistentSummaryCache::new(&tcx, crate_name, summary_store_path);
     for def_id in tcx.body_owners() {
         let name = summaries::summary_key_str(&tcx, crate_name, def_id);
-        debug!("analyzing({:?})", name);
+        info!("analyzing({:?})", name);
         // By this time all analyses have been carried out, so it should be safe to borrow this now.
         let mir = tcx.optimized_mir(def_id);
         let mut environment: HashTrieMap<Path, AbstractValue> = HashTrieMap::new();
@@ -147,4 +147,5 @@ fn after_analysis(state: &mut driver::CompileState) {
         );
         persistent_summary_cache.set_summary_for(def_id, summary);
     }
+    info!("done with analysis");
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17,13 +17,16 @@
 
 extern crate mirai;
 extern crate rustc_driver;
+extern crate tempdir;
 
 use mirai::callbacks;
 use mirai::utils;
+use tempdir::TempDir;
 
 #[test]
 fn invoke_driver() {
     rustc_driver::run(|| {
+        let temp_dir = TempDir::new("miraiTest").expect("failed to create a temp dir");
         let command_line_arguments: Vec<String> = vec![
             String::from("--crate-name mirai"),
             String::from("tests/run-pass/crate_traversal.rs"),
@@ -32,7 +35,7 @@ fn invoke_driver() {
             String::from("-C"),
             String::from("debuginfo=2"),
             String::from("--out-dir"),
-            String::from(std::env::temp_dir().to_str().unwrap()),
+            String::from(temp_dir.path().to_str().unwrap()),
             String::from("--sysroot"),
             utils::find_sysroot(),
             String::from("-Z"),


### PR DESCRIPTION
## Description

Update the developer guide with more information about DYLD_LIBRARY_PATH and tweak log output so that info is a bit more informative.

Since the above kept failing the CI build, also changed the CI script to be more standard (and do more caching) and changed the callback code to use the output directory as the location of the persistent summary cache. Then also changed the integration test script to use a different output directory every time.

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built Rust libstd with MIRAI_LOG=info and observed successful completion of build.


