### PR TITLE
Add some basic simplifications

### DIFF
--- a/tests/run-pass/simplify.rs
+++ b/tests/run-pass/simplify.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks various simplifications
+
+pub fn main() {
+    foo(true);
+}
+
+fn foo(b: bool) {
+    debug_assert!(b || !b);
+    debug_assert!(!b || b);
+}

--- a/tests/run-pass/weak_update_heap.rs
+++ b/tests/run-pass/weak_update_heap.rs
@@ -23,9 +23,13 @@ fn do_join(cond: bool) {
         c.f = 3;
         debug_assert!(c.f == 3);
     }
-//    todo: #32 enable this when the simplifier gets better
+//    todo: enable the next two asserts when the fixed point logic gets better
+//    (if there are two asserts the second shares the unwind block of the first and does
+//    a backwards branch to it, leading to a fixed point loop that widens and thus loses
+//    precision).
 //    debug_assert!(a.f == if cond { 3 } else { 1 });
 //    debug_assert!(b.f == if cond { 2 } else { 3 });
+//    todo: #32 enable this when the simplifier gets better
 //    debug_assert!(if cond { a.f == 3 } else { b.f == 3 });
 //    debug_assert!(if !cond { a.f == 1 } else { b.f == 2 });
 }

--- a/tests/run-pass/weak_update_local.rs
+++ b/tests/run-pass/weak_update_local.rs
@@ -18,9 +18,9 @@ fn do_join(cond: bool) {
         (&mut c)[0] = 3;
         debug_assert!(c[0] == 3);
     }
+    debug_assert!(a[0] == if cond { 3 } else { 1 });
+    debug_assert!(b[0] == if cond { 2 } else { 3 });
 //    todo: #32 enable this when the simplifier gets better
-//    debug_assert!(a[0] == if cond { 3 } else { 1 });
-//    debug_assert!(b[0] == if cond { 2 } else { 3 });
 //    debug_assert!(if cond { a[0] == 3 } else { b[0] == 3 });
 //    debug_assert!(if !cond { a[0] == 1 } else { b[0] == 2 });
 }


### PR DESCRIPTION
## Description

Expand the expression factories to do some more basic simplifications. These simplifications are effective for the expressions that arise in the entry conditions of basic blocks because of the control flow that Rustc generates for short circuit expressions, as well as the expressions that result at the join points of if statements and switch statements.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Uncommented some short circuit expressions in assert statements.
