### PR TITLE
Enhance integration test to run multiple test snippets in parallel.

### DIFF
--- a/tests/run-pass/crate_traversal.rs
+++ b/tests/run-pass/crate_traversal.rs
@@ -161,6 +161,4 @@ fn test14(a: i32, b: i32) -> Option<i32> {
     Some(a.checked_add(1)?.checked_mul(3_i32.checked_add(b)?)?)
 }
 
-fn test15() { { fn bar() {} } { fn bar() {} } }
-
 fn main() {}

--- a/tests/run-pass/disambiguate_nested_functions.rs
+++ b/tests/run-pass/disambiguate_nested_functions.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that has two nested functions that both have the same qualified name if not
+// disambiguated with a counter.
+
+#![allow(unused)]
+
+fn test() { { fn bar() {} } { fn bar() {} } }


### PR DESCRIPTION
## Description

This change adds logic to tests/integeration_tests.rs that allows it to run multiple test snippets by iterating in parallel through the files in a given directory and compiling each file via a separate call to the compiler driver.

Still to come:
- A way to capture diagnostic messages generated by Mirai and comparing them to expected output.
- Detailed output of which tests failed and how they failed.

Related to issue #10 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Added a second test file to tests/run-pass and ran ``cargo test -v -- --nocapture`` with debug output to show which tests run.
