### PR TITLE
Fix utils::is_public

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 # install formatter
 - rustup component add rustfmt-preview
 # install linter
- rustup component add clippy-preview
+- rustup component add clippy-preview
 # install code coverage tool
 - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin || true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 #![feature(rustc_private)]
 #![feature(box_syntax)]
 #![feature(const_vec_new)]
-#![feature(try_from)]
 
 extern crate getopts;
 extern crate rustc;

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -20,7 +20,7 @@ use summaries;
 use summaries::{PersistentSummaryCache, Summary};
 use syntax::errors::{Diagnostic, DiagnosticBuilder};
 use syntax_pos;
-use utils::is_public;
+use utils::{self, is_public};
 
 pub struct MirVisitorCrateContext<'a, 'b: 'a, 'tcx: 'b> {
     /// A place where diagnostic messages can be buffered by the test harness.
@@ -1677,7 +1677,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> MirVisitor<'a, 'b, 'tcx> {
             },
             mir::Place::Static(boxed_static) => {
                 let def_id = boxed_static.def_id;
-                let name = summaries::summary_key_str(&self.tcx, def_id);
+                let name = utils::summary_key_str(&self.tcx, def_id);
                 Path::StaticVariable {
                     def_id: Some(def_id),
                     summary_cache_key: name,


### PR DESCRIPTION
## Description

utils::is_public did not work for methods because the items collection of a crate only includes top level items. Rewrote the code to navigate to items via nodes.

Also moved summary_key_str to utils since it is more closely related to other routines in utils than its current home.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
Ran Mirai on Mirai and observed that methods are now treated as public. 

