### PR TITLE
Keep up with changes to the rust compiler.

### DIFF
--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -95,12 +95,7 @@ pub trait MirVisitor<'a, 'tcx> {
                 outputs,
                 inputs,
             } => self.visit_inline_asm(asm, outputs, inputs),
-            mir::StatementKind::Retag {
-                fn_entry,
-                two_phase,
-                place,
-            } => self.visit_retag(*fn_entry, *two_phase, place),
-            mir::StatementKind::EscapeToRaw(ref operands) => self.visit_escape_to_raw(operands),
+            mir::StatementKind::Retag(retag_kind, place) => self.visit_retag(*retag_kind, place),
             mir::StatementKind::AscribeUserType(..) => unreachable!(),
             mir::StatementKind::Nop => return,
         }
@@ -155,20 +150,11 @@ pub trait MirVisitor<'a, 'tcx> {
     /// by miri and only generated when "-Z mir-emit-retag" is passed.
     /// See <https://internals.rust-lang.org/t/stacked-borrows-an-aliasing-model-for-rust/8153/>
     /// for more details.
-    fn visit_retag(&self, fn_entry: bool, two_phase: bool, place: &mir::Place) {
+    fn visit_retag(&self, retag_kind: mir::RetagKind, place: &mir::Place) {
         debug!(
-            "default visit_retag(fn_entry: {:?}, two_phase: {:?} place: {:?})",
-            fn_entry, two_phase, place
+            "default visit_retag(retag_kind: {:?}, place: {:?})",
+            retag_kind, place
         );
-    }
-
-    /// Escape the given reference to a raw pointer, so that it can be accessed
-    /// without precise provenance tracking. These statements are currently only interpreted
-    /// by miri and only generated when "-Z mir-emit-retag" is passed.
-    /// See <https://internals.rust-lang.org/t/stacked-borrows-an-aliasing-model-for-rust/8153/>
-    /// for more details.
-    fn visit_escape_to_raw(&self, operand: &mir::Operand) {
-        debug!("default visit_escape_to_raw(operand: {:?})", operand);
     }
 
     /// Calls a specialized visitor for each kind of terminator.


### PR DESCRIPTION
## Description

StatementKind::Retag has been redefined and StatementKind::EscapeToRaw has been eliminated.
So far the only impact of this is that the visitor has to be updated to compile. No functional changes are needed since these are only stubs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Travis

