### PR TITLE
Use Option<bool> for predicates that may not be known at compile time.

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -92,6 +92,11 @@ impl AbstractValue {
         }
     }
 
+    /// The concrete Boolean value of this abstract value, if known, otherwise None.
+    pub fn as_bool_if_known(&self) -> Option<bool> {
+        self.value.as_bool_if_known()
+    }
+
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "equals" to each element of the cross product of the concrete
     /// values or self and other.

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -917,10 +917,10 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
                 TyKind::Int(..) => match val {
                     ConstValue::Scalar(Scalar::Bits { bits, size }) => {
                         let mut value: i128 = match *size {
-                            1 => (*bits as i8) as i128,
-                            2 => (*bits as i16) as i128,
-                            4 => (*bits as i32) as i128,
-                            8 => (*bits as i64) as i128,
+                            1 => i128::from(*bits as i8),
+                            2 => i128::from(*bits as i16),
+                            4 => i128::from(*bits as i32),
+                            8 => i128::from(*bits as i64),
                             _ => *bits as i128,
                         };
                         &mut self.constant_value_cache.get_i128_for(value)
@@ -936,7 +936,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
                 TyKind::Float(..) => match val {
                     ConstValue::Scalar(Scalar::Bits { bits, size }) => {
                         let mut value: u64 = match *size {
-                            4 => (*bits as u32) as u64,
+                            4 => u64::from(*bits as u32),
                             _ => *bits as u64,
                         };
                         &mut self.constant_value_cache.get_f64_for(value)


### PR DESCRIPTION
## Description

This is a cosmetic refactor that expresses must_be_false and must_be_true as a single predicate, as_bool_if_known() -> Option<boo>, which returns None if the Boolean value of the abstract value/domain is not known at compile time.

Also fix a Clippy complaint that got overlooked because of the problems with the latest nightly compiler builds on Linux.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Existing tests.
