### PR TITLE
Infer preconditions

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -170,7 +170,7 @@ impl Environment {
                     value_map = value_map.insert(p, join_or_widen(&val1, &val2, &join_condition));
                 }
                 None => {
-                    debug_assert!(!val1.is_bottom());
+                    assert!(!val1.is_bottom());
                     let val = join_or_widen(&val1, &abstract_value::BOTTOM, &join_condition);
                     if !val.is_bottom() {
                         value_map = value_map.insert(p, val);
@@ -180,7 +180,7 @@ impl Environment {
         }
         for (path, val2) in value_map2.iter() {
             if !value_map1.contains_key(path) {
-                debug_assert!(!val2.is_bottom());
+                assert!(!val2.is_bottom());
                 let p = path.clone();
                 let val = join_or_widen(&abstract_value::BOTTOM, &val2, &join_condition);
                 if !val.is_bottom() {
@@ -213,7 +213,7 @@ impl Environment {
                     }
                 }
                 None => {
-                    debug_assert!(!val1.is_bottom());
+                    assert!(!val1.is_bottom());
                     return false;
                 }
             }

--- a/tests/run-pass/abort.rs
+++ b/tests/run-pass/abort.rs
@@ -9,5 +9,5 @@
 use std::{panic};
 
 pub extern "C" fn panic_in_ffi() {
-    panic!("Test");  //~ Execution might panic.
+    panic!("Test");  //~ Test
 }

--- a/tests/run-pass/false_assertion.rs
+++ b/tests/run-pass/false_assertion.rs
@@ -8,5 +8,5 @@
 
 pub fn test_assert() {
     let i = 1;
-    debug_assert!(i == 2);  //~ Execution might panic.
+    debug_assert!(i == 2);  //~ could not prove assertion: i == 2
 }

--- a/tests/run-pass/maybe_unreachable.rs
+++ b/tests/run-pass/maybe_unreachable.rs
@@ -14,7 +14,7 @@ use std::intrinsics;
 fn foo(flag: bool) {
     if flag {
         unsafe {
-            intrinsics::unreachable(); //~ Control might reach a call to std::intrinsics::unreachable.
+            intrinsics::unreachable();
         }
     }
 }

--- a/tests/run-pass/unreachable.rs
+++ b/tests/run-pass/unreachable.rs
@@ -13,6 +13,6 @@ use std::intrinsics;
 
 fn foo() {
     unsafe {
-        intrinsics::unreachable(); //~ Control might reach a call to std::intrinsics::unreachable.
+        intrinsics::unreachable(); //~ Control reaches a call to std::intrinsics::unreachable.
     }
 }

--- a/tests/run-pass/x_equals_x.rs
+++ b/tests/run-pass/x_equals_x.rs
@@ -19,6 +19,6 @@ fn foo (x: i32, y: f32) {
     if y == y {
         debug_assert!(true);
     } else {
-        debug_assert!(false);  //~ Execution might panic.
+        debug_assert!(false);  //~ could not prove assertion: false
     }
 }


### PR DESCRIPTION
## Description

A false assertion or panic that may be reachable in a function is not necessarily a bug if the function requires its callers to supply parameter values that will ensure that such conditions never arise.

Consequently, instead of reporting such issues as potential errors in the function, the path conditions that could lead to the error conditions are inverted and added to as inferred preconditions of the function.

In a future PR the call sites will be enhanced to check the preconditions of the called functions.

Note that this scheme of doing things breaks down for functions called indirectly via traits and for public functions that are called by code that is not being analyzed. Such functions will need programmer supplied preconditions that are enforced at runtime. Al that will have to wait a bit longer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Modified some existing tests. I also run Mirai on itself on my development machine. We no longer do that on Travis since it uses too much memory.

