### PR TITLE
Check preconditions

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -5,6 +5,7 @@
 //
 use abstract_domains::{self, AbstractDomain};
 use constant_domain::ConstantDomain;
+use environment::Environment;
 use expression::{Expression, ExpressionType};
 use rustc::hir::def_id::DefId;
 use std::fmt::{Debug, Formatter, Result};
@@ -461,6 +462,17 @@ impl AbstractValue {
         AbstractValue {
             provenance,
             domain: self.domain.refine_with(&path_condition.domain),
+        }
+    }
+
+    /// Returns a value that is simplified (refined) by replacing values with Variable(path) expressions
+    /// with the value at that path (if there is one). If no refinement is possible
+    /// the result is simply a clone of this value. This refinement only makes sense
+    /// following a call to refine_parameters.
+    pub fn refine_paths(&self, environment: &mut Environment) -> AbstractValue {
+        AbstractValue {
+            provenance: self.provenance.clone(),
+            domain: self.domain.refine_paths(environment),
         }
     }
 

--- a/src/summaries.rs
+++ b/src/summaries.rs
@@ -44,7 +44,9 @@ pub struct Summary {
     // under the current path condition. Any values that do not simplify to true will require the
     // caller to either generate an error message or to add a precondition to its own summary that
     // will be sufficient to ensure that all of the preconditions in this summary are met.
-    pub preconditions: Vec<AbstractValue>,
+    // The string value bundled with the condition is the message that details what would go
+    // wrong at runtime if the precondition is not satisfied by the caller.
+    pub preconditions: Vec<(AbstractValue, String)>,
 
     // If the function returns a value, this summarizes what is known statically of the return value.
     // Callers should substitute parameter values with argument values and simplify the result
@@ -70,7 +72,7 @@ pub struct Summary {
     // Callers should substitute parameter values with argument values and simplify the result
     // under the current path condition. If the simplified value is statically known to be true
     // then the normal destination of the call should be treated as unreachable.
-    pub unwind_condition: Vec<AbstractValue>,
+    pub unwind_condition: Option<AbstractValue>,
 
     // Modifications the function makes to mutable state external to the function.
     // Every path will be rooted in a static or in a mutable parameter.
@@ -86,9 +88,9 @@ pub struct Summary {
 pub fn summarize(
     argument_count: usize,
     exit_environment: &Environment,
-    preconditions: &[AbstractValue],
+    preconditions: &[(AbstractValue, String)],
     post_conditions: &[AbstractValue],
-    unwind_condition: &[AbstractValue],
+    unwind_condition: Option<AbstractValue>,
     unwind_environment: &Environment,
 ) -> Summary {
     let result = exit_environment.value_at(&Path::LocalVariable { ordinal: 0 });
@@ -99,7 +101,7 @@ pub fn summarize(
         result: result.cloned(),
         side_effects,
         post_conditions: post_conditions.to_owned(),
-        unwind_condition: unwind_condition.to_owned(),
+        unwind_condition,
         unwind_side_effects,
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -14,6 +14,7 @@
 // While pretty bad, it is a lot less bad than having to write our own compiler, so here goes.
 #![feature(rustc_private)]
 #![feature(box_syntax)]
+#![feature(vec_remove_item)]
 
 extern crate mirai;
 extern crate rustc_data_structures;
@@ -160,9 +161,7 @@ impl ExpectedErrors {
 
     /// Removes the first element of self.messages and checks if it matches msg.
     fn remove_message(&mut self, msg: &str) {
-        if self.messages.len() > 0 && msg.eq(&self.messages[0]) {
-            self.messages.remove(0);
-        } else {
+        if self.messages.remove_item(&String::from(msg)).is_none() {
             panic!("Unexpected error: {} Expected: {:?}", msg, self.messages);
         }
     }

--- a/tests/run-pass/precondition.rs
+++ b/tests/run-pass/precondition.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that infers a precondition and report a failure to satisfy it.
+
+fn foo(arr: &mut [i32], i: usize) {
+    arr[i] = 12; //~ related location
+}
+
+pub fn main() {
+    let mut a = [1, 2];
+    foo(&mut a, 3); //~ array index out of bounds
+}

--- a/tests/validate.sh
+++ b/tests/validate.sh
@@ -3,6 +3,7 @@
 set -e
 # start clean
 cargo clean -p mirai
+rm -rf target/debug/.summary_store.rocksdb
 # Run format checks
 cargo fmt --all
 # Run lint checks


### PR DESCRIPTION
## Description

The crux of this PR is to actually check the inferred preconditions of a function at the point of call. Doing that requires a new kind of refinement operation. It also made visit_call so large that it is now broken up into many helper functions. Reviewing that code caused a new todo and some tweaks.

We now also have the first instance of a diagnostic with related locations. This uncovered a bug in the test runner. Debugging that made the random failures of the test runner more painful, so I looked into that also. That turns out to be a problem of running multiple invocations of LLVM in the same process. The test runner now arranges for the compiler controller to stop the compilation after Mirai has run. So now cargo test works every time again (on the Mac). Yay!!!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Added a new test case. Ran validate.sh, locally.


