### PR TITLE
Bundle DefId value with function constant to help with summary caching.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = true
 debug = true
 
 [dependencies]
-bincode = "1.0"
+bincode = { version = "1.0", features = ["i128"] }
 env_logger = "0.5"
 log = "0.4"
 rocksdb = "0.10"

--- a/src/constant_value.rs
+++ b/src/constant_value.rs
@@ -19,12 +19,12 @@ pub enum ConstantValue {
     False,
     /// A reference to a function
     Function {
+        #[serde(skip)]
+        def_id: Option<DefId>,
         /// Indicates if the function is known to be treated specially by the Rust compiler
         is_intrinsic: bool,
         /// The key to use when retrieving a summary for the function from the summary cache
         summary_cache_key: String,
-        // todo: is there some way store the def_id here if available?
-        // this would not be serialized/deserialized.
     },
     /// Signed 16 byte integer.
     I128(i128),
@@ -46,8 +46,8 @@ impl ConstantValue {
         summary_cache: &mut PersistentSummaryCache,
     ) -> ConstantValue {
         let summary_cache_key = summary_cache.get_summary_key_for(def_id);
-        // todo: include the def_id in the result
         ConstantValue::Function {
+            def_id: Some(def_id),
             is_intrinsic: is_rust_intrinsic(def_id, tcx),
             summary_cache_key: summary_cache_key.to_owned(),
         }
@@ -129,6 +129,7 @@ impl ConstantValueCache {
                 ConstantValue::Function {
                     is_intrinsic,
                     summary_cache_key,
+                    ..
                 } => *is_intrinsic && summary_cache_key.ends_with("unreachable"),
                 _ => false,
             };

--- a/src/summaries.rs
+++ b/src/summaries.rs
@@ -38,7 +38,7 @@ use std::ops::Deref;
 ///    desirable to havoc all static variables every time such a function is called. Consequently
 ///    sound analysis is only possible one can assume that all such functions have been provided
 ///    with explicit contract functions.
-#[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct Summary {
     // Conditions that should hold prior to the call.
     // Callers should substitute parameter values with argument values and simplify the results
@@ -85,18 +85,21 @@ pub struct Summary {
 /// Constructs a summary of a function body by processing state information gathered during
 /// abstract interpretation of the body.
 pub fn summarize(
-    _environment: &Environment,
+    environment: &Environment,
     _inferred_preconditions: &List<AbstractValue>,
     preconditions: &List<AbstractValue>,
     post_conditions: &List<AbstractValue>,
     unwind_condition: &List<AbstractValue>,
 ) -> Summary {
-    let result = None; // todo: #31 extract from exit environment
+    let result = environment.value_at(&Path::LocalVariable { ordinal: 0 });
     let side_effects: List<(Path, AbstractValue)> = List::new(); // todo: #31  extract from environment
     let unwind_side_effects: List<(Path, AbstractValue)> = List::new(); // todo: #31  extract from environment
     Summary {
         preconditions: preconditions.clone(),
-        result,
+        result: match result {
+            Some(v) => Some(v.clone()),
+            None => None,
+        },
         side_effects,
         post_conditions: post_conditions.clone(),
         unwind_condition: unwind_condition.clone(),

--- a/tests/run-pass/func_call.rs
+++ b/tests/run-pass/func_call.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a function summary.
+
+fn foo() -> i32 { 123 }
+pub fn main() {
+    let _x = foo();
+}


### PR DESCRIPTION
## Description

Include the DefId of a function in the constant value that a function reference results in. This is not serializable and function values retrieved from the summary cache will not have them. Most functions, however, should have them and this makes for a better caching story. The particular cache lookup used also registers the caller as a dependent of the function via the summary cache, so this is also providing for future incremental compilation scenarios.

Now that functions calls actually lookup the summaries of the called functions, and store the call result in the local state, it also makes sense to start making summaries have actual information in them. With this PR, return statements now update the visitor's exit_environment and the summarize function now makes use of it.

Part of fix for #28 and #31.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Added a new test case and inspected its debug log output to verify that the return value get's retrieved from the summary and transferred into the local state of the caller.


