### PR TITLE
Implement refine_parameters

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -465,9 +465,11 @@ impl AbstractValue {
     /// Returns a value that is simplified (refined) by replacing parameter values
     /// with their corresponding argument values. If no refinement is possible
     /// the result is simply a clone of this value.
-    pub fn refine_parameters(&self, _arguments: &[AbstractValue]) -> AbstractValue {
-        //todo: #60 actually refine this value when values identify parameters.
-        self.clone()
+    pub fn refine_parameters(&self, arguments: &[AbstractValue]) -> AbstractValue {
+        AbstractValue {
+            provenance: self.provenance.clone(),
+            value: self.value.refine_parameters(arguments),
+        }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the

--- a/tests/run-pass/func_call.rs
+++ b/tests/run-pass/func_call.rs
@@ -7,6 +7,8 @@
 // A test that uses a function summary.
 
 fn foo() -> i32 { 123 }
+fn bar(x: f32) -> f32 { x + 1.0 }
 pub fn main() {
     debug_assert!(foo() == 123);
+    debug_assert!(bar(1.0) == 2.0);
 }

--- a/tests/run-pass/simplify.rs
+++ b/tests/run-pass/simplify.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks various simplifications
+
+pub fn main() {
+    foo(true);
+}
+
+fn foo(b: bool) {
+    debug_assert!(b || !b);
+    debug_assert!(!b || b);
+}

--- a/tests/run-pass/weak_update_heap.rs
+++ b/tests/run-pass/weak_update_heap.rs
@@ -23,9 +23,13 @@ fn do_join(cond: bool) {
         c.f = 3;
         debug_assert!(c.f == 3);
     }
-//    todo: #32 enable this when the simplifier gets better
+//    todo: enable the next two asserts when the fixed point logic gets better
+//    (if there are two asserts the second shares the unwind block of the first and does
+//    a backwards branch to it, leading to a fixed point loop that widens and thus loses
+//    precision).
 //    debug_assert!(a.f == if cond { 3 } else { 1 });
 //    debug_assert!(b.f == if cond { 2 } else { 3 });
+//    todo: #32 enable this when the simplifier gets better
 //    debug_assert!(if cond { a.f == 3 } else { b.f == 3 });
 //    debug_assert!(if !cond { a.f == 1 } else { b.f == 2 });
 }

--- a/tests/run-pass/weak_update_local.rs
+++ b/tests/run-pass/weak_update_local.rs
@@ -18,9 +18,9 @@ fn do_join(cond: bool) {
         (&mut c)[0] = 3;
         debug_assert!(c[0] == 3);
     }
+    debug_assert!(a[0] == if cond { 3 } else { 1 });
+    debug_assert!(b[0] == if cond { 2 } else { 3 });
 //    todo: #32 enable this when the simplifier gets better
-//    debug_assert!(a[0] == if cond { 3 } else { 1 });
-//    debug_assert!(b[0] == if cond { 2 } else { 3 });
 //    debug_assert!(if cond { a[0] == 3 } else { b[0] == 3 });
 //    debug_assert!(if !cond { a[0] == 1 } else { b[0] == 2 });
 }


### PR DESCRIPTION
## Description

Specialize function summaries to particular call sites by walking the expressions in the (copy of the) summary and replacing all occurrences of parameter references with the actual argument values at the call site.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Modified an existing test case with an expression that has a parameter reference. Getting full code coverage would mean writing every possible kind of expression, so I'm putting that off for now.
