### PR TITLE
Get the crate name of a summary key from the DefId via the type context.

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -116,15 +116,14 @@ impl<'a> CompilerCalls<'a> for MiraiCallbacks {
 /// interpretation of all of the functions that will end up in the compiler output.
 fn after_analysis(state: &mut driver::CompileState, output_directory: &mut PathBuf) {
     let tcx = state.tcx.unwrap();
-    let crate_name: &str = state.crate_name.unwrap();
     output_directory.set_file_name(".summary_store");
     output_directory.set_extension("rocksdb");
     let summary_store_path = String::from(output_directory.to_str().unwrap());
     info!("storing summaries at {}", summary_store_path);
     let mut persistent_summary_cache =
-        summaries::PersistentSummaryCache::new(&tcx, crate_name, summary_store_path);
+        summaries::PersistentSummaryCache::new(&tcx, summary_store_path);
     for def_id in tcx.body_owners() {
-        let name = summaries::summary_key_str(&tcx, crate_name, def_id);
+        let name = summaries::summary_key_str(&tcx, def_id);
         info!("analyzing({:?})", name);
         // By this time all analyses have been carried out, so it should be safe to borrow this now.
         let mir = tcx.optimized_mir(def_id);


### PR DESCRIPTION
## Description

In order to get the summary key for a function from a crate other than the one being compiled, we need to get the name of the other crate directly from the DefId, so we may as well do it always.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

cargo test
The external crate part has been tested together with changes for which I do not yet have a PR>
