### PR TITLE
Use lookup_path_and_refine_result when moving/copying primitive values.

### DIFF
--- a/tests/run-pass/field_assign.rs
+++ b/tests/run-pass/field_assign.rs
@@ -12,4 +12,5 @@ pub struct Test {
 
 pub fn foo(t: &mut Test) {
     t.field = 123;
+    debug_assert!(t.field == 123);
 }

--- a/tests/run-pass/func_call.rs
+++ b/tests/run-pass/func_call.rs
@@ -8,5 +8,5 @@
 
 fn foo() -> i32 { 123 }
 pub fn main() {
-    let _x = foo();
+    debug_assert!(foo() == 123);
 }

--- a/tests/run-pass/numeric_constants.rs
+++ b/tests/run-pass/numeric_constants.rs
@@ -22,3 +22,22 @@ pub static M: i128 = -13;
 pub static N: u128 = 14;
 pub static O:f32 = 15.6;
 pub static P:f64 = 15.6666666666666666666666;
+
+pub fn main() {
+    debug_assert!(A == -1);
+    debug_assert!(B == 2);
+    debug_assert!(C == -3);
+    debug_assert!(D == 4);
+    debug_assert!(E == -5);
+    debug_assert!(F == 6);
+    debug_assert!(G == -7);
+    debug_assert!(H == 8);
+    debug_assert!(I == -9);
+    debug_assert!(J == 10);
+    debug_assert!(K == -11);
+    debug_assert!(L == 12);
+    debug_assert!(M == -13);
+    debug_assert!(N == 14);
+    debug_assert!(O == 15.6);
+    debug_assert!(P == 15.6666666666666666666666);
+}


### PR DESCRIPTION
## Description

Beefing up the numeric_constants test case revealed that moving/copying them assumed that statics will be stored in the environment. Since this is not the case, I've tweaked the relevant code by using lookup_path_and_refine_result. Using the latter revealed some bugs in its design, which I've also fixed.

Related to #28

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage

## How Has This Been Tested?
Beefed up numeric_constants, as well as two other tests just because.
