### PR TITLE
Fixed point bug fixes.

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -5,6 +5,8 @@
 //
 use abstract_domains::{self, AbstractDomains, ExpressionDomain};
 use constant_value::ConstantValue;
+use std::fmt::{Debug, Formatter, Result};
+use std::hash::{Hash, Hasher};
 use syntax_pos::Span;
 
 /// Mirai is an abstract interpreter and thus produces abstract values.
@@ -15,7 +17,7 @@ use syntax_pos::Span;
 /// When we do know everything about a value, it is concrete rather than
 /// abstract, but is convenient to just use this structure for concrete values
 /// as well, since all operations can be uniform.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AbstractValue {
     /// An abstract value is the result of some expression.
     /// The source location of that expression is stored in provenance.
@@ -54,6 +56,26 @@ pub const TRUE: AbstractValue = AbstractValue {
     provenance: Vec::new(),
     value: abstract_domains::TRUE,
 };
+
+impl Debug for AbstractValue {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        self.value.fmt(f)
+    }
+}
+
+impl Eq for AbstractValue {}
+
+impl PartialEq for AbstractValue {
+    fn eq(&self, other: &AbstractValue) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+impl Hash for AbstractValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state)
+    }
+}
 
 impl From<ConstantValue> for AbstractValue {
     fn from(cv: ConstantValue) -> AbstractValue {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -7,8 +7,9 @@ use abstract_value::{self, AbstractValue, Path};
 use rpds::HashTrieMap;
 use rustc::mir::BasicBlock;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter, Result};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Environment {
     /// The disjunction of all the exit conditions from the predecessors of this block.
     pub entry_condition: AbstractValue,
@@ -26,6 +27,12 @@ impl Environment {
             exit_conditions: HashMap::default(),
             value_map: HashTrieMap::default(),
         }
+    }
+}
+
+impl Debug for Environment {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        self.value_map.fmt(f)
     }
 }
 


### PR DESCRIPTION
## Description

Add special case code to ExpressionDomain operations to deal better with Top and Bottom.
Fix an oopsie in the "x is a subset of (condition ? consequent : alternate) x is a subset of both consequent and alternate." case.
Add == as an explicit case for ExpressionDomain::subset.
Customize various debug value formatters to make debug logs less verbose.
Remember the input state of a block after computing it from its predecessors.
Allow a qualified path to be a prefix of another qualified path.
Add some more debug log statements.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Existing test suffice. It would be nice if they actually failed, but were not quite there yet.
This PR started out as "Remember the input state of a block after computing it from its predecessors." because a future PR has a test that whose debug log is not as expected without it. The other changes were necessary to make the existing tests pass, given this fix, which enriches the state tracking during the fixed point computation.