### PR TITLE
Use the message parameter of the assertion statement in diagnostic

### DIFF
--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -757,10 +757,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
                 // Otherwise this diagnostic is too noisy, particular when yield enters the picture.
                 if expected != cond_val.as_bool_if_known().unwrap_or(expected) {
                     let span = self.current_span;
-                    let mut err = self.session.struct_span_warn(
-                        span,
-                        "Control might reach this expression with operand values that cause a panic.",
-                    );
+                    let mut err = self.session.struct_span_warn(span, msg.description());
                     (self.emit_diagnostic)(&mut err, &mut self.buffered_diagnostics);
                 }
             }

--- a/tests/run-pass/array_literal_out_of_bounds.rs
+++ b/tests/run-pass/array_literal_out_of_bounds.rs
@@ -8,5 +8,6 @@
 
 pub fn main() {
     let x = [1, 2];
-    let _y = x[2]; //~ Control might reach this expression with operand values that cause a panic.
+    let _y = x[2]; //~ array index out of bounds
 }
+

--- a/tests/run-pass/binary_overflow.rs
+++ b/tests/run-pass/binary_overflow.rs
@@ -8,80 +8,81 @@
 
 pub fn tu8_add() -> u8 {
     let a: u8 = 255;
-    a + 1 //~ Control might reach this expression with operand values that cause a panic.
+    a + 1 //~ attempt to add with overflow
 }
 
 pub fn tu8_div() -> u8 {
     let a: u8 = 255;
     let b: u8 = 0;
-    a / b    //~ Control might reach this expression with operand values that cause a panic.
+    a / b    //~ attempt to divide by zero
+
 }
 
 pub fn tu8_mul() -> u8 {
     let a: u8 = 255;
-    a * 2 //~ Control might reach this expression with operand values that cause a panic.
+    a * 2 //~ attempt to multiply with overflow
 }
 
 pub fn tu8_rem() -> u8 {
     let a: u8 = 255;
     let b: u8 = 0;
-    a % b    //~ Control might reach this expression with operand values that cause a panic.
+    a % b    //~ attempt to calculate the remainder with a divisor of zero
 }
 
 pub fn tu8_shl() -> u8 {
     let a: u8 = 255;
     let b = 8;
-    a << b //~ Control might reach this expression with operand values that cause a panic.
+    a << b //~ attempt to shift left with overflow
 }
 
 pub fn tu8_shr() -> u8 {
     let a: u8 = 255;
     let b = 8;
-    a >> b //~ Control might reach this expression with operand values that cause a panic.
+    a >> b //~ attempt to shift right with overflow
 }
 
 pub fn ti8_add() -> i8 {
     let a: i8 = 127;
-    a + 1 //~ Control might reach this expression with operand values that cause a panic.
+    a + 1 //~ attempt to add with overflow
 }
 
 pub fn ti8_div0() -> i8 {
     let a: i8 = 127;
     let b: i8 = 0;
-    a / b    //~ Control might reach this expression with operand values that cause a panic.
+    a / b    //~ attempt to divide by zero
 }
 
 pub fn ti8_div_m1() -> i8 {
     let a: i8 = -128;
     let b: i8 = -1;
-    a / b    //~ Control might reach this expression with operand values that cause a panic.
+    a / b    //~ attempt to divide with overflow
 }
 
 pub fn ti8_mul() -> i8 {
     let a: i8 = 127;
-    a * 2 //~ Control might reach this expression with operand values that cause a panic.
+    a * 2 //~ attempt to multiply with overflow
 }
 
 pub fn ti8_rem() -> i8 {
     let a: i8 = 127;
     let b: i8 = 0;
-    a % b    //~ Control might reach this expression with operand values that cause a panic.
+    a % b    //~ attempt to calculate the remainder with a divisor of zero
 }
 
 pub fn ti8_rem_m1() -> i8 {
     let a: i8 = -128;
     let b: i8 = -1;
-    a % b    //~ Control might reach this expression with operand values that cause a panic.
+    a % b    //~ attempt to calculate the remainder with overflow
 }
 
 pub fn ti8_shl() -> i8 {
     let a: i8 = 127;
     let b = 8;
-    a << b //~ Control might reach this expression with operand values that cause a panic.
+    a << b //~ attempt to shift left with overflow
 }
 
 pub fn ti8_shr() -> i8 {
     let a: i8 = 127;
     let b = 8;
-    a >> b //~ Control might reach this expression with operand values that cause a panic.
+    a >> b //~ attempt to shift right with overflow
 }

--- a/tests/run-pass/crate_traversal.rs
+++ b/tests/run-pass/crate_traversal.rs
@@ -151,7 +151,7 @@ fn test11(arr: &[String]){
 
 fn test12() {
     let x = 200u8 * 4;
-} //~ Control might reach this expression with operand values that cause a panic.
+} //~ attempt to multiply with overflow
 
 fn test13(i: i64) {
     let x = box -i;


### PR DESCRIPTION
## Description

The MIR assertion statement has a parameter with a customized description of the issue that could cause the assertion to fail (panic). Rather than give a generic message about the assertion failing, give the message that would appear if the code ran.

At the moment, we only give messages when MIRAI can prove that there is a feasible path that reaches the assertion when it fails. Once paths that may not be feasible is included for the sake of being sound, the message will have to be qualified for these paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Updated existing tests to expected new messages.

