### PR TITLE
Implement visit_constant for integer and floating point literals.

### DIFF
--- a/tests/run-pass/numeric_constants.rs
+++ b/tests/run-pass/numeric_constants.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that exercises the numeric parts of visit_constant.
+
+pub static A: isize = -1;
+pub static B: usize = 2;
+pub static C: i8 = -3;
+pub static D: u8 = 4;
+pub static E: i16 = -5;
+pub static F: u16 = 6;
+pub static G: i32 = -7;
+pub static H: u32 = 8;
+pub static I: i32 = -9;
+pub static J: u32 = 10;
+pub static K: i64 = -11;
+pub static L: u64 = 12;
+pub static M: i128 = -13;
+pub static N: u128 = 14;
+pub static O:f32 = 15.6;
+pub static P:f64 = 15.6666666666666666666666;


### PR DESCRIPTION
## Description

This fleshes out visit_constant to deal with numeric literals. A point to note here is that visit_constant gives out a reference to a ConstantValue, so the value has to live somewhere that outlives the visitor. That somewhere is the the constant value cache.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Added a test case that covers the new code.
