### PR TITLE
Provide hooks for an SMT solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly
+- nightly-2019-02-27
 cache: cargo
 
 before_script:

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -548,14 +548,19 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying ">>" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn shr(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn shr(
+        &self,
+        other: &AbstractValue,
+        expression_type: ExpressionType,
+        expression_provenance: Option<Span>,
+    ) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shr(&other.domain),
+            domain: self.domain.shr(&other.domain, expression_type),
         }
     }
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -10,6 +10,7 @@ use rustc::session::Session;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use rustc_driver::{driver, Compilation, CompilerCalls, RustcDefaultCalls};
 use rustc_metadata::cstore::CStore;
+use smt_solver::SolverStub;
 use std::path::PathBuf;
 use summaries;
 use syntax::errors::{Diagnostic, DiagnosticBuilder};
@@ -175,6 +176,8 @@ fn after_analysis(
         }
         // By this time all analyses have been carried out, so it should be safe to borrow this now.
         let mir = tcx.optimized_mir(def_id);
+        // todo: #3 provide a helper that returns the solver as specified by a compiler switch.
+        let mut smt_solver = SolverStub::default();
         let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
             buffered_diagnostics: &mut buffered_diagnostics,
             emit_diagnostic,
@@ -184,6 +187,7 @@ fn after_analysis(
             mir,
             summary_cache: &mut persistent_summary_cache,
             constant_value_cache: &mut constant_value_cache,
+            smt_solver: &mut smt_solver,
         });
         mir_visitor.visit_body();
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -217,6 +217,8 @@ pub enum Expression {
         left: Box<AbstractDomain>,
         // The value of the right operand.
         right: Box<AbstractDomain>,
+        // The type of the left argument and the result
+        result_type: ExpressionType,
     },
 
     /// An expression that is false if left shifted right by right bits would shift way all bits. >>
@@ -281,4 +283,40 @@ pub enum ExpressionType {
     U64,
     U128,
     Usize,
+}
+
+impl ExpressionType {
+    /// Returns true if this type is one of the signed integer types.
+    pub fn is_signed_integer(&self) -> bool {
+        use self::ExpressionType::*;
+        match self {
+            I8 | I16 | I32 | I64 | I128 | Isize => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the number of bits used to represent the given type, if primitive.
+    /// For non primitive types the result is just 0.
+    pub fn bit_length(&self) -> u8 {
+        use self::ExpressionType::*;
+        match self {
+            Bool => 1,
+            Char => 16,
+            F32 => 32,
+            F64 => 64,
+            I8 => 8,
+            I16 => 16,
+            I32 => 32,
+            I64 => 64,
+            I128 => 128,
+            Isize => 64,
+            NonPrimitive => 0,
+            U8 => 8,
+            U16 => 16,
+            U32 => 32,
+            U64 => 64,
+            U128 => 128,
+            Usize => 64,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod environment;
 pub mod expression;
 pub mod interval_domain;
 pub mod k_limits;
+pub mod smt_solver;
 pub mod summaries;
 pub mod utils;
 pub mod visitors;

--- a/src/smt_solver.rs
+++ b/src/smt_solver.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use expression::Expression;
+
+/// The result of using the solver to solve an expression.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum SmtResult {
+    /// There is an assignment of values to the free variables for which the expression is true.
+    Satisfiable,
+    /// There is a proof that no assignment of values to the free variables can make the expression true.
+    Unsatisfiable,
+    /// The solver timed out while trying to solve this expression.
+    Undefined,
+}
+
+/// The functionality that a solver must expose in order for MIRAI to use it.
+pub trait SmtSolver<SmtExpressionType> {
+    /// Returns a string representation of the given expression for use in debugging.
+    fn as_debug_string(&self, &SmtExpressionType) -> String;
+
+    /// Adds the given expression to the current context.
+    fn assert(&mut self, &SmtExpressionType);
+
+    /// Destroy the current context and restore the containing context as current.
+    fn backtrack(&mut self);
+
+    /// Translate the MIRAI expression into a corresponding expression for the Solver.
+    fn get_as_smt_predicate(&mut self, mirai_expression: &Expression) -> SmtExpressionType;
+
+    /// Create a nested context. When a matching backtrack is called, the current context (state)
+    /// of the solver will be restored to what it was when this was called.
+    fn set_backtrack_position(&mut self);
+
+    /// Try to find an assignment of values to the free variables so that the assertions in the
+    /// current context are all true.
+    fn solve(&mut self) -> SmtResult;
+
+    /// Establish if the given expression can be satisfied (or not) without changing the current context.
+    fn solve_expression(&mut self, expression: &SmtExpressionType) -> SmtResult {
+        self.set_backtrack_position();
+        self.assert(expression);
+        let result = self.solve();
+        self.backtrack();
+        result
+    }
+}
+
+/// A dummy implementation of SmtSolver to use in configurations where a real SMT solver is not available or required.
+#[derive(Default)]
+pub struct SolverStub {}
+
+impl SmtSolver<()> for SolverStub {
+    fn as_debug_string(&self, _: &()) -> String {
+        String::from("not implemented")
+    }
+
+    fn assert(&mut self, _: &()) {}
+
+    fn backtrack(&mut self) {}
+
+    fn get_as_smt_predicate(&mut self, _mirai_expression: &Expression) {}
+
+    fn set_backtrack_position(&mut self) {}
+
+    fn solve(&mut self) -> SmtResult {
+        SmtResult::Undefined
+    }
+}

--- a/tests/run-pass/false_assertion.rs
+++ b/tests/run-pass/false_assertion.rs
@@ -8,5 +8,5 @@
 
 pub fn test_assert() {
     let i = 1;
-    debug_assert!(i == 2);  //~ could not prove assertion: i == 2
+    debug_assert!(i == 2);  //~ assertion failed: i == 2
 }

--- a/tests/run-pass/maybe_unreachable.rs
+++ b/tests/run-pass/maybe_unreachable.rs
@@ -11,7 +11,7 @@
 
 use std::intrinsics;
 
-fn foo(flag: bool) {
+pub fn foo(flag: bool) {
     if flag {
         unsafe {
             intrinsics::unreachable();

--- a/tests/run-pass/relational_intervals.rs
+++ b/tests/run-pass/relational_intervals.rs
@@ -20,7 +20,7 @@ pub fn t2(cond: bool) {
     let raw = &cond as *const _;
     let bottom = interval - (raw as usize); //~ possible attempt to subtract with overflow
     debug_assert!((interval as isize) > -2);
-    debug_assert!(top < 3); //~ could not prove assertion: top < 3
-    debug_assert!(bottom <= bottom); //~ could not prove assertion: bottom <= bottom
+    debug_assert!(top < 3); //~ possible error: assertion failed: top < 3
+    debug_assert!(bottom <= bottom); //~ possible error: assertion failed: bottom <= bottom
 }
 

--- a/tests/run-pass/unreachable.rs
+++ b/tests/run-pass/unreachable.rs
@@ -13,6 +13,6 @@ use std::intrinsics;
 
 fn foo() {
     unsafe {
-        intrinsics::unreachable(); //~ Control reaches a call to std::intrinsics::unreachable.
+        intrinsics::unreachable();
     }
 }

--- a/tests/run-pass/x_equals_x.rs
+++ b/tests/run-pass/x_equals_x.rs
@@ -10,6 +10,14 @@ pub fn main() {
     foo(1, 2.0);
 }
 
+pub fn bar(y: f32) {
+    if y == y {
+        debug_assert!(true);
+    } else {
+        debug_assert!(false);  //~  possible error: assertion failed: false
+    }
+}
+
 fn foo (x: i32, y: f32) {
     if x == x {
         debug_assert!(true);
@@ -19,6 +27,6 @@ fn foo (x: i32, y: f32) {
     if y == y {
         debug_assert!(true);
     } else {
-        debug_assert!(false);  //~ could not prove assertion: false
+        debug_assert!(false);  //~ possible error: assertion failed: false
     }
 }


### PR DESCRIPTION
## Description

This PR defines a trait that is used by MIRAI to talk to an unspecified SMT Solver. The solver is only used in situations where a diagnostic is being issued and is meant to reduce false positives by employing heroic reasoning over complicated expressions involving arithmetic.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

I've used this with a provisional integration of Z3 (not included in this PR) and determined that a couple of false positive messages in the test suite go away and that MIRAI on MIRAI works (with a couple of false positives going away as well).

The runtime of MIRAI on MIRAI does not increase significantly.
