### PR TITLE
Create abstract values for referenced function constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
 - cargo clean -p mirai
 - RUSTC_WRAPPER=mirai cargo build
 - cargo uninstall mirai
-- cargo clean -p mirai
-- cargo tarpaulin -v --skip-clean --out Xml
-- bash <(curl -s https://codecov.io/bash)
+# disable tarpaulin until it no longer crashes
+#- cargo clean -p mirai
+#- cargo tarpaulin -v --skip-clean --out Xml
+#- bash <(curl -s https://codecov.io/bash)

--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -3,8 +3,38 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use constant_value::ConstantValue;
+
+// See https://github.com/facebookexperimental/MIRAI/blob/master/documentation/AbstractValues.md.
+
+/// A collection of abstract domains associated with a particular abstract value.
+/// The expression domain captures the precise expression that resulted in the abstract
+/// value. It can be used to derive any other kind of abstract domain on demand.
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
 pub struct AbstractDomains {
-    //todo: just store the expression (as a domain)
-//todo: use cached getters to get other domains on demand
+    pub expression_domain: ExpressionDomain,
+    //todo: use cached getters to get other domains on demand
 }
+
+/// The things all abstract domain instances have to be able to do
+pub trait AbstractDomain {
+    //todo: join, is_top, is_bottom, etc.
+}
+
+/// An abstract domain uses a functional (side effect free) expression that precisely tracks
+/// a single value.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+pub enum ExpressionDomain {
+    /// An expression that represents any possible value
+    Top,
+
+    /// An expression that represents an impossible value, such as the value returned by function
+    /// that always panics.
+    Bottom,
+
+    /// An expression that is a compile time constant value, such as a numeric literal or a
+    /// function.
+    CompileTimeConstant(ConstantValue),
+}
+
+// todo: implement the AbstractDomain trait for ExpressionDomain

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 use abstract_domains::AbstractDomains;
-use rpds::List;
+use syntax_pos::Span;
 
 /// Mirai is an abstract interpreter and thus produces abstract values.
 /// In general, an abstract value is a value that is not fully known.
@@ -20,28 +20,14 @@ pub struct AbstractValue {
     /// The source location of that expression is stored in provenance.
     /// When an expression is stored somewhere and then retrieved via an accessor expression, a new
     /// abstract value is created (via refinement using the current path condition) with a provenance
-    /// that is the source location of accessor expression prepended to the provenance of the
-    /// refined expression.
-    pub provenance: List<Span>,
+    /// that is the source location of accessor expression. If refinement results in an existing
+    /// expression (i.e. one with a provenance of its own) then a copy expression is created with
+    /// the existing expression as argument, so that both locations are tracked.
+    #[serde(skip)]
+    pub provenance: Span,
     /// Various approximations of the actual value.
     /// See https://github.com/facebookexperimental/MIRAI/blob/master/documentation/AbstractValues.md.
     pub value: AbstractDomains,
-}
-
-/// Identifies a region of source code that corresponds to a source construct that the
-/// analyzer tracks and about which it can generate diagnostic messages.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
-pub struct Span {
-    /// The absolute name of the file containing this source span.
-    pub filename: Name,
-    /// The number (starting at 1) of the line where this span starts.
-    pub start_line: u32,
-    /// The number (starting at 1) of the column where this span starts.
-    pub start_column: u32,
-    /// The number (starting at 1) of the line where this span ends.
-    pub end_line: u32,
-    /// The number (starting at 1) of the column where this span ends.
-    pub end_column: u32,
 }
 
 /// The name of a function or method, sufficiently qualified so that it uniquely identifies it

--- a/src/constant_value.rs
+++ b/src/constant_value.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use rustc::hir::def_id::DefId;
+use std::collections::HashMap;
+use summaries::PersistentSummaryCache;
+
+/// Abstracts over constant values referenced in MIR and adds information
+/// that is useful for the abstract interpreter. More importantly, this
+/// value can be serialized to the persistent summary cache.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ConstantValue {
+    /// A reference to a function
+    Function {
+        /// Indicates if the function is known to be treated specially by the Rust compiler
+        is_intrinsic: bool,
+        /// The key to use when retrieving a summary for the function from the summary cache
+        summary_cache_key: String,
+        // todo: is there some way store the def_id here if available?
+        // this would not be serialized/deserialized.
+    },
+    // A place holder for other kinds of constants. Eventually this goes away.
+    Unimplemented,
+}
+
+impl ConstantValue {
+    /// Returns a constant value that is a reference to a function
+    pub fn for_function(
+        def_id: DefId,
+        summary_cache: &mut PersistentSummaryCache,
+    ) -> ConstantValue {
+        let summary_cache_key = summary_cache.get_summary_key_for(def_id);
+        // todo: include the def_id in the result
+        ConstantValue::Function {
+            is_intrinsic: false,
+            summary_cache_key: summary_cache_key.to_owned(),
+        }
+    }
+}
+
+/// Keeps track of MIR constants that have already been mapped onto ConstantValue instances.
+pub struct ConstantValueCache {
+    cache: HashMap<DefId, ConstantValue>,
+    std_intrinsics_unreachable_function: Option<ConstantValue>,
+}
+
+impl ConstantValueCache {
+    pub fn new() -> ConstantValueCache {
+        ConstantValueCache {
+            cache: HashMap::default(),
+            std_intrinsics_unreachable_function: None,
+        }
+    }
+
+    /// Given the MIR DefId of a function return the unique ConstantValue that corresponds to
+    /// the function identified by that DefId.
+    pub fn get_function_constant_for(
+        &mut self,
+        def_id: DefId,
+        summary_cache: &mut PersistentSummaryCache,
+    ) -> &ConstantValue {
+        self.cache
+            .entry(def_id)
+            .or_insert_with(|| ConstantValue::for_function(def_id, summary_cache))
+    }
+
+    /// Does an expensive check to see if the given function is std::intrinsics::unreachable.
+    /// Once it finds the function it caches it so that subsequent checks are cheaper.
+    pub fn check_if_std_intrinsics_unreachable_function(&mut self, fun: &ConstantValue) -> bool {
+        let result = match &self.std_intrinsics_unreachable_function {
+            Some(std_fun) => Some(*std_fun == *fun),
+            _ => None,
+        };
+        match result {
+            Some(r) => r,
+            None => {
+                let result = match fun {
+                    ConstantValue::Function {
+                        is_intrinsic,
+                        summary_cache_key,
+                    } => *is_intrinsic && summary_cache_key.ends_with("unreachable"),
+                    _ => false,
+                };
+                if result {
+                    self.std_intrinsics_unreachable_function = Some(fun.clone());
+                };
+                true
+            }
+        }
+    }
+}
+
+impl Default for ConstantValueCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate rustc;
 extern crate rustc_codegen_utils;
 extern crate rustc_driver;
 extern crate rustc_metadata;
+extern crate rustc_target;
 extern crate syntax;
 extern crate syntax_pos;
 
@@ -36,6 +37,7 @@ extern crate serde;
 pub mod abstract_domains;
 pub mod abstract_value;
 pub mod callbacks;
+pub mod constant_value;
 pub mod summaries;
 pub mod utils;
 pub mod visitors;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,17 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#[cfg_attr(tarpaulin, skip)]
+use rustc::hir::def_id::DefId;
+use rustc::ty::TyCtxt;
+use rustc_target::spec::abi::Abi;
+
+/// Returns the location of the rust system binaries that are associated with this build of Mirai.
+/// The location is obtained by looking at the contents of the environmental variables that were
+/// set at the time Mirai was compiled. If the rust compiler was installed by rustup, the variables
+/// RUSTUP_HOME and RUSTUP_TOOLCHAIN are used and these are set by the compiler itself.
+/// If the rust compiler was compiled and installed in some other way, for example from a source
+/// enlistment, then the RUST_SYSROOT variable must be set in the environment from which Mirai
+/// is compiled.
 pub fn find_sysroot() -> String {
     let home = option_env!("RUSTUP_HOME");
     let toolchain = option_env!("RUSTUP_TOOLCHAIN");
@@ -15,5 +25,16 @@ pub fn find_sysroot() -> String {
                  or use rustup to set the compiler to use for Mirai",
             )
             .to_owned(),
+    }
+}
+
+/// Returns true if the function identified by def_id is a Rust intrinsic function.
+/// Warning: it is not clear what will happen if def_id does not identify a function.
+pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt) -> bool {
+    let binder = tcx.fn_sig(def_id);
+    let sig = binder.skip_binder();
+    match sig.abi {
+        Abi::RustIntrinsic => true,
+        _ => false,
     }
 }

--- a/tests/run-pass/unreachable.rs
+++ b/tests/run-pass/unreachable.rs
@@ -1,0 +1,8 @@
+#![feature(core_intrinsics)]
+#![allow(unused)]
+
+use std::intrinsics;
+
+fn foo() {
+    unsafe { intrinsics::unreachable(); }
+}


### PR DESCRIPTION
## Description

This sets up some scaffolding for creating a test case that results in a genuine diagnostic, namely that a call to std::intrinsics::unreachable can actually be reached.

The changes in this request are mostly fleshing out of abstract values, but also involves some fixes to caching logic and more functionality in the visitor.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Travis

I had to disable code coverage checking since Tarpaulin crashes with a segfault.
