### PR TITLE
Implement refinement with the path condition.

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -455,13 +455,12 @@ impl AbstractValue {
     /// (conditions known to be true in the current context). If no refinement is possible
     /// the result is simply a clone of this value, but with its provenance updated by
     /// pre-pending the given span.
-    pub fn refine_with(&self, _path_condtion: &AbstractValue, provenance: Span) -> AbstractValue {
-        //todo: #32 simplify this value using the path condition
+    pub fn refine_with(&self, path_condition: &AbstractValue, provenance: Span) -> AbstractValue {
         let mut provenance = vec![provenance];
         provenance.extend_from_slice(&self.provenance);
         AbstractValue {
             provenance,
-            domain: self.domain.clone(),
+            domain: self.domain.refine_with(&path_condition.domain),
         }
     }
 

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -947,7 +947,6 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
             value_map = value_map.insert(qualified_path, value.with_provenance(self.current_span));
         }
         let value = self.lookup_path_and_refine_result(rpath.clone());
-        debug!("copying {:?} to {:?}", value, target_path);
         if move_elements {
             debug!("moving {:?} to {:?}", value, target_path);
             value_map = value_map.remove(&rpath);

--- a/tests/run-pass/weak_update_local.rs
+++ b/tests/run-pass/weak_update_local.rs
@@ -20,7 +20,6 @@ fn do_join(cond: bool) {
     }
     debug_assert!(a[0] == if cond { 3 } else { 1 });
     debug_assert!(b[0] == if cond { 2 } else { 3 });
-//    todo: #32 enable this when the simplifier gets better
-//    debug_assert!(if cond { a[0] == 3 } else { b[0] == 3 });
-//    debug_assert!(if !cond { a[0] == 1 } else { b[0] == 2 });
+    debug_assert!(if cond { a[0] == 3 } else { b[0] == 3 });
+    debug_assert!(if !cond { a[0] == 1 } else { b[0] == 2 });
 }


### PR DESCRIPTION
## Description

Abstract values are now refined using the current path condition. This involves a recursive walk over the structure of the value, refining each component as appropriate and then simplifying the whole.

The non trivial part of this is going to be the implies and implies_not function. Right now they do very little. In future pull requests many more rules will be added and eventually, conditions that cannot be solved with simple rewrite rules will be shipped off to an SMT solver (when high precision is required).

That said, even the dead simple versions that are provided in this PR are actually quite useful in practice.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Uncommented two assertions in weak_update_local.rs that pull in a whole lot of complexity. More coverage will come in the future as more complex things get tested and many more assertions are written.
