### PR TITLE
Complain if a public function possibly generates a panic.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,3 +38,16 @@ pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt) -> bool {
         _ => false,
     }
 }
+
+/// Returns true if the function identified by def_id is a public function.
+pub fn is_public(def_id: DefId, tcx: &TyCtxt) -> bool {
+    let this_crate = tcx.hir().krate();
+    let node_id = tcx.hir().def_index_to_node_id(def_id.index);
+    let items = &this_crate.items;
+    //todo: quite a few functions have bodies with DefIds that do not match an item.
+    // this function needs fixing.
+    match items.get(&node_id) {
+        Some(item) => item.vis.node.is_pub(),
+        None => false,
+    }
+}

--- a/tests/run-pass/array_access_with_unwind.rs
+++ b/tests/run-pass/array_access_with_unwind.rs
@@ -7,8 +7,8 @@
 // A test that needs to do cleanup if an array access is out of bounds.
 
 pub fn foo(arr: &mut [i32], i: usize) -> String {
-    arr[i] = 123;
+    arr[i] = 123; //~ possible array index out of bounds
     let result = String::from("foo");
-    let _e = arr[i];
+    let _e = arr[i]; //~ possible array index out of bounds
     result
 }

--- a/tests/run-pass/array_index.rs
+++ b/tests/run-pass/array_index.rs
@@ -8,6 +8,12 @@
 // and the ProjectionElem::Index case of Visitor::visit_projection_elem.
 
 pub fn foo(arr: &mut [i32], i: usize) {
+    arr[i] = 123; //~ possible array index out of bounds
+    // If we get here i is known to be within bounds, so no warning below.
+    bar(arr, i);
+}
+
+fn bar(arr: &mut [i32], i: usize) {
     arr[i] = 123;
     debug_assert!(arr[i] == 123);
 }


### PR DESCRIPTION
## Description

If a panic happens only if particular parameter values are supplied, it may be an implicit precondition of the function that no such values will be supplied by the caller. Therefore we created inferred preconditions and check the call sites instead. If a call site may violate a precondition, it in turn gets to push an inferred precondition to its caller and so on.

Except, of course, that the buck has to stop somewhere. Since we can't know and check all of the callers of a public function, the buck should stop there and we should warn the author of the function to either explicitly check (and document) the precondition or to fix the public function's code so that its callees' preconditions are satisfied.

That said, the public function will still get the inferred preconditions added to its summary, so that callers' authors will get diagnostics if they call the public function with problem arguments, even if the author of the public function failed to heed our warnings.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Tweaked two test cases. Ran Mirai on Mirai.

