### PR TITLE
Add fixed point iteration to visit_body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 # install formatter
 - rustup component add rustfmt-preview
 # install linter
-- rustup component add clippy-preview
+#- rustup component add clippy-preview
 # install code coverage tool
 - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin || true
 
@@ -25,7 +25,7 @@ script:
 # Run format checks
 - cargo fmt --all -- --check
 # Run lint checks
-- cargo clippy -- -D warnings
+#- cargo clippy -- -D warnings
 # Build
 - cargo build
 # Run unit and integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 # install formatter
 - rustup component add rustfmt-preview
 # install linter
-#- rustup component add clippy-preview
+- rustup component add clippy-preview
 # install code coverage tool
 - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin || true
 
@@ -25,7 +25,7 @@ script:
 # Run format checks
 - cargo fmt --all -- --check
 # Run lint checks
-#- cargo clippy -- -D warnings
+- cargo clippy -- -D warnings
 # Build
 - cargo build
 # Run unit and integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly
+- nightly-2019-01-07
 cache: cargo
 
 before_script:
@@ -29,7 +29,7 @@ script:
 # Build
 - cargo build
 # Run unit and integration tests
-- cargo test
+- RUST_BACKTRACE=1 cargo test
 # Run mirai on itself
 - cargo uninstall mirai || true
 - cargo install --debug --path .

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -5,7 +5,7 @@ The instructions assume that you've cloned the mirai repository into your home d
 ## Building
 
 You'll need to have Rust installed on your system. See 
-[here](https://doc.rust-lang.org/book/2018-edition/ch01-01-installation.html) for instructions.
+[here](https://doc.rust-lang.org/book/ch01-01-installation.html) for instructions.
 
 Mirai depends on unstable private APIs of the rust compiler to do things like parsing, type checking and
 lowering to MIR. These can only be accessed by using the nightly build of the compiler. So use rustup to set

--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -10,20 +10,100 @@ use constant_value::ConstantValue;
 /// A collection of abstract domains associated with a particular abstract value.
 /// The expression domain captures the precise expression that resulted in the abstract
 /// value. It can be used to derive any other kind of abstract domain on demand.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AbstractDomains {
     pub expression_domain: ExpressionDomain,
     //todo: use cached getters to get other domains on demand
 }
 
-/// The things all abstract domain instances have to be able to do
-pub trait AbstractDomain {
-    //todo: join, is_top, is_bottom, etc.
+/// A collection of abstract domains that all represent the impossible abstract value.
+/// I.e. the corresponding set of possible concrete values is empty.
+pub const BOTTOM: AbstractDomains = AbstractDomains {
+    expression_domain: ExpressionDomain::Bottom,
+};
+
+/// A collection of abstract domains that all represent the universal abstract value.
+/// I.e. the corresponding set of possible concrete values includes every possible concrete values.
+pub const TOP: AbstractDomains = AbstractDomains {
+    expression_domain: ExpressionDomain::Top,
+};
+
+impl AbstractDomains {
+    /// True if all of the abstract domains in this collection correspond to an empty set of concrete values.
+    pub fn is_bottom(&self) -> bool {
+        self.expression_domain.is_bottom()
+    }
+
+    /// True if all of the abstract domains in this collection correspond to the set of all possible concrete values.
+    pub fn is_top(&self) -> bool {
+        self.expression_domain.is_bottom()
+    }
+
+    /// Joins all of the abstract domains in the two collections to form a single collection.
+    /// In a context where the join condition is known to be true, the result can be refined to be
+    /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
+    pub fn join(
+        &self,
+        other: &AbstractDomains,
+        join_condition: &AbstractDomains,
+    ) -> AbstractDomains {
+        AbstractDomains {
+            expression_domain: self
+                .expression_domain
+                .join(&other.expression_domain, &join_condition),
+        }
+    }
+
+    /// Widen all of the abstract domains in the two collections to form a single collection.
+    pub fn widen(
+        &self,
+        other: &AbstractDomains,
+        join_condition: &AbstractDomains,
+    ) -> AbstractDomains {
+        AbstractDomains {
+            expression_domain: self
+                .expression_domain
+                .widen(&other.expression_domain, &join_condition),
+        }
+    }
+
+    /// True if for each abstract domains in the self collection, all of its concrete values are
+    /// elements of the corresponding set of the same domain in other.
+    pub fn subset(&self, other: &AbstractDomains) -> bool {
+        self.expression_domain.subset(&other.expression_domain)
+    }
 }
 
-/// An abstract domain uses a functional (side effect free) expression that precisely tracks
+/// An abstract domain defines a set of concrete values in some way.
+pub trait AbstractDomain {
+    /// True if the set of concrete values that correspond to this domain is empty.
+    fn is_bottom(&self) -> bool;
+
+    /// True if all possible concrete values are elements of the set corresponding to this domain.
+    fn is_top(&self) -> bool;
+
+    /// Returns a domain whose corresponding set of concrete values include all of the values
+    /// corresponding to self and other.
+    /// In a context where the join condition is known to be true, the result can be refined to be
+    /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
+    fn join(&self, other: &Self, join_condition: &AbstractDomains) -> Self;
+
+    /// True if all of the concrete values that correspond to self also correspond to other.
+    fn subset(&self, other: &Self) -> bool;
+
+    /// Returns a domain whose corresponding set of concrete values include all of the values
+    /// corresponding to self and other.The set of values may be less precise (more inclusive) than
+    /// the set returned by join. The chief requirement is that a small number of widen calls
+    /// deterministically lead to Top.
+    fn widen(&self, other: &Self, join_condition: &AbstractDomains) -> Self;
+}
+
+/// An abstract domain that uses a functional (side effect free) expression that precisely tracks
 /// a single value.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+/// Note: that value might not be known at compile time, so some operations on the domain
+/// may conservatively expand the set of of values that correspond to the domain to more than
+/// just one element.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum ExpressionDomain {
     /// An expression that represents any possible value
     Top,
@@ -32,9 +112,93 @@ pub enum ExpressionDomain {
     /// that always panics.
     Bottom,
 
-    /// An expression that is a compile time constant value, such as a numeric literal or a
-    /// function.
+    /// An expression that is a compile time constant value, such as a numeric literal or a function.
     CompileTimeConstant(ConstantValue),
+
+    /// An expression that is either if_true or if_false, depending on the value of join_condition.
+    JoinedExpression {
+        // A condition that results in a Boolean value
+        join_condition: Box<AbstractDomains>,
+        // The value of this expression if join_condition is true.
+        if_true: Box<ExpressionDomain>,
+        // The value of this expression if join_condition is false.
+        if_false: Box<ExpressionDomain>,
+    },
 }
 
-// todo: implement the AbstractDomain trait for ExpressionDomain
+impl AbstractDomain for ExpressionDomain {
+    /// True if the set of concrete values that correspond to this domain is empty.
+    fn is_bottom(&self) -> bool {
+        match self {
+            ExpressionDomain::Bottom => true,
+            _ => false,
+        }
+    }
+
+    /// True if all possible concrete values are elements of the set corresponding to this domain.
+    fn is_top(&self) -> bool {
+        match self {
+            ExpressionDomain::Top => true,
+            _ => false,
+        }
+    }
+
+    /// Returns a domain whose corresponding set of concrete values include all of the values
+    /// corresponding to self and other.
+    /// In a context where the join condition is known to be true, the result can be refined to be
+    /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
+    fn join(&self, other: &ExpressionDomain, join_condition: &AbstractDomains) -> ExpressionDomain {
+        ExpressionDomain::JoinedExpression {
+            join_condition: box join_condition.clone(),
+            if_true: box self.clone(),
+            if_false: box other.clone(),
+        }
+    }
+
+    /// Returns a domain whose corresponding set of concrete values include all of the values
+    /// corresponding to self and other.The set of values may be less precise (more inclusive) than
+    /// the set returned by join. The chief requirement is that a small number of widen calls
+    /// deterministically lead to Top.
+    fn widen(&self, _other: &Self, _join_condition: &AbstractDomains) -> ExpressionDomain {
+        //todo: don't get to top quite this quickly.
+        ExpressionDomain::Top
+    }
+
+    /// True if all of the concrete values that correspond to self also correspond to other.
+    /// Note: !x.subset(y) does not imply y.subset(x).
+    fn subset(&self, other: &ExpressionDomain) -> bool {
+        match (self, other) {
+            // The empty set is a subset of every other set
+            (ExpressionDomain::Bottom, _) => true,
+            // A non empty set if not a subset of the empty set
+            (_, ExpressionDomain::Bottom) => false,
+            // Every set is a subset of the universal set
+            (_, ExpressionDomain::Top) => true,
+            // The universal set is not a subset of any set other than the universal set
+            (ExpressionDomain::Top, _) => false,
+            (
+                ExpressionDomain::JoinedExpression {
+                    if_true, if_false, ..
+                },
+                _,
+            ) => {
+                // This is a conservative answer. False does not imply other.subset(self).
+                if_true.subset(other) && if_false.subset(other)
+            }
+            (
+                _,
+                ExpressionDomain::JoinedExpression {
+                    if_true, if_false, ..
+                },
+            ) => {
+                // This is a conservative answer. False does not imply other.subset(self).
+                self.subset(if_true) || self.subset(if_false)
+            }
+            // {x} subset {y} iff x = y
+            (
+                ExpressionDomain::CompileTimeConstant(cv1),
+                ExpressionDomain::CompileTimeConstant(cv2),
+            ) => cv1 == cv2,
+        }
+    }
+}

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -51,7 +51,7 @@ impl AbstractValue {
 
     /// True if all possible concrete values are elements of the set corresponding to this abstract value.
     pub fn is_top(&self) -> bool {
-        self.value.is_bottom()
+        self.value.is_top()
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the values

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 //
-use abstract_domains::AbstractDomains;
+use abstract_domains::{self, AbstractDomains};
 use syntax_pos::Span;
 
 /// Mirai is an abstract interpreter and thus produces abstract values.
@@ -14,7 +14,7 @@ use syntax_pos::Span;
 /// When we do know everything about a value, it is concrete rather than
 /// abstract, but is convenient to just use this structure for concrete values
 /// as well, since all operations can be uniform.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AbstractValue {
     /// An abstract value is the result of some expression.
     /// The source location of that expression is stored in provenance.
@@ -24,15 +24,67 @@ pub struct AbstractValue {
     /// expression (i.e. one with a provenance of its own) then a copy expression is created with
     /// the existing expression as argument, so that both locations are tracked.
     #[serde(skip)]
-    pub provenance: Span,
+    pub provenance: Span, //todo: perhaps this should be a list of spans
     /// Various approximations of the actual value.
     /// See https://github.com/facebookexperimental/MIRAI/blob/master/documentation/AbstractValues.md.
     pub value: AbstractDomains,
 }
 
+/// An abstract value that can be used as the value for an operation that has no normal result.
+pub const BOTTOM: AbstractValue = AbstractValue {
+    provenance: syntax_pos::DUMMY_SP,
+    value: abstract_domains::BOTTOM,
+};
+
+/// An abstract value to use when nothing is known about the value. All possible concrete values
+/// are members of the concrete set of values corresponding to this abstract value.
+pub const TOP: AbstractValue = AbstractValue {
+    provenance: syntax_pos::DUMMY_SP,
+    value: abstract_domains::TOP,
+};
+
+impl AbstractValue {
+    /// True if the set of concrete values that correspond to this abstract value is empty.
+    pub fn is_bottom(&self) -> bool {
+        self.value.is_bottom()
+    }
+
+    /// True if all possible concrete values are elements of the set corresponding to this abstract value.
+    pub fn is_top(&self) -> bool {
+        self.value.is_bottom()
+    }
+
+    /// Returns an abstract value whose corresponding set of concrete values include all of the values
+    /// corresponding to self and other.
+    /// In a context where the join condition is known to be true, the result can be refined to be
+    /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
+    pub fn join(&self, other: &AbstractValue, join_condition: &AbstractValue) -> AbstractValue {
+        AbstractValue {
+            provenance: syntax_pos::DUMMY_SP,
+            value: self.value.join(&other.value, &join_condition.value),
+        }
+    }
+
+    /// True if all of the concrete values that correspond to self also correspond to other.
+    pub fn subset(&self, other: &AbstractValue) -> bool {
+        self.value.subset(&other.value)
+    }
+
+    /// Returns an abstract value whose corresponding set of concrete values include all of the values
+    /// corresponding to self and other. The set of values may be less precise (more inclusive) than
+    /// the set returned by join. The chief requirement is that a small number of widen calls
+    /// deterministically lead to Top.
+    pub fn widen(&self, other: &AbstractValue, join_condition: &AbstractValue) -> AbstractValue {
+        AbstractValue {
+            provenance: syntax_pos::DUMMY_SP,
+            value: self.value.widen(&other.value, &join_condition.value),
+        }
+    }
+}
+
 /// The name of a function or method, sufficiently qualified so that it uniquely identifies it
 /// among all functions and methods defined in the project corresponding to a summary store.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Name {
     /// A root name in the current name space. Typically the name of a crate, used module, or
     /// used function or struct/trait/enum/type.
@@ -49,20 +101,20 @@ pub enum Name {
 /// A path represents a left hand side expression.
 /// When the actual expression is evaluated at runtime it will resolve to a particular memory
 /// location. During analysis it is used to keep track of state changes.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Path {
     /// The ordinal specifies a local variable or compiler temporary of the current function
     /// For example, in fn foo() { x: i32 = 0; x} we identify variable x with:
     /// Path::LocalVariable { ordinal: 0 }
     LocalVariable {
-        ordinal: u32,
+        ordinal: usize,
     },
 
     /// The index specifies the position of the parameter in the parameter list of the current function
     /// For example, in fn foo(x: int, y: int) {} we identify parameter x with:
     /// Path::Parameter { index: 0 }
     Parameter {
-        index: u32,
+        index: usize,
     },
 
     // The name uniquely identifies a static field within the current crate.
@@ -97,4 +149,5 @@ pub enum Path {
         qualifier: Box<Path>,
         index: Box<AbstractValue>,
     },
+    //todo: need a path for a conditional CFG link
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -84,18 +84,13 @@ impl Environment {
             }
         }
         for (path, val2) in value_map2.iter() {
-            match value_map1.get(path) {
-                Some(_) => {
-                    // Already joined in previous loop
-                }
-                None => {
-                    debug_assert!(!val2.is_bottom());
-                    let p = path.clone();
-                    value_map = value_map.insert(
-                        p,
-                        join_or_widen(&abstract_value::BOTTOM, &val2, &join_condition),
-                    );
-                }
+            if !value_map1.contains_key(path) {
+                debug_assert!(!val2.is_bottom());
+                let p = path.clone();
+                value_map = value_map.insert(
+                    p,
+                    join_or_widen(&abstract_value::BOTTOM, &val2, &join_condition),
+                );
             }
         }
         Environment { value_map }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use abstract_value::{self, AbstractValue, Path};
+use rpds::HashTrieMap;
+use rustc::hir::def_id::DefId;
+use rustc::ty::{self, Ty, TyCtxt};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Environment {
+    /// Does not include any entries where the value is abstract_value::Bottom
+    value_map: HashTrieMap<Path, AbstractValue>,
+}
+
+/// Constructor
+impl Environment {
+    /// Returns an environment that has a path for every parameter of the given function,
+    /// initialized with abstract_values::Top
+    pub fn with_parameters(def_id: DefId, tcx: TyCtxt) -> Environment {
+        let value_map = HashTrieMap::default();
+        let func_ty: Ty = tcx.type_of(def_id);
+        match func_ty.sty {
+            ty::FnDef(..) | ty::FnPtr(_) => {
+                let sig = func_ty.fn_sig(tcx);
+                let len = sig.inputs().skip_binder().len();
+                for i in 0..len {
+                    let par_i = Path::Parameter { index: i };
+                    // todo: figure out how to get a source span for each parameter definition
+                    value_map.insert(par_i, abstract_value::TOP);
+                }
+            }
+            _ => {}
+        };
+        Environment { value_map }
+    }
+}
+
+/// Methods
+impl Environment {
+    /// Returns a reference to the value associated with the given path.
+    /// If no such value exists, &abstract_value::Bottom is returned.
+    pub fn value_at(&self, path: &Path) -> &AbstractValue {
+        self.value_map.get(path).unwrap_or(&abstract_value::BOTTOM)
+    }
+
+    /// Returns an environment with a path for every entry in self and other and an associated
+    /// value that is the join of self.value_at(path) and other.value_at(path)
+    pub fn join(&self, other: &Environment, join_condition: &AbstractValue) -> Environment {
+        self.join_or_widen(other, join_condition, |x, y, c| x.join(y, c))
+    }
+
+    /// Returns an environment with a path for every entry in self and other and an associated
+    /// value that is the widen of self.value_at(path) and other.value_at(path)
+    pub fn widen(&self, other: &Environment, join_condition: &AbstractValue) -> Environment {
+        self.join_or_widen(other, join_condition, |x, y, c| x.widen(y, c))
+    }
+
+    /// Returns an environment with a path for every entry in self and other and an associated
+    /// value that is the join or widen of self.value_at(path) and other.value_at(path).
+    fn join_or_widen(
+        &self,
+        other: &Environment,
+        join_condition: &AbstractValue,
+        join_or_widen: fn(&AbstractValue, &AbstractValue, &AbstractValue) -> AbstractValue,
+    ) -> Environment {
+        let value_map1 = &self.value_map;
+        let value_map2 = &other.value_map;
+        let mut value_map: HashTrieMap<Path, AbstractValue> = HashTrieMap::default();
+        for (path, val1) in value_map1.iter() {
+            let p = path.clone();
+            match value_map2.get(path) {
+                Some(val2) => {
+                    value_map = value_map.insert(p, join_or_widen(&val1, &val2, &join_condition));
+                }
+                None => {
+                    debug_assert!(!val1.is_bottom());
+                    value_map = value_map.insert(
+                        p,
+                        join_or_widen(&val1, &abstract_value::BOTTOM, &join_condition),
+                    );
+                }
+            }
+        }
+        for (path, val2) in value_map2.iter() {
+            match value_map1.get(path) {
+                Some(_) => {
+                    // Already joined in previous loop
+                }
+                None => {
+                    debug_assert!(!val2.is_bottom());
+                    let p = path.clone();
+                    value_map = value_map.insert(
+                        p,
+                        join_or_widen(&abstract_value::BOTTOM, &val2, &join_condition),
+                    );
+                }
+            }
+        }
+        Environment { value_map }
+    }
+
+    /// Returns true if for every path, self.value_at(path).subset(other.value_at(path))
+    pub fn subset(&self, other: &Environment) -> bool {
+        let value_map1 = &self.value_map;
+        let value_map2 = &other.value_map;
+        if value_map1.size() > value_map2.size() {
+            // There is a key in value_map1 that has a value that is not bottom and which is not
+            // present in value_map2 (and therefore is bottom), hence there is a path where
+            // !(self[path] <= other[path])
+            return false;
+        }
+        for (path, val1) in value_map1.iter() {
+            match value_map2.get(path) {
+                Some(val2) => {
+                    if !(val1.subset(val2)) {
+                        return false;
+                    }
+                }
+                None => {
+                    debug_assert!(!val1.is_bottom());
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate getopts;
 extern crate rustc;
 extern crate rustc_codegen_utils;
+extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_metadata;
 extern crate rustc_target;
@@ -38,6 +39,7 @@ pub mod abstract_domains;
 pub mod abstract_value;
 pub mod callbacks;
 pub mod constant_value;
+pub mod environment;
 pub mod summaries;
 pub mod utils;
 pub mod visitors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ use mirai::utils;
 use std::env;
 use std::path::Path;
 
-#[cfg_attr(tarpaulin, skip)]
 fn main() {
     rustc_driver::run(|| {
         // Initialize loggers.

--- a/src/summaries.rs
+++ b/src/summaries.rs
@@ -4,7 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use abstract_value::{AbstractValue, Path};
-use rpds::{HashTrieMap, List};
+use environment::Environment;
+use rpds::List;
 use rustc::hir::def_id::DefId;
 use rustc::ty::TyCtxt;
 use std::collections::HashMap;
@@ -70,27 +71,37 @@ pub struct Summary {
     // Callers should substitute parameter values with argument values and simplify the result
     // under the current path condition. If the simplified value is statically known to be true
     // then the normal destination of the call should be treated as unreachable.
-    pub unwind_condition: Option<AbstractValue>,
+    pub unwind_condition: List<AbstractValue>,
+
+    // Modifications the function makes to mutable state external to the function.
+    // Every path will be rooted in a static or in a mutable parameter.
+    // No two paths in this collection will lead to the same place in memory.
+    // Callers should substitute parameter values with argument values and simplify the results
+    // under the current path condition. They should then update their current state to reflect the
+    // side-effects of the call for the unwind control paths, following the call.
+    pub unwind_side_effects: List<(Path, AbstractValue)>,
 }
 
 /// Constructs a summary of a function body by processing state information gathered during
 /// abstract interpretation of the body.
 pub fn summarize(
-    _environment: HashTrieMap<Path, AbstractValue>,
-    _inferred_preconditions: List<AbstractValue>,
-    _path_conditions: List<AbstractValue>,
-    preconditions: List<AbstractValue>,
-    post_conditions: List<AbstractValue>,
-    unwind_condition: Option<AbstractValue>,
+    _environment: &Environment,
+    _inferred_preconditions: &List<AbstractValue>,
+    _path_conditions: &List<AbstractValue>,
+    preconditions: &List<AbstractValue>,
+    post_conditions: &List<AbstractValue>,
+    unwind_condition: &List<AbstractValue>,
 ) -> Summary {
-    let result = None; // todo: extract from environment
+    let result = None; // todo: extract from exit environment
     let side_effects: List<(Path, AbstractValue)> = List::new(); // todo: extract from environment
+    let unwind_side_effects: List<(Path, AbstractValue)> = List::new(); // todo: extract from environment
     Summary {
-        preconditions,
+        preconditions: preconditions.clone(),
         result,
         side_effects,
-        post_conditions,
-        unwind_condition,
+        post_conditions: post_conditions.clone(),
+        unwind_condition: unwind_condition.clone(),
+        unwind_side_effects,
     }
 }
 

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -109,13 +109,13 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
                 // Merge output states of predcessors of bb
                 let mut i_state = Environment::default();
                 for pred_bb in self.mir.predecessors_for(bb).iter() {
-                    // todo: obtain join condition from out_state[pred_bb]
+                    // todo: obtain join condition from analysis of pred_bb
                     let join_condition = &abstract_value::TOP;
+                    // Once all paths have already been analyzed for a second time (iteration_count >= 3)
+                    // we to abstract more aggressively in order to ensure reaching a fixed point.
                     if iteration_count < 3 {
                         i_state = i_state.join(&out_state[pred_bb], join_condition);
                     } else {
-                        // At this point, all paths have already been analyzed for a second time and it is
-                        // time to abstract more aggressively in order to ensure reaching a fixed point.
                         i_state = i_state.widen(&out_state[pred_bb], join_condition);
                     }
                 }

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -4,19 +4,21 @@
 // LICENSE file in the root directory of this source tree.
 
 use abstract_domains::{AbstractDomains, ExpressionDomain};
-use abstract_value::{AbstractValue, Path};
+use abstract_value::{self, AbstractValue};
 use constant_value::{ConstantValue, ConstantValueCache};
-use rpds::{HashTrieMap, List};
+use environment::Environment;
+use rpds::List;
 use rustc::session::Session;
 use rustc::ty::{LazyConst, Ty, TyCtxt, TyKind, UserTypeAnnotationIndex};
 use rustc::{hir, mir};
 use std::borrow::Borrow;
+use std::collections::HashMap;
+use summaries;
 use summaries::PersistentSummaryCache;
 use syntax::errors::{Diagnostic, DiagnosticBuilder};
 use syntax_pos;
 
-/// Holds the state for the MIR test visitor.
-pub struct MirVisitor<'a, 'b: 'a, 'tcx: 'b> {
+pub struct MirVisitorCrateContext<'a, 'b: 'a, 'tcx: 'b> {
     /// A place where diagnostic messages can be buffered by the test harness.
     pub buffered_diagnostics: &'a mut Vec<Diagnostic>,
     /// A call back that the test harness can use to buffer the diagnostic message.
@@ -26,30 +28,139 @@ pub struct MirVisitor<'a, 'b: 'a, 'tcx: 'b> {
     pub tcx: TyCtxt<'b, 'tcx, 'tcx>,
     pub def_id: hir::def_id::DefId,
     pub mir: &'a mir::Mir<'tcx>,
-    pub environment: &'a mut HashTrieMap<Path, AbstractValue>,
-    pub inferred_preconditions: &'a mut List<AbstractValue>,
-    pub path_conditions: &'a mut List<AbstractValue>,
-    pub preconditions: &'a mut List<AbstractValue>,
-    pub post_conditions: &'a mut List<AbstractValue>,
-    pub unwind_condition: &'a mut Option<AbstractValue>,
-    pub summary_cache: &'a mut PersistentSummaryCache<'b, 'tcx>,
     pub constant_value_cache: &'a mut ConstantValueCache,
-    pub current_span: syntax_pos::Span,
+    pub summary_cache: &'a mut PersistentSummaryCache<'b, 'tcx>,
+}
+
+/// Holds the state for the MIR test visitor.
+pub struct MirVisitor<'a, 'b: 'a, 'tcx: 'b> {
+    buffered_diagnostics: &'a mut Vec<Diagnostic>,
+    emit_diagnostic: fn(&mut DiagnosticBuilder, buf: &mut Vec<Diagnostic>) -> (),
+    session: &'tcx Session,
+    tcx: TyCtxt<'b, 'tcx, 'tcx>,
+    def_id: hir::def_id::DefId,
+    mir: &'a mir::Mir<'tcx>,
+    constant_value_cache: &'a mut ConstantValueCache,
+    summary_cache: &'a mut PersistentSummaryCache<'b, 'tcx>,
+
+    check_for_errors: bool,
+    current_environment: Environment,
+    current_span: syntax_pos::Span,
+    exit_environment: Environment,
+    inferred_preconditions: List<AbstractValue>,
+    path_conditions: List<AbstractValue>,
+    post_conditions: List<AbstractValue>,
+    preconditions: List<AbstractValue>,
+    unwind_condition: List<AbstractValue>,
 }
 
 /// A visitor that simply traverses enough of the MIR associated with a particular code body
 /// so that we can test a call to every default implementation of the MirVisitor trait.
 impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
-    /// Visits each basic block in order of occurrence.
-    pub fn visit_body(&mut self) {
-        debug!("visit_body({:?})", self.def_id);
+    pub fn new(crate_context: MirVisitorCrateContext<'a, 'b, 'tcx>) -> MirVisitor<'a, 'b, 'tcx> {
+        MirVisitor {
+            buffered_diagnostics: crate_context.buffered_diagnostics,
+            emit_diagnostic: crate_context.emit_diagnostic,
+            session: crate_context.session,
+            tcx: crate_context.tcx,
+            def_id: crate_context.def_id,
+            mir: crate_context.mir,
+            constant_value_cache: crate_context.constant_value_cache,
+            summary_cache: crate_context.summary_cache,
 
-        for bb in self.mir.basic_blocks().indices() {
-            self.visit_basic_block(bb);
+            check_for_errors: false,
+            current_environment: Environment::default(),
+            current_span: syntax_pos::DUMMY_SP,
+            exit_environment: Environment::default(),
+            inferred_preconditions: List::new(),
+            path_conditions: List::new(),
+            post_conditions: List::new(),
+            preconditions: List::new(),
+            unwind_condition: List::new(),
         }
     }
 
-    /// Visit each statement in order and then visits the terminator.
+    /// Analyze the body and store a summary of its behavior in self.summary_cache.
+    pub fn visit_body(&mut self) {
+        debug!("visit_body({:?})", self.def_id);
+        // in_state[bb] is the join (or widening) of the out_state values of each predecessor of bb
+        let mut in_state: HashMap<rustc::mir::BasicBlock, Environment> = HashMap::new();
+        // out_state[bb] is the environment that results from analyzing block bb, given in_state[bb]
+        let mut out_state: HashMap<rustc::mir::BasicBlock, Environment> = HashMap::new();
+        // The entry block has no predecessors and its initial state is the function parameters.
+        let mut first_block = true;
+        for bb in self.mir.basic_blocks().indices() {
+            let i_state = if first_block {
+                first_block = false;
+                Environment::with_parameters(self.def_id, self.tcx)
+            } else {
+                Environment::default() // Will be joined with other states before analysis of bb
+            };
+            in_state.insert(bb, i_state);
+            out_state.insert(bb, Environment::default());
+        }
+
+        // Compute a fixed point, which is a value of out_state that will not grow with more iterations.
+        let mut changed = true;
+        let mut iteration_count = 0;
+        while changed {
+            changed = false;
+            for bb in self.mir.basic_blocks().indices() {
+                // Merge output states of predcessors of bb
+                let mut i_state = Environment::default();
+                for pred_bb in self.mir.predecessors_for(bb).iter() {
+                    // todo: obtain join condition from out_state[pred_bb]
+                    let join_condition = &abstract_value::TOP;
+                    if iteration_count < 3 {
+                        i_state = i_state.join(&out_state[pred_bb], join_condition);
+                    } else {
+                        // At this point, all paths have already been analyzed for a second time and it is
+                        // time to abstract more aggressively in order to ensure reaching a fixed point.
+                        i_state = i_state.widen(&out_state[pred_bb], join_condition);
+                    }
+                }
+
+                // Analyze the basic block.
+                self.current_environment = i_state;
+                self.visit_basic_block(bb);
+
+                // Check for a fixed point.
+                if !self.current_environment.subset(&out_state[&bb]) {
+                    // There is some path for which self.current_environment.value_at(path) includes
+                    // a value this is not present in out_state[bb].value_at(path), so any block
+                    // that used out_state[bb] as part of its input state now needs to get reanalyzed.
+                    out_state.insert(bb, self.current_environment.clone());
+                    changed = true;
+                } else {
+                    // If the environment at the end of this block does not have any new values,
+                    // we have reached a fixed point for this block.
+                }
+            }
+            iteration_count += 1;
+        }
+
+        // Now traverse the blocks again, doing checks and emitting diagnostics.
+        // in_state[bb] is now complete for every basic block bb in the body.
+        self.check_for_errors = true;
+        for bb in self.mir.basic_blocks().indices() {
+            let i_state = (&in_state[&bb]).clone();
+            self.current_environment = i_state;
+            self.visit_basic_block(bb);
+        }
+
+        // Now create a summary of the body that can be in-lined into call sites.
+        let summary = summaries::summarize(
+            &self.exit_environment,
+            &self.inferred_preconditions,
+            &self.path_conditions,
+            &self.preconditions,
+            &self.post_conditions,
+            &self.unwind_condition,
+        );
+        self.summary_cache.set_summary_for(self.def_id, summary);
+    }
+
+    /// Visits each statement in order and then visits the terminator.
     fn visit_basic_block(&mut self, bb: mir::BasicBlock) {
         debug!("visit_basic_block({:?})", bb);
 
@@ -285,6 +396,9 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
     ) {
         debug!("default visit_call(func: {:?}, args: {:?}, destination: {:?}, cleanup: {:?}, from_hir_call: {:?})", func, args, destination, cleanup, from_hir_call);
         let func_to_call = self.visit_operand(func);
+        if !self.check_for_errors {
+            return;
+        }
         if let ExpressionDomain::CompileTimeConstant(fun) = func_to_call.value.expression_domain {
             if self
                 .constant_value_cache

--- a/tests/run-pass/maybe_unreachable.rs
+++ b/tests/run-pass/maybe_unreachable.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls std::intrinsics::unreachable unconditionally.
+
+#![feature(core_intrinsics)]
+#![allow(unused)]
+
+use std::intrinsics;
+
+fn foo(flag: bool) {
+    if flag {
+        unsafe {
+            intrinsics::unreachable(); //~ Control might reach a call to std::intrinsics::unreachable
+        }
+    }
+}

--- a/tests/run-pass/maybe_unreachable.rs
+++ b/tests/run-pass/maybe_unreachable.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that calls std::intrinsics::unreachable unconditionally.
+// A test that calls std::intrinsics::unreachable conditionally.
 
 #![feature(core_intrinsics)]
 #![allow(unused)]


### PR DESCRIPTION
## Description

Flesh out the logic in the visit_body method of MirVisitor to compute a fixed point of input states for each basic block before visiting the blocks to look for problems and issuing diagnostics.

Since this involves joining/widening and checking if a state is a subset of another state, a lot of scaffolding has been added to the abstract value/domain classes. Various pieces of existing code have also been tweaked now that things are a bit more concrete.

Also new this PR is a separate class to model the memory (environment) that is accessible to a block.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Added a new test case, but for 100% coverage we'll have to wait for more scaffolding.