### PR TITLE
Track entry and exit conditions in block environment

### DIFF
--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -22,13 +22,37 @@ pub const BOTTOM: AbstractDomains = AbstractDomains {
     expression_domain: ExpressionDomain::Bottom,
 };
 
+/// A collection of abstract domains that all represent the single concrete value, false.
+pub const FALSE: AbstractDomains = AbstractDomains {
+    expression_domain: ExpressionDomain::CompileTimeConstant(ConstantValue::False),
+};
+
 /// A collection of abstract domains that all represent the universal abstract value.
 /// I.e. the corresponding set of possible concrete values includes every possible concrete value.
 pub const TOP: AbstractDomains = AbstractDomains {
     expression_domain: ExpressionDomain::Top,
 };
 
+/// A collection of abstract domains that all represent the single concrete value, true.
+pub const TRUE: AbstractDomains = AbstractDomains {
+    expression_domain: ExpressionDomain::CompileTimeConstant(ConstantValue::True),
+};
+
 impl AbstractDomains {
+    /// Applies "and" to every pair of domain elements and returns the collection of results.
+    pub fn and(&self, other: &AbstractDomains) -> AbstractDomains {
+        AbstractDomains {
+            expression_domain: self.expression_domain.and(&other.expression_domain),
+        }
+    }
+
+    /// Applies "equals" to every pair of domain elements and returns the collection of results.
+    pub fn equals(&self, other: &AbstractDomains) -> AbstractDomains {
+        AbstractDomains {
+            expression_domain: self.expression_domain.equals(&other.expression_domain),
+        }
+    }
+
     /// True if all of the abstract domains in this collection correspond to an empty set of concrete values.
     pub fn is_bottom(&self) -> bool {
         self.expression_domain.is_bottom()
@@ -51,6 +75,20 @@ impl AbstractDomains {
             expression_domain: self
                 .expression_domain
                 .join(&other.expression_domain, &join_condition),
+        }
+    }
+
+    /// Applies "not" to every domain element and returns the collection of results.
+    pub fn not(&self) -> AbstractDomains {
+        AbstractDomains {
+            expression_domain: self.expression_domain.not(),
+        }
+    }
+
+    /// Applies "or" to every pair of domain elements and returns the collection of results.
+    pub fn or(&self, other: &AbstractDomains) -> AbstractDomains {
+        AbstractDomains {
+            expression_domain: self.expression_domain.or(&other.expression_domain),
         }
     }
 
@@ -78,6 +116,14 @@ impl AbstractDomains {
 
 /// An abstract domain defines a set of concrete values in some way.
 pub trait AbstractDomain {
+    /// Returns a domain whose concrete set is a superset of the set of values resulting from
+    /// mapping the concrete "and" operation over the elements of the cross product of self and other.
+    fn and(&self, other: &Self) -> Self;
+
+    /// Returns a domain whose concrete set is a superset of the set of values resulting from
+    /// mapping the concrete "equals" operation over the elements of the cross product of self and other.
+    fn equals(&self, other: &Self) -> Self;
+
     /// True if the set of concrete values that correspond to this domain is empty.
     fn is_bottom(&self) -> bool;
 
@@ -89,6 +135,20 @@ pub trait AbstractDomain {
     /// In a context where the join condition is known to be true, the result can be refined to be
     /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
     fn join(&self, other: &Self, join_condition: &AbstractDomains) -> Self;
+
+    /// True if the domain corresponds to the concrete set { false }
+    fn must_be_false(&self) -> bool;
+
+    /// True if the domain corresponds to the concrete set { true }
+    fn must_be_true(&self) -> bool;
+
+    /// Returns a domain whose concrete set is a superset of the set of values resulting from
+    /// mapping the concrete "not" operation over the elements of self.
+    fn not(&self) -> Self;
+
+    /// Returns a domain whose concrete set is a superset of the set of values resulting from
+    /// mapping the concrete "or" operation over the elements of the cross product of self and other.
+    fn or(&self, other: &Self) -> Self;
 
     /// True if all of the concrete values that correspond to self also correspond to other.
     fn subset(&self, other: &Self) -> bool;
@@ -104,7 +164,7 @@ pub trait AbstractDomain {
 /// a single value.
 /// Note: that value might not be known at compile time, so some operations on the domain
 /// may conservatively expand the set of of values that correspond to the domain to more than
-/// just one element.
+/// just one element. See for example the subset operation.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum ExpressionDomain {
     /// An expression that represents any possible value
@@ -113,6 +173,14 @@ pub enum ExpressionDomain {
     /// An expression that represents an impossible value, such as the value returned by function
     /// that always panics.
     Bottom,
+
+    // An expression that is true if both left and right are true.
+    And {
+        // The value of the left operand.
+        left: Box<ExpressionDomain>,
+        // The value of the right operand.
+        right: Box<ExpressionDomain>,
+    },
 
     /// An expression that is a compile time constant value, such as a numeric literal or a function.
     CompileTimeConstant(ConstantValue),
@@ -126,9 +194,67 @@ pub enum ExpressionDomain {
         // The value of this expression if join_condition is false.
         alternate: Box<ExpressionDomain>,
     },
+
+    // An expression that is true if left and right are equal.
+    Equals {
+        // The value of the left operand.
+        left: Box<ExpressionDomain>,
+        // The value of the right operand.
+        right: Box<ExpressionDomain>,
+    },
+
+    /// An expression that is true if the operand is false.
+    Not { operand: Box<ExpressionDomain> },
+
+    // An expression that is true if either one of left or right are true.
+    Or {
+        // The value of the left operand.
+        left: Box<ExpressionDomain>,
+        // The value of the right operand.
+        right: Box<ExpressionDomain>,
+    },
 }
 
 impl AbstractDomain for ExpressionDomain {
+    /// Returns an expression that is "self && other".
+    fn and(&self, other: &Self) -> Self {
+        if self.must_be_true() {
+            if other.must_be_true() {
+                ExpressionDomain::CompileTimeConstant(ConstantValue::True)
+            } else {
+                other.clone()
+            }
+        } else if other.must_be_true() {
+            self.clone()
+        } else {
+            // todo: #32 more simplifications
+            ExpressionDomain::And {
+                left: box self.clone(),
+                right: box other.clone(),
+            }
+        }
+    }
+
+    /// Returns an expression that is "self == other".
+    fn equals(&self, other: &Self) -> Self {
+        match (self, other) {
+            (
+                ExpressionDomain::CompileTimeConstant(cv1),
+                ExpressionDomain::CompileTimeConstant(cv2),
+            ) => {
+                if cv1 == cv2 {
+                    ExpressionDomain::CompileTimeConstant(ConstantValue::True)
+                } else {
+                    ExpressionDomain::CompileTimeConstant(ConstantValue::False)
+                }
+            }
+            _ => ExpressionDomain::Equals {
+                left: box self.clone(),
+                right: box other.clone(),
+            },
+        }
+    }
+
     /// True if the set of concrete values that correspond to this domain is empty.
     fn is_bottom(&self) -> bool {
         match self {
@@ -154,6 +280,54 @@ impl AbstractDomain for ExpressionDomain {
             condition: box join_condition.clone(),
             consequent: box self.clone(),
             alternate: box other.clone(),
+        }
+    }
+
+    /// True if this expression is known at compile time to be false.
+    fn must_be_false(&self) -> bool {
+        match self {
+            ExpressionDomain::CompileTimeConstant(ConstantValue::False) => true,
+            _ => false,
+        }
+    }
+
+    /// True if this expression is known at compile time to be true.
+    fn must_be_true(&self) -> bool {
+        match self {
+            ExpressionDomain::CompileTimeConstant(ConstantValue::True) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns an expression that is "!self".
+    fn not(&self) -> Self {
+        match self {
+            ExpressionDomain::CompileTimeConstant(ConstantValue::False) => {
+                ExpressionDomain::CompileTimeConstant(ConstantValue::True)
+            }
+            ExpressionDomain::CompileTimeConstant(ConstantValue::True) => {
+                ExpressionDomain::CompileTimeConstant(ConstantValue::False)
+            }
+            _ => ExpressionDomain::Not {
+                operand: box self.clone(),
+            },
+        }
+    }
+
+    /// Returns an expression that is "self || other".
+    fn or(&self, other: &ExpressionDomain) -> ExpressionDomain {
+        if self.must_be_true() || other.must_be_true() {
+            ExpressionDomain::CompileTimeConstant(ConstantValue::True)
+        } else if self.must_be_false() {
+            other.clone()
+        } else if other.must_be_false() {
+            self.clone()
+        } else {
+            // todo: #32 more simplifications
+            ExpressionDomain::Or {
+                left: box self.clone(),
+                right: box other.clone(),
+            }
         }
     }
 
@@ -196,6 +370,8 @@ impl AbstractDomain for ExpressionDomain {
                 ExpressionDomain::CompileTimeConstant(cv1),
                 ExpressionDomain::CompileTimeConstant(cv2),
             ) => cv1 == cv2,
+            // in all other cases we conservatively answer false
+            _ => false,
         }
     }
 

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 use abstract_domains::{self, AbstractDomains};
-use rpds::List;
 use syntax_pos::Span;
 
 /// Mirai is an abstract interpreter and thus produces abstract values.
@@ -36,6 +35,12 @@ pub const BOTTOM: AbstractValue = AbstractValue {
     value: abstract_domains::BOTTOM,
 };
 
+/// An abstract value that is corresponds to the single concrete value, true.
+pub const FALSE: AbstractValue = AbstractValue {
+    provenance: Vec::new(),
+    value: abstract_domains::FALSE,
+};
+
 /// An abstract value to use when nothing is known about the value. All possible concrete values
 /// are members of the concrete set of values corresponding to this abstract value.
 pub const TOP: AbstractValue = AbstractValue {
@@ -43,7 +48,49 @@ pub const TOP: AbstractValue = AbstractValue {
     value: abstract_domains::TOP,
 };
 
+/// An abstract value that is corresponds to the single concrete value, true.
+pub const TRUE: AbstractValue = AbstractValue {
+    provenance: Vec::new(),
+    value: abstract_domains::TRUE,
+};
+
 impl AbstractValue {
+    /// Returns an abstract value whose corresponding set of concrete values include all of the
+    /// values resulting from applying "and" to each element of the cross product of the concrete
+    /// values or self and other.
+    pub fn and(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+        let mut provenance = Vec::new();
+        if expression_provenance.is_some() {
+            provenance.push(expression_provenance.unwrap())
+        }
+        provenance.extend_from_slice(&self.provenance);
+        provenance.extend_from_slice(&other.provenance);
+        AbstractValue {
+            provenance,
+            value: self.value.and(&other.value),
+        }
+    }
+
+    /// Returns an abstract value whose corresponding set of concrete values include all of the
+    /// values resulting from applying "equals" to each element of the cross product of the concrete
+    /// values or self and other.
+    pub fn equals(
+        &self,
+        other: &AbstractValue,
+        expression_provenance: Option<Span>,
+    ) -> AbstractValue {
+        let mut provenance = Vec::new();
+        if expression_provenance.is_some() {
+            provenance.push(expression_provenance.unwrap())
+        }
+        provenance.extend_from_slice(&self.provenance);
+        provenance.extend_from_slice(&other.provenance);
+        AbstractValue {
+            provenance,
+            value: self.value.equals(&other.value),
+        }
+    }
+
     /// True if the set of concrete values that correspond to this abstract value is empty.
     pub fn is_bottom(&self) -> bool {
         self.value.is_bottom()
@@ -69,16 +116,40 @@ impl AbstractValue {
         }
     }
 
+    pub fn not(&self, expression_provenance: Option<Span>) -> AbstractValue {
+        let mut provenance = Vec::new();
+        if expression_provenance.is_some() {
+            provenance.push(expression_provenance.unwrap())
+        }
+        provenance.extend_from_slice(&self.provenance);
+        AbstractValue {
+            provenance,
+            value: self.value.not(),
+        }
+    }
+
+    /// Returns an abstract value whose corresponding set of concrete values include all of the
+    /// values resulting from applying "or" to each element of the cross product of the concrete
+    /// values or self and other.
+    pub fn or(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+        let mut provenance = Vec::new();
+        if expression_provenance.is_some() {
+            provenance.push(expression_provenance.unwrap())
+        }
+        provenance.extend_from_slice(&self.provenance);
+        provenance.extend_from_slice(&other.provenance);
+        AbstractValue {
+            provenance,
+            value: self.value.or(&other.value),
+        }
+    }
+
     /// Returns a value that could be simplified (refined) by using the current path conditions
     /// (conditions known to be true in the current context). If no refinement is possible
     /// the result is simply a clone of this value, but with its provenance updated by
     /// pre-pending the given span.
-    pub fn refine_with(
-        &self,
-        _path_condtions: &List<AbstractValue>,
-        provenance: Span,
-    ) -> AbstractValue {
-        //todo: #32 simplify this value using the path conditions
+    pub fn refine_with(&self, _path_condtion: &AbstractValue, provenance: Span) -> AbstractValue {
+        //todo: #32 simplify this value using the path condition
         let mut provenance = vec![provenance];
         provenance.extend_from_slice(&self.provenance);
         AbstractValue {
@@ -101,6 +172,13 @@ impl AbstractValue {
             provenance: other.provenance.clone(),
             value: self.value.widen(&other.value, &join_condition.value),
         }
+    }
+
+    /// Returns a clone of the value with the given span prepended to its provence.
+    pub fn with_provenance(&self, provenance: Span) -> AbstractValue {
+        let mut result = self.clone();
+        result.provenance.insert(0, provenance);
+        result
     }
 }
 

--- a/src/constant_value.rs
+++ b/src/constant_value.rs
@@ -3,6 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use abstract_domains::{AbstractDomains, ExpressionDomain};
+use abstract_value::AbstractValue;
 use rustc::hir::def_id::DefId;
 use rustc::ty::TyCtxt;
 use std::collections::HashMap;
@@ -14,6 +16,8 @@ use utils::is_rust_intrinsic;
 /// value can be serialized to the persistent summary cache.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum ConstantValue {
+    /// The Boolean value false.
+    False,
     /// A reference to a function
     Function {
         /// Indicates if the function is known to be treated specially by the Rust compiler
@@ -23,8 +27,23 @@ pub enum ConstantValue {
         // todo: is there some way store the def_id here if available?
         // this would not be serialized/deserialized.
     },
-    // A place holder for other kinds of constants. Eventually this goes away.
+    /// Unsigned 16 byte integer.
+    U128(u128),
+    /// The Boolean true value.
+    True,
+    /// A place holder for other kinds of constants. Eventually this goes away.
     Unimplemented,
+}
+
+impl Into<AbstractValue> for ConstantValue {
+    fn into(self) -> AbstractValue {
+        AbstractValue {
+            provenance: vec![],
+            value: AbstractDomains {
+                expression_domain: ExpressionDomain::CompileTimeConstant(self),
+            },
+        }
+    }
 }
 
 impl ConstantValue {

--- a/src/summaries.rs
+++ b/src/summaries.rs
@@ -87,7 +87,6 @@ pub struct Summary {
 pub fn summarize(
     _environment: &Environment,
     _inferred_preconditions: &List<AbstractValue>,
-    _path_conditions: &List<AbstractValue>,
     preconditions: &List<AbstractValue>,
     post_conditions: &List<AbstractValue>,
     unwind_condition: &List<AbstractValue>,

--- a/tests/validate.sh
+++ b/tests/validate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Exit immediately if a command exits with a non-zero status.
+set -e
+# start clean
+cargo clean -p mirai
+# Run format checks
+cargo fmt --all
+# Run lint checks
+cargo clippy -- -D warnings
+# Build
+time cargo build
+# Run unit and integration tests
+RUST_BACKTRACE=1 cargo test
+# Run mirai on itself
+cargo uninstall mirai || true
+cargo install --debug --path .
+cargo clean -p mirai
+time RUSTC_WRAPPER=mirai cargo build


### PR DESCRIPTION
## Description

Track the conditions that guard control flow from one block to another and join them into path conditions that can be used to simplify (refine) abstract values that were constructed in a different context from the referring context.

Part of #28

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update

## How Has This Been Tested?

Covered by existing tests. (More infrastructure is needed before the tests can become more interesting.)