### PR TITLE
Implement support for aggregates (array literals).

### DIFF
--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -230,13 +230,21 @@ pub enum ExpressionDomain {
 impl AbstractDomain for ExpressionDomain {
     /// Returns an expression that is "self && other".
     fn and(&self, other: &Self) -> Self {
-        if self.as_bool_if_known().unwrap_or(false) {
-            if other.as_bool_if_known().unwrap_or(false) {
+        let self_bool = self.as_bool_if_known();
+        if let Some(false) = self_bool {
+            return ExpressionDomain::CompileTimeConstant(ConstantValue::False);
+        };
+        let other_bool = other.as_bool_if_known();
+        if let Some(false) = other_bool {
+            return ExpressionDomain::CompileTimeConstant(ConstantValue::False);
+        };
+        if self_bool.unwrap_or(false) {
+            if other_bool.unwrap_or(false) {
                 ExpressionDomain::CompileTimeConstant(ConstantValue::True)
             } else {
                 other.clone()
             }
-        } else if other.as_bool_if_known().unwrap_or(false)
+        } else if other_bool.unwrap_or(false)
             || self.is_top()
             || self.is_bottom() && other.is_bottom()
         {

--- a/tests/run-pass/array_literal.rs
+++ b/tests/run-pass/array_literal.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls visit_aggregate
+
+pub fn main() {
+    let x = [1, 2];
+    debug_assert!(x[0] == 1);
+    debug_assert!(x[1] == 2);
+}


### PR DESCRIPTION
## Description

This implements state tracking for array literals. It also enhances ExpressionDomain::and to result in false for the "top && false" case.

Related to #28

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Added a test case that constructs an array via a literal and then asserts that the two elements have the expected values.
