### PR TITLE
Give diagnostic if control might reach a panic.

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -119,6 +119,15 @@ impl AbstractValue {
         self.value.as_bool_if_known()
     }
 
+    /// If the concrete Boolean value of this abstract value is known, return it as a UI28 constant,
+    /// otherwise return None.
+    pub fn as_int_if_known(&self) -> Option<AbstractValue> {
+        match self.as_bool_if_known() {
+            Some(b) => Some(ConstantValue::U128(b as u128).into()),
+            None => None,
+        }
+    }
+
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "equals" to each element of the cross product of the concrete
     /// values or self and other.

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -41,10 +41,10 @@ impl Environment {
     /// Returns an environment that has a path for every parameter of the given function,
     /// initialized with abstract_values::Top
     pub fn with_parameters(num_args: usize) -> Environment {
-        let value_map = HashTrieMap::default();
+        let mut value_map = HashTrieMap::default();
         for i in 1..=num_args {
             let par_i = Path::LocalVariable { ordinal: i };
-            value_map.insert(par_i, abstract_value::TOP);
+            value_map = value_map.insert(par_i, abstract_value::TOP);
         }
         Environment {
             value_map,

--- a/tests/run-pass/false_assertion.rs
+++ b/tests/run-pass/false_assertion.rs
@@ -4,10 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that calls Visitor::visit_abort
+// A test that uses a false assertion
 
-use std::{panic};
-
-pub extern "C" fn panic_in_ffi() {
-    panic!("Test");  //~ Execution might panic
+pub fn test_assert() {
+    let i = 1;
+    debug_assert!(i == 2);  //~ Execution might panic
 }

--- a/tests/run-pass/true_assertion.rs
+++ b/tests/run-pass/true_assertion.rs
@@ -4,10 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that calls Visitor::visit_abort
+// A test that uses a true assertion
 
-use std::{panic};
-
-pub extern "C" fn panic_in_ffi() {
-    panic!("Test");  //~ Execution might panic
+pub fn test_assert() {
+    let i = 1;
+    debug_assert!(i == 1);
 }


### PR DESCRIPTION
## Description

We now give a diagnostic if a call to std::panics::begin_panic can possibly be reached. This, of course, results in a lot of false positives right now, but it also allows us to write test cases that will fail if state transfers did not happen as expected, or if expression simplification does the wrong thing.

Even for the two relative trivial test cases that are included with this PR, a number of bugs had to be fixed to get them to pass.

One class of such bugs is treating the value map of an environment as a mutable map, rather than a functional map.

I also had to add some new features, such as:
- Checking that a basic block is reachable before analyzing it for errors.
- Converting switch discriminants to integers so that constant folding works.
- Supporting moving and copying non structured values.
-  Implementing visit_copy and visit_move for the simple case.
- Canonicalizing paths by rewriting deref(ref path) as just path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage

## How Has This Been Tested?

Added test cases.

