### PR TITLE
Add a test that exercises visit_used_copy with a structured value.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ Fixes # (issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] API change with a documentation update
+- [ ] Additional test coverage
 
 ## How Has This Been Tested?
 

--- a/tests/run-pass/use_copy.rs
+++ b/tests/run-pass/use_copy.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that exercises visit_used_copy with a structured value.
+
+#[derive(Clone, Copy)]
+struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+pub fn test() {
+    let p = Point { x: 1, y: 2};
+    let _q = p;
+}


### PR DESCRIPTION
## Description

Adds a test case that exercises visit_used_copy in a non trivial way, which is to say with a structured value rather than a primitive type.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage

## How Has This Been Tested?

Integration tests.

