### PR TITLE
Tweak static assign test case to also read the static.

### DIFF
--- a/tests/run-pass/static_assign.rs
+++ b/tests/run-pass/static_assign.rs
@@ -11,3 +11,7 @@ pub static mut A: isize = 3;
 pub fn main() {
     unsafe { A = 4; }
 }
+
+pub fn foo() -> isize {
+    unsafe { A.clone() }
+}


### PR DESCRIPTION
## Description

Add a bit of test code to cover a path that is currently not reached by the integration tests.



