### PR TITLE
Use Expression::Variable for qualified paths

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -658,6 +658,7 @@ pub enum Path {
     /// The qualifier denotes some reference, struct, or collection.
     /// The selector denotes a de-referenced item, field, or element, or slice.
     QualifiedPath {
+        length: usize,
         qualifier: Box<Path>,
         selector: Box<PathSelector>,
     },
@@ -674,12 +675,21 @@ impl Path {
         }
     }
 
+    // Returns the length of the path.
+    pub fn path_length(&self) -> usize {
+        match self {
+            Path::QualifiedPath { length, .. } => *length,
+            _ => 1,
+        }
+    }
+
     /// Returns a copy path with the root replaced by new_root.
     pub fn replace_root(&self, old_root: &Path, new_root: Path) -> Path {
         match self {
             Path::QualifiedPath {
                 qualifier,
                 selector,
+                ..
             } => {
                 let new_qualifier = if **qualifier == *old_root {
                     new_root
@@ -687,6 +697,7 @@ impl Path {
                     qualifier.replace_root(old_root, new_root)
                 };
                 Path::QualifiedPath {
+                    length: new_qualifier.path_length() + 1,
                     qualifier: box new_qualifier,
                     selector: selector.clone(),
                 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -121,14 +121,17 @@ impl Environment {
             Path::QualifiedPath {
                 ref qualifier,
                 ref selector,
+                ..
             } => {
                 if let Some((join_condition, true_path, false_path)) = self.try_to_split(qualifier)
                 {
                     let true_path = Path::QualifiedPath {
+                        length: true_path.path_length() + 1,
                         qualifier: box true_path,
                         selector: selector.clone(),
                     };
                     let false_path = Path::QualifiedPath {
+                        length: false_path.path_length() + 1,
                         qualifier: box false_path,
                         selector: selector.clone(),
                     };

--- a/src/k_limits.rs
+++ b/src/k_limits.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Somewhat arbitrary constants used to limit things in the abstract interpreter that may
+// take too long or use too much memory.
+
+/// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
+pub const MAX_PATH_LENGTH: usize = 10;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod callbacks;
 pub mod constant_domain;
 pub mod environment;
 pub mod expression;
+pub mod k_limits;
 pub mod summaries;
 pub mod utils;
 pub mod visitors;

--- a/tests/run-pass/func_call.rs
+++ b/tests/run-pass/func_call.rs
@@ -6,9 +6,15 @@
 
 // A test that uses a function summary.
 
+struct Foo { x: i32 }
+
 fn foo() -> i32 { 123 }
 fn bar(x: f32) -> f32 { x + 1.0 }
+fn bas(foo: &mut Foo) { foo.x = 456; }
 pub fn main() {
     debug_assert!(foo() == 123);
     debug_assert!(bar(1.0) == 2.0);
+    let mut f = Foo { x: 123 };
+    bas(&mut f);
+    debug_assert!(f.x == 456);
 }


### PR DESCRIPTION
## Description

When looking up a qualified path that is rooted in a parameter (and thus has an unknown value to the interpreter) produce a Variable(path) abstract value, rather than just Top. This was already done for unqualified paths. Doing so for qualified paths is a bit more painful because much more work is needed to obtain the type of value that a path points to. The type is currently important only to prevent folding equality operations for paths that may point to floating point values that may be NaN. In the future it may also be useful for generating conditions for an SMT solver.

The is currently no support for widening paths during the fixed point loop, so a k-limit is used to return Top at some point, which ensures fixed point loop termination. Eventually this limit should no longer be necessary.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Added a new test case. Also ran Mirai on itself, which uncovered the fix point loop divergence issue. Testing that will have to wait until proper widening is tackled.


