### PR TITLE
Give warning if control might right reach std::intrinsics::unreachable

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
 ignore:
   - tests/.*
   - src/main.rs
+
+coverage:
+  range: 60..85
+  round: down
+  precision: 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 # install linter
 - rustup component add clippy-preview
 # install code coverage tool
-- RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin || true
+- RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin || true
 
 script:
 # Exit immediately if a command exits with a non-zero status.
@@ -37,6 +37,6 @@ script:
 - RUSTC_WRAPPER=mirai cargo build
 - cargo uninstall mirai
 - cargo clean -p mirai
-- cargo tarpaulin -v --skip-clean --out Xml || true
+- cargo tarpaulin -v --out Xml || true
 - bash <(curl -s https://codecov.io/bash)
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -116,6 +116,7 @@ impl<'a> CompilerCalls<'a> for MiraiCallbacks {
 /// At this point the compiler is ready to tell us all it knows and we can proceed to do abstract
 /// interpretation of all of the functions that will end up in the compiler output.
 fn after_analysis(state: &mut driver::CompileState, output_directory: &mut PathBuf) {
+    let session = state.session;
     let tcx = state.tcx.unwrap();
     output_directory.set_file_name(".summary_store");
     output_directory.set_extension("rocksdb");
@@ -123,7 +124,7 @@ fn after_analysis(state: &mut driver::CompileState, output_directory: &mut PathB
     info!("storing summaries at {}", summary_store_path);
     let mut persistent_summary_cache =
         summaries::PersistentSummaryCache::new(&tcx, summary_store_path);
-    let mut constant_value_cache = ConstantValueCache::new();
+    let mut constant_value_cache = ConstantValueCache::default();
     for def_id in tcx.body_owners() {
         {
             let name = persistent_summary_cache.get_summary_key_for(def_id);
@@ -139,6 +140,7 @@ fn after_analysis(state: &mut driver::CompileState, output_directory: &mut PathB
         let mut unwind_condition: Option<AbstractValue> = None;
         {
             let mut mir_visitor = MirVisitor {
+                session,
                 tcx,
                 def_id,
                 mir,

--- a/tests/run-pass/unreachable.rs
+++ b/tests/run-pass/unreachable.rs
@@ -1,3 +1,11 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls std::intrinsics::unreachable unconditionally.
+
 #![feature(core_intrinsics)]
 #![allow(unused)]
 


### PR DESCRIPTION
## Description

This follows up on PR #23 and actually emits a warning if the visitor comes across a call to std::intrinsics::unreachable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Existing tests