### PR TITLE
Introduce ExpressionDomain::Variable.

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -37,24 +37,6 @@ impl Debug for Environment {
     }
 }
 
-/// Constructor
-impl Environment {
-    /// Returns an environment that has a path for every parameter of the given function,
-    /// initialized with abstract_values::Top
-    pub fn with_parameters(num_args: usize) -> Environment {
-        let mut value_map = HashTrieMap::default();
-        for i in 1..=num_args {
-            let par_i = Path::LocalVariable { ordinal: i };
-            value_map = value_map.insert(par_i, abstract_value::TOP);
-        }
-        Environment {
-            value_map,
-            entry_condition: abstract_value::TRUE,
-            exit_conditions: HashMap::default(),
-        }
-    }
-}
-
 /// Methods
 impl Environment {
     /// Returns a reference to the value associated with the given path, if there is one.

--- a/tests/run-pass/x_equals_x.rs
+++ b/tests/run-pass/x_equals_x.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks if expressions like x == x can be simplified.
+
+pub fn main() {
+    foo(1, 2.0);
+}
+
+fn foo (x: i32, y: f32) {
+    if x == x {
+        debug_assert!(true);
+    } else {
+        debug_assert!(false);
+    }
+    if y == y {
+        debug_assert!(true);
+    } else {
+        debug_assert!(false);  //~ Execution might panic.
+    }
+}


### PR DESCRIPTION
## Description

When the value of a parameter is not known it is not all that useful to just set it to Top, since that prevents us from simplifying trivial expressions like x == x and more complicated expressions like (x == 0) || !(x == 0) that arise at join points and which we very much want to simplify to true.

To solve this, the expression domain now has a value for "the value of local n". Since this is not Top, we can conclude that two such values with the same n are in fact equal. Of course, this may not be true if the local contains a floating point NaN value, so the value additionally tracks the type of the local to allow us to special case this.

Fixes #60 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

New test case.