### PR TITLE
Compute promoted constants.

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -300,7 +300,8 @@ pub enum Path {
         summary_cache_key: String,
     },
 
-    /// The ordinal is an index into a crate level constant table.
+    /// The ordinal is an index into a method level table of MIR bodies.
+    /// This should not be serialized into a summary since it is function private local state.
     PromotedConstant { ordinal: usize },
 
     /// The qualifier denotes some reference, struct, or collection.

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -252,10 +252,10 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
     fn promote_constants(&mut self, mut state_with_parameters: Environment) -> Environment {
         let saved_mir = self.mir;
         let result_root = Path::LocalVariable { ordinal: 0 };
-        let mut ordinal = 0;
-        for constant_mir in self.mir.promoted.iter() {
+        for (ordinal, constant_mir) in self.mir.promoted.iter().enumerate() {
             self.mir = constant_mir;
             self.visit_body();
+
             let promoted_root = Path::PromotedConstant { ordinal };
             let value = self.lookup_path_and_refine_result(result_root.clone());
             state_with_parameters.update_value_at(promoted_root.clone(), value);
@@ -268,8 +268,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
                 let promoted_path = Self::replace_root(&path, &result_root, promoted_root.clone());
                 state_with_parameters.update_value_at(promoted_path, value.clone());
             }
+
             self.reset_visitor_state();
-            ordinal += 1;
         }
         self.mir = saved_mir;
         state_with_parameters

--- a/tests/run-pass/promoted_constant.rs
+++ b/tests/run-pass/promoted_constant.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that promotes a constant to static memory by taking its address.
+
+pub fn main() {
+    let x = &1;
+    let y = *x;
+    debug_assert_eq!(y, 1);
+}


### PR DESCRIPTION
## Description

Literal values that have their addresses taken need to be stored somewhere. For some reason or another, MIR models this by putting the code for initializing the storage in separate MIR bodies that are stored in an array that hangs of the main MIR body of a function.

For the purposes of the abstract interpreter, we'll inline the initialization code at the start of a function, by recursively invoking visit_body, taking care to reset the visitor state after each call.

Fixes #34

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

New test case.
