### PR TITLE
Add an interval domain

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -84,9 +84,7 @@ impl From<ConstantDomain> for AbstractValue {
     fn from(cv: ConstantDomain) -> AbstractValue {
         AbstractValue {
             provenance: vec![],
-            domain: AbstractDomain {
-                expression: Expression::CompileTimeConstant(cv),
-            },
+            domain: Expression::CompileTimeConstant(cv).into(),
         }
     }
 }
@@ -95,9 +93,7 @@ impl From<Expression> for AbstractValue {
     fn from(expression_domain: Expression) -> AbstractValue {
         AbstractValue {
             provenance: vec![],
-            domain: AbstractDomain {
-                expression: expression_domain,
-            },
+            domain: expression_domain.into(),
         }
     }
 }
@@ -121,8 +117,8 @@ impl AbstractValue {
     /// values resulting from applying add_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn add_overflows(
-        &self,
-        other: &AbstractValue,
+        &mut self,
+        other: &mut AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -132,7 +128,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.add_overflows(&other.domain, target_type),
+            domain: (&mut self.domain).add_overflows(&mut other.domain, target_type),
         }
     }
 
@@ -263,28 +259,36 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying ">=" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn ge(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn ge(
+        &mut self,
+        other: &mut AbstractValue,
+        expression_provenance: Option<Span>,
+    ) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.ge(&other.domain),
+            domain: self.domain.ge(&mut other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying ">" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn gt(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn gt(
+        &mut self,
+        other: &mut AbstractValue,
+        expression_provenance: Option<Span>,
+    ) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.gt(&other.domain),
+            domain: self.domain.gt(&mut other.domain),
         }
     }
 
@@ -316,28 +320,36 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "<=" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn le(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn le(
+        &mut self,
+        other: &mut AbstractValue,
+        expression_provenance: Option<Span>,
+    ) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.le(&other.domain),
+            domain: self.domain.le(&mut other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "lt" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn lt(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn lt(
+        &mut self,
+        other: &mut AbstractValue,
+        expression_provenance: Option<Span>,
+    ) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.lt(&other.domain),
+            domain: self.domain.lt(&mut other.domain),
         }
     }
 
@@ -359,8 +371,8 @@ impl AbstractValue {
     /// values resulting from applying mul_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn mul_overflows(
-        &self,
-        other: &AbstractValue,
+        &mut self,
+        other: &mut AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -370,7 +382,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.mul_overflows(&other.domain, target_type),
+            domain: self.domain.mul_overflows(&mut other.domain, target_type),
         }
     }
 
@@ -519,7 +531,7 @@ impl AbstractValue {
     /// values or self and other.
     pub fn shl_overflows(
         &self,
-        other: &AbstractValue,
+        other: &mut AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -529,7 +541,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shl_overflows(&other.domain, target_type),
+            domain: self.domain.shl_overflows(&mut other.domain, target_type),
         }
     }
 
@@ -552,7 +564,7 @@ impl AbstractValue {
     /// values or self and other.
     pub fn shr_overflows(
         &self,
-        other: &AbstractValue,
+        other: &mut AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -562,7 +574,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shr_overflows(&other.domain, target_type),
+            domain: self.domain.shr_overflows(&mut other.domain, target_type),
         }
     }
 
@@ -584,8 +596,8 @@ impl AbstractValue {
     /// values resulting from applying sub_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn sub_overflows(
-        &self,
-        other: &AbstractValue,
+        &mut self,
+        other: &mut AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -595,7 +607,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.sub_overflows(&other.domain, target_type),
+            domain: self.domain.sub_overflows(&mut other.domain, target_type),
         }
     }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -84,6 +84,7 @@ impl Environment {
                                         consequent,
                                         alternate,
                                     },
+                                ..
                             },
                         provenance,
                     } = val

--- a/src/interval_domain.rs
+++ b/src/interval_domain.rs
@@ -1,0 +1,253 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+use expression::ExpressionType::{self, *};
+use std::cmp;
+use std::convert::TryFrom;
+
+/// An element of the Interval domain is a range of i128 numbers denoted by a lower bound and
+/// upper bound. A lower bound of std::i128::MIN denotes -infinity and an upper bound of
+/// std::i128::MAX denotes +infinity.
+/// Interval domain elements are constructed on demand from AbstractDomain expressions.
+/// They are most useful for checking if an array index is within bounds.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialOrd, PartialEq, Hash)]
+pub struct IntervalDomain {
+    lower_bound: i128,
+    upper_bound: i128,
+}
+
+pub const BOTTOM: IntervalDomain = IntervalDomain {
+    lower_bound: 1,
+    upper_bound: 0,
+};
+
+pub const TOP: IntervalDomain = IntervalDomain {
+    lower_bound: std::i128::MIN,
+    upper_bound: std::i128::MAX,
+};
+
+impl From<i128> for IntervalDomain {
+    fn from(i: i128) -> IntervalDomain {
+        IntervalDomain {
+            lower_bound: i,
+            upper_bound: i,
+        }
+    }
+}
+
+impl From<u128> for IntervalDomain {
+    fn from(u: u128) -> IntervalDomain {
+        if let Result::Ok(i) = i128::try_from(u) {
+            i.into()
+        } else {
+            IntervalDomain {
+                lower_bound: std::i128::MAX,
+                upper_bound: std::i128::MAX,
+            }
+        }
+    }
+}
+
+impl IntervalDomain {
+    //[x...y] + [a...b] = [x+a...y+b]
+    pub fn add(&self, other: &Self) -> Self {
+        if self.is_bottom() || other.is_bottom() {
+            return BOTTOM.clone();
+        }
+        if self.is_top() || other.is_top() {
+            return TOP.clone();
+        }
+        IntervalDomain {
+            lower_bound: self.lower_bound.saturating_add(other.lower_bound),
+            upper_bound: self.upper_bound.saturating_add(other.upper_bound),
+        }
+    }
+
+    // [x...y] >= [a...b] = x >= b
+    // !([x...y] >= [a...b]) = [a...b] > [x...y] = a > y
+    pub fn ge(&self, other: &Self) -> Option<bool> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            None
+        } else if self.lower_bound >= other.upper_bound {
+            Some(true)
+        } else if other.lower_bound > self.upper_bound {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    // [x...y] > [a...b] = x > b
+    // !([x...y] > [a...b]) = [a...b] >= [x...y] = a >= y
+    pub fn gt(&self, other: &Self) -> Option<bool> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            None
+        } else if self.lower_bound > other.upper_bound {
+            Some(true)
+        } else if other.lower_bound >= self.upper_bound {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    // The expression that corresponds to this interval is not known to result in a integer value.
+    // This is either because we just don't know, or because the necessary transfer function was
+    // not implemented. The expectation is that bottom values will not often be encountered.
+    // We don't need this domain to implement transfer functions for all operations that might
+    // result in integer values since other domains will be preferred in those cases.
+    pub fn is_bottom(&self) -> bool {
+        self.upper_bound < self.lower_bound
+    }
+
+    // Returns true if this interval is known to be contained in the interval [target_type::MIN ... target_type::MAX].
+    // A false result just means that we don't know, it never means that we know it does not.
+    // Note that i128::MIN and i128::MAX are reserved to indicate missing (unbounded) lower and upper
+    // bounds, respectively.
+    pub fn is_contained_in(&self, target_type: &ExpressionType) -> bool {
+        if self.is_bottom() || self.is_top() {
+            return false;
+        };
+        match target_type {
+            I8 => {
+                self.lower_bound >= i128::from(std::i8::MIN)
+                    && self.upper_bound <= i128::from(std::i8::MAX)
+            }
+            I16 => {
+                self.lower_bound >= i128::from(std::i16::MIN)
+                    && self.upper_bound <= i128::from(std::i16::MAX)
+            }
+            I32 => {
+                self.lower_bound >= i128::from(std::i32::MIN)
+                    && self.upper_bound <= i128::from(std::i32::MAX)
+            }
+            I64 => {
+                self.lower_bound >= i128::from(std::i64::MIN)
+                    && self.upper_bound <= i128::from(std::i64::MAX)
+            }
+            I128 => self.lower_bound > std::i128::MIN && self.upper_bound < std::i128::MAX,
+            Isize => {
+                self.lower_bound >= (std::isize::MIN as i128)
+                    && self.upper_bound <= (std::isize::MAX as i128)
+            }
+            U8 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u8::MAX),
+            U16 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u16::MAX),
+            U32 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u32::MAX),
+            U64 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u64::MAX),
+            U128 => self.lower_bound >= 0 && self.upper_bound < std::i128::MAX,
+            Usize => self.lower_bound >= 0 && self.upper_bound <= (std::usize::MAX as i128),
+            _ => false,
+        }
+    }
+
+    // Returns true if this interval is known to be contained in the interval [0 ... bit size of target_type).
+    // A false result just means that we don't know, it never means that we know it does not.
+    pub fn is_contained_in_width_of(&self, target_type: &ExpressionType) -> bool {
+        if self.is_bottom() || self.is_top() {
+            return false;
+        };
+        match target_type {
+            I8 | U8 => self.lower_bound >= 0 && self.upper_bound < 8,
+            I16 | U16 => self.lower_bound >= 0 && self.upper_bound < 16,
+            I32 | U32 => self.lower_bound >= 0 && self.upper_bound < 32,
+            I64 | U64 => self.lower_bound >= 0 && self.upper_bound < 64,
+            I128 | U128 => self.lower_bound >= 0 && self.upper_bound < 128,
+            Isize | Usize => {
+                self.lower_bound >= 0 && self.upper_bound < i128::from(std::usize::MAX.count_ones())
+            }
+            _ => false,
+        }
+    }
+
+    // All concrete integer values belong to this interval, so we know nothing.
+    pub fn is_top(&self) -> bool {
+        self.lower_bound == std::i128::MIN && self.upper_bound == std::i128::MAX
+    }
+
+    // [x...y] * [a...b] = [x*a...y*b]
+    pub fn mul(&self, other: &Self) -> Self {
+        if self.is_bottom() || other.is_bottom() {
+            return BOTTOM.clone();
+        }
+        if self.is_top() || other.is_top() {
+            return TOP.clone();
+        }
+        IntervalDomain {
+            lower_bound: self.lower_bound.saturating_mul(other.lower_bound),
+            upper_bound: self.upper_bound.saturating_mul(other.upper_bound),
+        }
+    }
+
+    // [x...y] <= [a...b] = y <= a
+    // !([x...y] <= [a...b]) = [a...b] < [x...y] = b < x
+    pub fn le(&self, other: &Self) -> Option<bool> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            None
+        } else if self.upper_bound <= other.lower_bound {
+            Some(true)
+        } else if other.upper_bound < self.lower_bound {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    // [x...y] < [a...b] = y < a
+    // !([x...y] < [a...b]) = [a...b] <= [x...y] = b <= x
+    pub fn lt(&self, other: &Self) -> Option<bool> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            None
+        } else if self.upper_bound < other.lower_bound {
+            Some(true)
+        } else if other.upper_bound <= self.lower_bound {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    // -[x...y] = [-y...-x]
+    pub fn neg(&self) -> Self {
+        if self.is_bottom() {
+            return BOTTOM.clone();
+        }
+        if self.is_top() {
+            return TOP.clone();
+        }
+        IntervalDomain {
+            lower_bound: self.upper_bound.checked_neg().unwrap_or(std::i128::MAX),
+            upper_bound: self.lower_bound.checked_neg().unwrap_or(std::i128::MAX),
+        }
+    }
+
+    // [x...y] - [a...b] = [x-b...y-a]
+    pub fn sub(&self, other: &Self) -> Self {
+        if self.is_bottom() || other.is_bottom() {
+            return BOTTOM.clone();
+        }
+        if self.is_top() || other.is_top() {
+            return TOP.clone();
+        }
+        IntervalDomain {
+            lower_bound: self.lower_bound.saturating_sub(other.upper_bound),
+            upper_bound: self.upper_bound.saturating_sub(other.lower_bound),
+        }
+    }
+
+    // [x...y] widen [a...b] = [min(x,a)...max(y,b)],
+    pub fn widen(&self, other: &Self) -> Self {
+        if self.is_bottom() || other.is_bottom() {
+            return BOTTOM.clone();
+        }
+        if self.is_top() || other.is_top() {
+            return TOP.clone();
+        }
+        IntervalDomain {
+            lower_bound: cmp::min(self.lower_bound, other.lower_bound),
+            upper_bound: cmp::max(self.upper_bound, other.upper_bound),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod callbacks;
 pub mod constant_domain;
 pub mod environment;
 pub mod expression;
+pub mod interval_domain;
 pub mod k_limits;
 pub mod summaries;
 pub mod utils;

--- a/tests/run-pass/array_literal_out_of_bounds.rs
+++ b/tests/run-pass/array_literal_out_of_bounds.rs
@@ -11,3 +11,14 @@ pub fn main() {
     let _y = x[2]; //~ array index out of bounds
 }
 
+pub fn foo(c: bool) {
+    let x = [1, 2];
+    let i = if c { 1 } else { 0 };
+    let _y = x[i];
+}
+
+pub fn bar(c: bool) {
+    let x = [1, 2];
+    let i = if c { 1 } else { 2 };
+    let _y = x[i]; //~ possible array index out of bounds
+}

--- a/tests/run-pass/relational_intervals.rs
+++ b/tests/run-pass/relational_intervals.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Tests if intervals satisfy relational constraints
+
+pub fn t1(cond: bool) {
+    let interval = if cond { -2 } else { 1000000 };
+    debug_assert!(interval <= 1000000);
+    debug_assert!(interval < 1000001);
+    debug_assert!(interval >= -2);
+    debug_assert!(interval > -3);
+}
+
+pub fn t2(cond: bool) {
+    let interval = if cond { 0 } else { 10usize };
+    let top = interval % 2;
+    let raw = &cond as *const _;
+    let bottom = interval - (raw as usize); //~ possible attempt to subtract with overflow
+    debug_assert!((interval as isize) > -2);
+    debug_assert!(top < 3); //~ could not prove assertion: top < 3
+    debug_assert!(bottom <= bottom); //~ could not prove assertion: bottom <= bottom
+}
+

--- a/tests/run-pass/signed_interval_overflows.rs
+++ b/tests/run-pass/signed_interval_overflows.rs
@@ -1,0 +1,259 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Tests arithmetic binary operations that overflow
+
+pub fn ti8_add_overflows(cond: bool) -> i8 {
+    let a: i8 = if cond { 0x7F } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn ti8_add_safe(cond: bool) -> i8 {
+    let a: i8 = if cond { 0x7E } else { 1 };
+    a + 1
+}
+
+pub fn ti8_mul_overflows(cond: bool) -> i8 {
+    let a: i8 = if cond { 0x40 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn ti8_mul_safe(cond: bool) -> i8 {
+    let a: i8 = if cond { 0x3F } else { 1 };
+    a * 2
+}
+
+pub fn ti8_sub_overflows(cond: bool) -> i8 {
+    let a: i8 = if cond { -128i8 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 1
+}
+
+pub fn ti8_sub_safe(cond: bool) -> i8 {
+    let a: i8 = if cond { -127i8 } else { 0 };
+    a - 1
+}
+
+pub fn ti8_shl_overflows(cond: bool) -> i8 {
+    let a: i8 = if cond { 8 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn ti8_shl_safe(cond: bool) -> i8 {
+    let a: i8 = if cond { 7 } else { 1 };
+    a << a
+}
+
+pub fn ti8_shr_overflows(cond: bool) -> i8 {
+    let a: i8 = if cond { 8 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn ti8_shr_safe(cond: bool) -> i8 {
+    let a: i8 = if cond { 7 } else { 1 };
+    a >> a
+}
+
+pub fn ti16_add_overflows(cond: bool) -> i16 {
+    let a: i16 = if cond { 0x7FFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn ti16_add_safe(cond: bool) -> i16 {
+    let a: i16 = if cond { 0x7FFE } else { 1 };
+    a + 1
+}
+
+pub fn ti16_mul_overflows(cond: bool) -> i16 {
+    let a: i16 = if cond { 0x4000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn ti16_mul_safe(cond: bool) -> i16 {
+    let a: i16 = if cond { 0x3FFF } else { 1 };
+    a * 2
+}
+
+pub fn ti16_sub_overflows(cond: bool) -> i16 {
+    let a: i16 = if cond { -32768i16 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 1
+}
+
+pub fn ti16_sub_safe(cond: bool) -> i16 {
+    let a: i16 = if cond { -32767i16 } else { 0 };
+    a - 1
+}
+
+pub fn ti16_shl_overflows(cond: bool) -> i16 {
+    let a: i16 = if cond { 16 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn ti16_shl_safe(cond: bool) -> i16 {
+    let a: i16 = if cond { 15 } else { 1 };
+    a << a
+}
+
+pub fn ti16_shr_overflows(cond: bool) -> i16 {
+    let a: i16 = if cond { 16 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn ti16_shr_safe(cond: bool) -> i16 {
+    let a: i16 = if cond { 15 } else { 1 };
+    a >> a
+}
+
+pub fn ti32_add_overflows(cond: bool) -> i32 {
+    let a: i32 = if cond { 0x7FFFFFFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn ti32_add_safe(cond: bool) -> i32 {
+    let a: i32 = if cond { 0x7FFFFFFE } else { 1 };
+    a + 1
+}
+
+pub fn ti32_mul_overflows(cond: bool) -> i32 {
+    let a: i32 = if cond { 0x40000000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn ti32_mul_safe(cond: bool) -> i32 {
+    let a: i32 = if cond { 0x3FFFFFFF } else { 1 };
+    a * 2
+}
+
+pub fn ti32_sub_overflows(cond: bool) -> i32 {
+    let a: i32 = if cond { -2147483648i32 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 1
+}
+
+pub fn ti32_sub_safe(cond: bool) -> i32 {
+    let a: i32 = if cond { -2147483647i32 } else { 1 };
+    a - 1
+}
+
+pub fn ti32_shl_overflows(cond: bool) -> i32 {
+    let a: i32 = if cond { 32 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn ti32_shl_safe(cond: bool) -> i32 {
+    let a: i32 = if cond { 31 } else { 1 };
+    a << a
+}
+
+pub fn ti32_shr_overflows(cond: bool) -> i32 {
+    let a: i32 = if cond { 32 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn ti32_shr_safe(cond: bool) -> i32 {
+    let a: i32 = if cond { 31 } else { 1 };
+    a >> a
+}
+
+pub fn ti64_add_overflows(cond: bool) -> i64 {
+    let a: i64 = if cond { 0x7FFFFFFFFFFFFFFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn ti64_add_safe(cond: bool) -> i64 {
+    let a: i64 = if cond { 0x7FFFFFFFFFFFFFFE } else { 1 };
+    a + 1
+}
+
+pub fn ti64_mul_overflows(cond: bool) -> i64 {
+    let a: i64 = if cond { 0x4000000000000000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn ti64_mul_safe(cond: bool) -> i64 {
+    let a: i64 = if cond { 0x3FFFFFFFFFFFFFFF } else { 1 };
+    a * 2
+}
+
+pub fn ti64_sub_overflows(cond: bool) -> i64 {
+    let a: i64 = if cond { -9223372036854775808i64 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 1
+}
+
+pub fn ti64_sub_safe(cond: bool) -> i64 {
+    let a: i64 = if cond { -9223372036854775807i64 } else { 0 };
+    a - 1
+}
+
+pub fn ti64_shl_overflows(cond: bool) -> i64 {
+    let a: i64 = if cond { 64 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn ti64_shl_safe(cond: bool) -> i64 {
+    let a: i64 = if cond { 63 } else { 1 };
+    a << a
+}
+
+pub fn ti64_shr_overflows(cond: bool) -> i64 {
+    let a: i64 = if cond { 64 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn ti64_shr_safe(cond: bool) -> i64 {
+    let a: i64 = if cond { 63 } else { 1 };
+    a >> a
+}
+
+// Interval domains can only represent finite intervals contained in [i128::MIN+1, ..., i128::MAX-1]
+
+pub fn ti128_add_overflows(cond: bool) -> i128 {
+    let a: i128 = if cond { 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn ti128_add_safe(cond: bool) -> i128 {
+    let a: i128 = if cond { 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC } else { 1 };
+    a + 1
+}
+
+pub fn ti128_mul_overflows(cond: bool) -> i128 {
+    let a: i128 = if cond { 0x40000000000000000000000000000000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn ti128_mul_safe(cond: bool) -> i128 {
+    let a: i128 = if cond { 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE } else { 1 };
+    a * 2
+}
+
+pub fn ti128_sub_overflows(cond: bool) -> i128 {
+    let a: i128 = if cond { -170141183460469231731687303715884105727i128 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 1
+}
+
+pub fn ti128_sub_safe(cond: bool) -> i128 {
+    let a: i128 = if cond { -170141183460469231731687303715884105726i128 } else { 0 };
+    a - 1
+}
+
+pub fn ti128_shl_overflows(cond: bool) -> i128 {
+    let a: i128 = if cond { 128 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn ti128_shl_safe(cond: bool) -> i128 {
+    let a: i128 = if cond { 127 } else { 1 };
+    a << a
+}
+
+pub fn ti128_shr_overflows(cond: bool) -> i128 {
+    let a: i128 = if cond { 128 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn ti128_shr_safe(cond: bool) -> i128 {
+    let a: i128 = if cond { 127 } else { 1 };
+    a >> a
+}

--- a/tests/run-pass/unsigned_interval_overflows.rs
+++ b/tests/run-pass/unsigned_interval_overflows.rs
@@ -1,0 +1,259 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Tests arithmetic binary operations that overflow
+
+pub fn tu8_add_overflows(cond: bool) -> u8 {
+    let a: u8 = if cond { 0xFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn tu8_add_safe(cond: bool) -> u8 {
+    let a: u8 = if cond { 0xFE } else { 1 };
+    a + 1
+}
+
+pub fn tu8_mul_overflows(cond: bool) -> u8 {
+    let a: u8 = if cond { 0x80 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn tu8_mul_safe(cond: bool) -> u8 {
+    let a: u8 = if cond { 0x7F } else { 1 };
+    a * 2
+}
+
+pub fn tu8_sub_overflows(cond: bool) -> u8 {
+    let a: u8 = if cond { 1 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 2
+}
+
+pub fn tu8_sub_safe(cond: bool) -> u8 {
+    let a: u8 = if cond { 2 } else { 1 };
+    a - 1
+}
+
+pub fn tu8_shl_overflows(cond: bool) -> u8 {
+    let a: u8 = if cond { 8 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn tu8_shl_safe(cond: bool) -> u8 {
+    let a: u8 = if cond { 7 } else { 1 };
+    a << a
+}
+
+pub fn tu8_shr_overflows(cond: bool) -> u8 {
+    let a: u8 = if cond { 8 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn tu8_shr_safe(cond: bool) -> u8 {
+    let a: u8 = if cond { 7 } else { 1 };
+    a >> a
+}
+
+pub fn tu16_add_overflows(cond: bool) -> u16 {
+    let a: u16 = if cond { 0xFFFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn tu16_add_safe(cond: bool) -> u16 {
+    let a: u16 = if cond { 0xFFFE } else { 1 };
+    a + 1
+}
+
+pub fn tu16_mul_overflows(cond: bool) -> u16 {
+    let a: u16 = if cond { 0x8000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn tu16_mul_safe(cond: bool) -> u16 {
+    let a: u16 = if cond { 0x7FFF } else { 1 };
+    a * 2
+}
+
+pub fn tu16_sub_overflows(cond: bool) -> u16 {
+    let a: u16 = if cond { 1 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 2
+}
+
+pub fn tu16_sub_safe(cond: bool) -> u16 {
+    let a: u16 = if cond { 2 } else { 1 };
+    a - 1
+}
+
+pub fn tu16_shl_overflows(cond: bool) -> u16 {
+    let a: u16 = if cond { 16 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn tu16_shl_safe(cond: bool) -> u16 {
+    let a: u16 = if cond { 15 } else { 1 };
+    a << a
+}
+
+pub fn tu16_shr_overflows(cond: bool) -> u16 {
+    let a: u16 = if cond { 16 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn tu16_shr_safe(cond: bool) -> u16 {
+    let a: u16 = if cond { 15 } else { 1 };
+    a >> a
+}
+
+pub fn tu32_add_overflows(cond: bool) -> u32 {
+    let a: u32 = if cond { 0xFFFFFFFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn tu32_add_safe(cond: bool) -> u32 {
+    let a: u32 = if cond { 0xFFFFFFFE } else { 1 };
+    a + 1
+}
+
+pub fn tu32_mul_overflows(cond: bool) -> u32 {
+    let a: u32 = if cond { 0x80000000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn tu32_mul_safe(cond: bool) -> u32 {
+    let a: u32 = if cond { 0x7FFFFFFF } else { 1 };
+    a * 2
+}
+
+pub fn tu32_sub_overflows(cond: bool) -> u32 {
+    let a: u32 = if cond { 1 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 2
+}
+
+pub fn tu32_sub_safe(cond: bool) -> u32 {
+    let a: u32 = if cond { 2 } else { 1 };
+    a - 1
+}
+
+pub fn tu32_shl_overflows(cond: bool) -> u32 {
+    let a: u32 = if cond { 32} else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn tu32_shl_safe(cond: bool) -> u32 {
+    let a: u32 = if cond { 31} else { 1 };
+    a << a
+}
+
+pub fn tu32_shr_overflows(cond: bool) -> u32 {
+    let a: u32 = if cond { 32 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn tu32_shr_safe(cond: bool) -> u32 {
+    let a: u32 = if cond { 31 } else { 1 };
+    a >> a
+}
+
+pub fn tu64_add_overflows(cond: bool) -> u64 {
+    let a: u64 = if cond { 0xFFFFFFFFFFFFFFFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn tu64_add_safe(cond: bool) -> u64 {
+    let a: u64 = if cond { 0xFFFFFFFFFFFFFFFE } else { 1 };
+    a + 1
+}
+
+pub fn tu64_mul_overflows(cond: bool) -> u64 {
+    let a: u64 = if cond { 0x8000000000000000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn tu64_mul_safe(cond: bool) -> u64 {
+    let a: u64 = if cond { 0x7FFFFFFFFFFFFFFF } else { 1 };
+    a * 2
+}
+
+pub fn tu64_sub_overflows(cond: bool) -> u64 {
+    let a: u64 = if cond { 1 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 2
+}
+
+pub fn tu64_sub_safe(cond: bool) -> u64 {
+    let a: u64 = if cond { 2 } else { 1 };
+    a - 1
+}
+
+pub fn tu64_shl_overflows(cond: bool) -> u64 {
+    let a: u64 = if cond { 64 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn tu64_shl_safe(cond: bool) -> u64 {
+    let a: u64 = if cond { 63 } else { 1 };
+    a << a
+}
+
+pub fn tu64_shr_overflows(cond: bool) -> u64 {
+    let a: u64 = if cond { 64 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn tu64_shr_safe(cond: bool) -> u64 {
+    let a: u64 = if cond { 63 } else { 1 };
+    a >> a
+}
+
+// Interval domains can only represent finite intervals contained in [i128::MIN+1, ..., i128::MAX-1]
+
+pub fn tu128_add_overflows(cond: bool) -> u128 {
+    let a: u128 = if cond { 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF } else { 1 };  //~ possible attempt to add with overflow
+    a + 1
+}
+
+pub fn tu128_add_safe(cond: bool) -> u128 {
+    let a: u128 = if cond { 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC } else { 1 };
+    a + 1
+}
+
+pub fn tu128_mul_overflows(cond: bool) -> u128 {
+    let a: u128 = if cond { 0x40000000000000000000000000000000 } else { 1 }; //~ possible attempt to multiply with overflow
+    a * 2
+}
+
+pub fn tu128_mul_safe(cond: bool) -> u128 {
+    let a: u128 = if cond { 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE } else { 1 };
+    a * 2
+}
+
+pub fn tu128_sub_overflows(cond: bool) -> u128 {
+    let a: u128 = if cond { 1 } else { 0 }; //~ possible attempt to subtract with overflow
+    a - 2
+}
+
+pub fn tu128_sub_safe(cond: bool) -> u128 {
+    let a: u128 = if cond { 2 } else { 1 };
+    a - 1
+}
+
+pub fn tu128_shl_overflows(cond: bool) -> u128 {
+    let a: u128 = if cond { 128 } else { 1 }; //~ possible attempt to shift left with overflow
+    a << a
+}
+
+pub fn tu128_shl_safe(cond: bool) -> u128 {
+    let a: u128 = if cond { 127 } else { 1 };
+    a << a
+}
+
+pub fn tu128_shr_overflows(cond: bool) -> u128 {
+    let a: u128 = if cond { 128 } else { 1 }; //~ possible attempt to shift right with overflow
+    a >> a
+}
+
+pub fn tu128_shr_safe(cond: bool) -> u128 {
+    let a: u128 = if cond { 127 } else { 1 };
+    a >> a
+}


### PR DESCRIPTION
## Description

Adds an interval domain. The domain is constructed upon demand when checking for arithmetic overflow and index in range conditions. It is not complete, but only implements operations that might reasonably be expected to arise in real code.

Bounded intervals have to be proper subsets of the open interval (i128::MIN, ..., i128:MAX). The min and max values are used to denote that the lower/upper bound, respectively, of an interval is unbounded (infinite).  

Fixes #62

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Added new test cases. Mirai on Mirai.


