### PR TITLE
Implement enum discriminant tracking.

### DIFF
--- a/tests/run-pass/array_index.rs
+++ b/tests/run-pass/array_index.rs
@@ -9,4 +9,5 @@
 
 pub fn foo(arr: &mut [i32], i: usize) {
     arr[i] = 123;
+    debug_assert!(arr[i] == 123);
 }

--- a/tests/run-pass/box_struct.rs
+++ b/tests/run-pass/box_struct.rs
@@ -10,5 +10,7 @@
 pub struct Foo { pub x: i32, pub y: i64 }
 pub fn f() -> Box<Foo> {
     let foo = Foo { x: 1, y: 1111111111111111111 };
+    debug_assert!(foo.x == 1);
+    debug_assert!(foo.y == 1111111111111111111);
     box foo
 }

--- a/tests/run-pass/enum_assign.rs
+++ b/tests/run-pass/enum_assign.rs
@@ -11,6 +11,10 @@ pub enum Foo {
     Bar2(i32),
 }
 
-pub fn g() -> Foo {
-    Foo::Bar1(2)
+pub fn main() {
+    let foo = Foo::Bar1(2);
+    match foo {
+        Foo::Bar1(x) => { debug_assert!(x == 2); }
+        _ => unreachable!()
+    }
 }


### PR DESCRIPTION
## Description

Track the state of enum discriminants in the environment.
While I'm at it, also fix the integration test runner to gracefully handle individual test failures, report the names of the failing tests and to actually cause cargo test to report a test failure.

Also beefed up two unrelated test cases to use debug_assert to verify state tracking.

Related to #28

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage

## How Has This Been Tested?

Beefed up enum_assign.rs with assertions.

