### PR TITLE
Outer fixed point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly-2019-02-27
+- nightly
 cache: cargo
 
 before_script:

--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -18,7 +18,7 @@ use syntax::ast;
 
 /// Basically, this domain is a structured container for other domains. It is also the only
 /// client for the other domains.
-#[derive(Serialize, Deserialize, Clone, Eq)]
+#[derive(Serialize, Deserialize, Clone, Eq, Ord, PartialOrd)]
 pub struct AbstractDomain {
     // todo: make this private
     // This is not a domain element, but a representation of how this instance has been constructed.
@@ -371,13 +371,16 @@ impl AbstractDomain {
     }
 
     /// Returns an element that is "self >= other".
-    pub fn ge(&mut self, other: &mut Self) -> Self {
+    pub fn greater_or_equal(&mut self, other: &mut Self) -> Self {
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
-            return v1.ge(v2).into();
+            return v1.greater_or_equal(v2).into();
         };
-        if let Some(result) = self.get_cached_interval().ge(&other.get_cached_interval()) {
+        if let Some(result) = self
+            .get_cached_interval()
+            .greater_or_equal(&other.get_cached_interval())
+        {
             return result.into();
         }
         Expression::GreaterOrEqual {
@@ -388,13 +391,16 @@ impl AbstractDomain {
     }
 
     /// Returns an element that is "self > other".
-    pub fn gt(&mut self, other: &mut Self) -> Self {
+    pub fn greater_than(&mut self, other: &mut Self) -> Self {
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
-            return v1.gt(v2).into();
+            return v1.greater_than(v2).into();
         };
-        if let Some(result) = self.get_cached_interval().gt(&other.get_cached_interval()) {
+        if let Some(result) = self
+            .get_cached_interval()
+            .greater_than(&other.get_cached_interval())
+        {
             return result.into();
         }
         Expression::GreaterThan {
@@ -482,13 +488,16 @@ impl AbstractDomain {
     }
 
     /// Returns an element that is "self <= other".
-    pub fn le(&mut self, other: &mut Self) -> Self {
+    pub fn less_or_equal(&mut self, other: &mut Self) -> Self {
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
-            return v1.le(v2).into();
+            return v1.less_or_equal(v2).into();
         };
-        if let Some(result) = self.get_cached_interval().le(&other.get_cached_interval()) {
+        if let Some(result) = self
+            .get_cached_interval()
+            .less_equal(&other.get_cached_interval())
+        {
             return result.into();
         }
         Expression::LessOrEqual {
@@ -499,13 +508,16 @@ impl AbstractDomain {
     }
 
     /// Returns an element that is self < other
-    pub fn lt(&mut self, other: &mut Self) -> Self {
+    pub fn less_than(&mut self, other: &mut Self) -> Self {
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
-            return v1.lt(v2).into();
+            return v1.less_than(v2).into();
         };
-        if let Some(result) = self.get_cached_interval().lt(&other.get_cached_interval()) {
+        if let Some(result) = self
+            .get_cached_interval()
+            .less_than(&other.get_cached_interval())
+        {
             return result.into();
         }
         Expression::LessThan {
@@ -901,16 +913,16 @@ impl AbstractDomain {
                 .equals(&right.refine_paths(environment)),
             Expression::GreaterOrEqual { left, right } => left
                 .refine_paths(environment)
-                .ge(&mut right.refine_paths(environment)),
+                .greater_or_equal(&mut right.refine_paths(environment)),
             Expression::GreaterThan { left, right } => left
                 .refine_paths(environment)
-                .gt(&mut right.refine_paths(environment)),
+                .greater_than(&mut right.refine_paths(environment)),
             Expression::LessOrEqual { left, right } => left
                 .refine_paths(environment)
-                .le(&mut right.refine_paths(environment)),
+                .less_or_equal(&mut right.refine_paths(environment)),
             Expression::LessThan { left, right } => left
                 .refine_paths(environment)
-                .lt(&mut right.refine_paths(environment)),
+                .less_than(&mut right.refine_paths(environment)),
             Expression::Mul { left, right } => left
                 .refine_paths(environment)
                 .mul(&right.refine_paths(environment)),
@@ -1025,16 +1037,16 @@ impl AbstractDomain {
                 .equals(&right.refine_parameters(arguments)),
             Expression::GreaterOrEqual { left, right } => left
                 .refine_parameters(arguments)
-                .ge(&mut right.refine_parameters(arguments)),
+                .greater_or_equal(&mut right.refine_parameters(arguments)),
             Expression::GreaterThan { left, right } => left
                 .refine_parameters(arguments)
-                .gt(&mut right.refine_parameters(arguments)),
+                .greater_than(&mut right.refine_parameters(arguments)),
             Expression::LessOrEqual { left, right } => left
                 .refine_parameters(arguments)
-                .le(&mut right.refine_parameters(arguments)),
+                .less_or_equal(&mut right.refine_parameters(arguments)),
             Expression::LessThan { left, right } => left
                 .refine_parameters(arguments)
-                .lt(&mut right.refine_parameters(arguments)),
+                .less_than(&mut right.refine_parameters(arguments)),
             Expression::Mul { left, right } => left
                 .refine_parameters(arguments)
                 .mul(&right.refine_parameters(arguments)),
@@ -1172,16 +1184,16 @@ impl AbstractDomain {
                 .equals(&right.refine_with(path_condition)),
             Expression::GreaterOrEqual { left, right } => left
                 .refine_with(path_condition)
-                .ge(&mut right.refine_with(path_condition)),
+                .greater_or_equal(&mut right.refine_with(path_condition)),
             Expression::GreaterThan { left, right } => left
                 .refine_with(path_condition)
-                .gt(&mut right.refine_with(path_condition)),
+                .greater_than(&mut right.refine_with(path_condition)),
             Expression::LessOrEqual { left, right } => left
                 .refine_with(path_condition)
-                .le(&mut right.refine_with(path_condition)),
+                .less_or_equal(&mut right.refine_with(path_condition)),
             Expression::LessThan { left, right } => left
                 .refine_with(path_condition)
-                .lt(&mut right.refine_with(path_condition)),
+                .less_than(&mut right.refine_with(path_condition)),
             Expression::Mul { left, right } => left
                 .refine_with(path_condition)
                 .mul(&right.refine_with(path_condition)),

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -20,7 +20,7 @@ use syntax_pos::Span;
 /// When we do know everything about a value, it is concrete rather than
 /// abstract, but is convenient to just use this structure for concrete values
 /// as well, since all operations can be uniform.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Ord, PartialOrd)]
 pub struct AbstractValue {
     /// An abstract value is the result of some expression.
     /// The source location of that expression is stored in provenance.
@@ -259,7 +259,7 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying ">=" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn ge(
+    pub fn greater_or_equal(
         &mut self,
         other: &mut AbstractValue,
         expression_provenance: Option<Span>,
@@ -270,14 +270,14 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.ge(&mut other.domain),
+            domain: self.domain.greater_or_equal(&mut other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying ">" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn gt(
+    pub fn greater_than(
         &mut self,
         other: &mut AbstractValue,
         expression_provenance: Option<Span>,
@@ -288,7 +288,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.gt(&mut other.domain),
+            domain: self.domain.greater_than(&mut other.domain),
         }
     }
 
@@ -320,7 +320,7 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "<=" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn le(
+    pub fn less_or_equal(
         &mut self,
         other: &mut AbstractValue,
         expression_provenance: Option<Span>,
@@ -331,14 +331,14 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.le(&mut other.domain),
+            domain: self.domain.less_or_equal(&mut other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "lt" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn lt(
+    pub fn less_than(
         &mut self,
         other: &mut AbstractValue,
         expression_provenance: Option<Span>,
@@ -349,7 +349,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.lt(&mut other.domain),
+            domain: self.domain.less_than(&mut other.domain),
         }
     }
 
@@ -659,7 +659,7 @@ pub enum Name {
 /// A path represents a left hand side expression.
 /// When the actual expression is evaluated at runtime it will resolve to a particular memory
 /// location. During analysis it is used to keep track of state changes.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Path {
     /// A dynamically allocated memory block.
     AbstractHeapAddress { ordinal: usize },
@@ -737,7 +737,7 @@ impl Path {
 }
 
 /// The selector denotes a de-referenced item, field, or element, or slice.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum PathSelector {
     /// The length of an array.
     ArrayLength,

--- a/src/constant_domain.rs
+++ b/src/constant_domain.rs
@@ -15,7 +15,7 @@ use utils::is_rust_intrinsic;
 /// that is useful for the abstract interpreter. More importantly, this
 /// value can be serialized to the persistent summary cache.
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialOrd, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialOrd, PartialEq, Hash, Ord)]
 pub enum ConstantDomain {
     /// The impossible constant. Use this as the result of a partial transfer function.
     Bottom,
@@ -223,7 +223,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self >= other".
-    pub fn ge(&self, other: &Self) -> Self {
+    pub fn greater_or_equal(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
                 f32::from_bits(*val1) >= f32::from_bits(*val2)
@@ -237,7 +237,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self > other".
-    pub fn gt(&self, other: &Self) -> Self {
+    pub fn greater_than(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
                 f32::from_bits(*val1) > f32::from_bits(*val2)
@@ -251,7 +251,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self <= other".
-    pub fn le(&self, other: &Self) -> Self {
+    pub fn less_or_equal(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
                 f32::from_bits(*val1) <= f32::from_bits(*val2)
@@ -265,7 +265,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self < other".
-    pub fn lt(&self, other: &Self) -> Self {
+    pub fn less_than(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
                 f32::from_bits(*val1) < f32::from_bits(*val2)

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -8,7 +8,7 @@ use abstract_value::Path;
 use constant_domain::ConstantDomain;
 
 /// Closely based on the expressions found in MIR.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Expression {
     /// An expression that represents any possible value
     Top,
@@ -264,7 +264,7 @@ pub enum Expression {
 /// For now, we are only really interested to distinguish between
 /// floating point values and other values, because NaN != NaN.
 /// In the future the other distinctions may be helpful to SMT solvers.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum ExpressionType {
     Bool,
     Char,

--- a/src/interval_domain.rs
+++ b/src/interval_domain.rs
@@ -13,7 +13,7 @@ use std::convert::TryFrom;
 /// std::i128::MAX denotes +infinity.
 /// Interval domain elements are constructed on demand from AbstractDomain expressions.
 /// They are most useful for checking if an array index is within bounds.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialOrd, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialOrd, PartialEq, Hash, Ord)]
 pub struct IntervalDomain {
     lower_bound: i128,
     upper_bound: i128,
@@ -68,7 +68,7 @@ impl IntervalDomain {
 
     // [x...y] >= [a...b] = x >= b
     // !([x...y] >= [a...b]) = [a...b] > [x...y] = a > y
-    pub fn ge(&self, other: &Self) -> Option<bool> {
+    pub fn greater_or_equal(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
         } else if self.lower_bound >= other.upper_bound {
@@ -82,7 +82,7 @@ impl IntervalDomain {
 
     // [x...y] > [a...b] = x > b
     // !([x...y] > [a...b]) = [a...b] >= [x...y] = a >= y
-    pub fn gt(&self, other: &Self) -> Option<bool> {
+    pub fn greater_than(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
         } else if self.lower_bound > other.upper_bound {
@@ -183,7 +183,7 @@ impl IntervalDomain {
 
     // [x...y] <= [a...b] = y <= a
     // !([x...y] <= [a...b]) = [a...b] < [x...y] = b < x
-    pub fn le(&self, other: &Self) -> Option<bool> {
+    pub fn less_equal(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
         } else if self.upper_bound <= other.lower_bound {
@@ -197,7 +197,7 @@ impl IntervalDomain {
 
     // [x...y] < [a...b] = y < a
     // !([x...y] < [a...b]) = [a...b] <= [x...y] = b <= x
-    pub fn lt(&self, other: &Self) -> Option<bool> {
+    pub fn less_than(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
         } else if self.upper_bound < other.lower_bound {

--- a/src/k_limits.rs
+++ b/src/k_limits.rs
@@ -8,3 +8,6 @@
 
 /// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
 pub const MAX_PATH_LENGTH: usize = 10;
+
+/// The point at which diverging summaries experience exponential blowup right now.
+pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;

--- a/tests/run-pass/precondition.rs
+++ b/tests/run-pass/precondition.rs
@@ -6,11 +6,12 @@
 
 // A test that infers a precondition and report a failure to satisfy it.
 
-fn foo(arr: &mut [i32], i: usize) {
-    arr[i] = 12; //~ related location
-}
-
 pub fn main() {
     let mut a = [1, 2];
     foo(&mut a, 3); //~ array index out of bounds
 }
+
+fn foo(arr: &mut [i32], i: usize) {
+    arr[i] = 12; //~ related location
+}
+


### PR DESCRIPTION
## Description

If function a depends on function b, which succeeds its in source order, then a is being analyzed without the benefit of a summary for b, which could lead to both false positives (because the lack of knowledge about the result (post conditions) of b may lead to overly pessimistic assumptions) and false negatives (because a's call to be may violate unknown preconditions of b).

In order to avoid this, any function that depends on another function whose summary is unknown (or incomplete) has to get re-analyzed. This process has to be repeated until all summaries are complete. We regard a summary as complete when it does not change after being recomputed with updated summaries for the functions it calls. 

This represents a fixed point, usually referred to as the "outer fixed point".

In order to safely compare a new summary with a previous summary, the collections in summaries should be sorted. That requires AbtractValues to be comparable, which requires abstract operations such as gt and ge to be renamed so that they do not clash with the corresponding concrete operations on AbstractValues in the interpreter.

Finally, note that appropriate widening is required for the fixed point loop to converge. This is not supplied by this PR, so instyead there is a new k-limit that terminates the fixed point loop before it causes too much additional runtime. Even so, the runtime of Mirai now more than doubles when it is run on itself.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
Modified an existing test so that a function calls another that has not yet been analyzed in round 1.
Ran MIRAI on MIRAI.
