### PR TITLE
Introduce a hook for value refinement and generalize provenance.

### DIFF
--- a/documentation/IncrementalAnalysis.md
+++ b/documentation/IncrementalAnalysis.md
@@ -29,4 +29,7 @@ implement trait methods will have to honor the post conditions of the trait meth
 preconditions. This does have the implication that trait methods have to be annotated somehow to provide useful
 summaries to their callers.
 
-todo: write stuff about fixed points
+When a function recursively calls itself, directly or indirectly, it will be scheduled for re-analysis when its analysis
+completes, if the resulting summary is different from its previous summary. The code that responds to an incremental
+change should therefore be a loop that iterates until a fixed point, and the summaries that result from later iterations
+of the fixed point loop should be widened in order to ensure that the fixed point is reached.

--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -13,7 +13,7 @@ use constant_value::ConstantValue;
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AbstractDomains {
     pub expression_domain: ExpressionDomain,
-    //todo: use cached getters to get other domains on demand
+    //todo: #30 use cached getters to get other domains on demand
 }
 
 /// A collection of abstract domains that all represent the impossible abstract value.
@@ -204,7 +204,7 @@ impl AbstractDomain for ExpressionDomain {
     /// the set returned by join. The chief requirement is that a small number of widen calls
     /// deterministically lead to Top.
     fn widen(&self, _other: &Self, _join_condition: &AbstractDomains) -> ExpressionDomain {
-        //todo: don't get to top quite this quickly.
+        //todo: #30 don't get to top quite this quickly.
         ExpressionDomain::Top
     }
 }

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -21,8 +21,8 @@ pub struct AbstractValue {
     /// The source location of that expression is stored in provenance.
     /// When an expression value is stored somewhere and then retrieved via an accessor expression,
     /// a new abstract value is created (via refinement using the current path condition) with a
-    /// provenance that is the source location of accessor expression prepended to the provenance of
-    /// the stored value.
+    /// provenance that is the source location of the accessor expression prepended to the
+    /// provenance of the stored value.
     #[serde(skip)]
     pub provenance: Vec<Span>,
     /// Various approximations of the actual value.

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 use abstract_domains::{self, AbstractDomains};
+use rpds::List;
 use syntax_pos::Span;
 
 /// Mirai is an abstract interpreter and thus produces abstract values.
@@ -18,13 +19,12 @@ use syntax_pos::Span;
 pub struct AbstractValue {
     /// An abstract value is the result of some expression.
     /// The source location of that expression is stored in provenance.
-    /// When an expression is stored somewhere and then retrieved via an accessor expression, a new
-    /// abstract value is created (via refinement using the current path condition) with a provenance
-    /// that is the source location of accessor expression. If refinement results in an existing
-    /// expression (i.e. one with a provenance of its own) then a copy expression is created with
-    /// the existing expression as argument, so that both locations are tracked.
+    /// When an expression value is stored somewhere and then retrieved via an accessor expression,
+    /// a new abstract value is created (via refinement using the current path condition) with a
+    /// provenance that is the source location of accessor expression prepended to the provenance of
+    /// the stored value.
     #[serde(skip)]
-    pub provenance: Span, //todo: perhaps this should be a list of spans
+    pub provenance: Vec<Span>,
     /// Various approximations of the actual value.
     /// See https://github.com/facebookexperimental/MIRAI/blob/master/documentation/AbstractValues.md.
     pub value: AbstractDomains,
@@ -32,14 +32,14 @@ pub struct AbstractValue {
 
 /// An abstract value that can be used as the value for an operation that has no normal result.
 pub const BOTTOM: AbstractValue = AbstractValue {
-    provenance: syntax_pos::DUMMY_SP,
+    provenance: Vec::new(),
     value: abstract_domains::BOTTOM,
 };
 
 /// An abstract value to use when nothing is known about the value. All possible concrete values
 /// are members of the concrete set of values corresponding to this abstract value.
 pub const TOP: AbstractValue = AbstractValue {
-    provenance: syntax_pos::DUMMY_SP,
+    provenance: Vec::new(),
     value: abstract_domains::TOP,
 };
 
@@ -59,9 +59,31 @@ impl AbstractValue {
     /// In a context where the join condition is known to be true, the result can be refined to be
     /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
     pub fn join(&self, other: &AbstractValue, join_condition: &AbstractValue) -> AbstractValue {
+        let mut provenance = Vec::new();
+        provenance.extend_from_slice(&join_condition.provenance);
+        provenance.extend_from_slice(&self.provenance);
+        provenance.extend_from_slice(&other.provenance);
         AbstractValue {
-            provenance: syntax_pos::DUMMY_SP,
+            provenance,
             value: self.value.join(&other.value, &join_condition.value),
+        }
+    }
+
+    /// Returns a value that could be simplified (refined) by using the current path conditions
+    /// (conditions known to be true in the current context). If no refinement is possible
+    /// the result is simply a clone of this value, but with its provenance updated by
+    /// pre-pending the given span.
+    pub fn refine_with(
+        &self,
+        _path_condtions: &List<AbstractValue>,
+        provenance: Span,
+    ) -> AbstractValue {
+        //todo: #32 simplify this value using the path conditions
+        let mut provenance = vec![provenance];
+        provenance.extend_from_slice(&self.provenance);
+        AbstractValue {
+            provenance,
+            value: self.value.clone(),
         }
     }
 
@@ -76,7 +98,7 @@ impl AbstractValue {
     /// deterministically lead to Top.
     pub fn widen(&self, other: &AbstractValue, join_condition: &AbstractValue) -> AbstractValue {
         AbstractValue {
-            provenance: syntax_pos::DUMMY_SP,
+            provenance: other.provenance.clone(),
             value: self.value.widen(&other.value, &join_condition.value),
         }
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -29,10 +29,9 @@ impl Environment {
 
 /// Methods
 impl Environment {
-    /// Returns a reference to the value associated with the given path.
-    /// If no such value exists, &abstract_value::Bottom is returned.
-    pub fn value_at(&self, path: &Path) -> &AbstractValue {
-        self.value_map.get(path).unwrap_or(&abstract_value::BOTTOM)
+    /// Returns a reference to the value associated with the given path, if there is one.
+    pub fn value_at(&self, path: &Path) -> Option<&AbstractValue> {
+        self.value_map.get(path)
     }
 
     /// Updates the path to value map so that the given path now points to the given value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 // While pretty bad, it is a lot less bad than having to write our own compiler, so here goes.
 #![feature(rustc_private)]
 #![feature(box_syntax)]
+#![feature(const_vec_new)]
 
 extern crate getopts;
 extern crate rustc;

--- a/src/summaries.rs
+++ b/src/summaries.rs
@@ -92,9 +92,9 @@ pub fn summarize(
     post_conditions: &List<AbstractValue>,
     unwind_condition: &List<AbstractValue>,
 ) -> Summary {
-    let result = None; // todo: extract from exit environment
-    let side_effects: List<(Path, AbstractValue)> = List::new(); // todo: extract from environment
-    let unwind_side_effects: List<(Path, AbstractValue)> = List::new(); // todo: extract from environment
+    let result = None; // todo: #31 extract from exit environment
+    let side_effects: List<(Path, AbstractValue)> = List::new(); // todo: #31  extract from environment
+    let unwind_side_effects: List<(Path, AbstractValue)> = List::new(); // todo: #31  extract from environment
     Summary {
         preconditions: preconditions.clone(),
         result,
@@ -211,7 +211,7 @@ impl<'a, 'tcx: 'a> PersistentSummaryCache<'a, 'tcx> {
             Ok(Some(serialized_summary)) => {
                 bincode::deserialize(serialized_summary.deref()).unwrap()
             }
-            _ => Summary::default(), // todo: look for a contract summary or construct from type
+            _ => Summary::default(), // todo: #33 look for a contract summary or construct from type
         }
     }
 

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -84,12 +84,11 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
     /// For now, statics and promoted constants just return Top.
     /// If a local value cannot be found the result is Bottom.
     fn lookup_path_and_refine_result(&mut self, path: Path) -> AbstractValue {
-        let refined_val;
-        {
+        let refined_val = {
             let bottom = abstract_value::BOTTOM;
             let local_val = self.current_environment.value_at(&path).unwrap_or(&bottom);
-            refined_val = local_val.refine_with(&self.path_conditions, self.current_span);
-        }
+            local_val.refine_with(&self.path_conditions, self.current_span)
+        };
         if refined_val.is_bottom() {
             // Not found locally, so try statics and promoted constants
             let mut val: Option<AbstractValue> = None;


### PR DESCRIPTION
## Description

Provides issues numbers for a bunch of todo comments and implements the following todos:
- makes AbstractValue::provenance a list of spans
- adds AbstractValue:: refine_with (just a hook for now)
- wrote stuff about fixed points in IncrementalAnalysis.md

Related to #28

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Existing tests cover this.


