### PR TITLE
Use crate:: prefix and supply trait function parameter names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "A static analysis tool for Rust, based on Abstract Interpretation
 repository = "https://github.com/facebookexperimental/MIRAI"
 readme = "README.md"
 license = "MIT"
+edition = "2018"
 
 [lib]
 test = false # we have no unit tests

--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -3,11 +3,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use abstract_value::{AbstractValue, Path};
-use constant_domain::ConstantDomain;
-use environment::Environment;
-use expression::{Expression, ExpressionType};
-use interval_domain::{self, IntervalDomain};
+use crate::abstract_value::{AbstractValue, Path};
+use crate::constant_domain::ConstantDomain;
+use crate::environment::Environment;
+use crate::expression::{Expression, ExpressionType};
+use crate::interval_domain::{self, IntervalDomain};
+
 use rustc::ty::TyKind;
 use std::fmt::{Debug, Formatter, Result};
 use std::hash::Hash;

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -3,10 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 //
-use abstract_domains::{self, AbstractDomain};
-use constant_domain::ConstantDomain;
-use environment::Environment;
-use expression::{Expression, ExpressionType};
+use crate::abstract_domains::{self, AbstractDomain};
+use crate::constant_domain::ConstantDomain;
+use crate::environment::Environment;
+use crate::expression::{Expression, ExpressionType};
+
 use rustc::hir::def_id::DefId;
 use std::fmt::{Debug, Formatter, Result};
 use std::hash::{Hash, Hasher};

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,22 +4,23 @@
 // LICENSE file in the root directory of this source tree.
 #![allow(clippy::borrowed_box)]
 
-use constant_domain::ConstantValueCache;
-use k_limits;
+use crate::constant_domain::ConstantValueCache;
+use crate::k_limits;
+use crate::smt_solver::SolverStub;
+use crate::summaries;
+use crate::visitors::{MirVisitor, MirVisitorCrateContext};
+
 use rustc::hir::def_id::DefId;
 use rustc::session::config::{self, ErrorOutputType, Input};
 use rustc::session::Session;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use rustc_driver::{driver, Compilation, CompilerCalls, RustcDefaultCalls};
 use rustc_metadata::cstore::CStore;
-use smt_solver::SolverStub;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::path::PathBuf;
-use summaries;
 use syntax::errors::{Diagnostic, DiagnosticBuilder};
 use syntax::{ast, errors};
-use visitors::{MirVisitor, MirVisitorCrateContext};
 
 /// Private state used to implement the callbacks.
 pub struct MiraiCallbacks {

--- a/src/constant_domain.rs
+++ b/src/constant_domain.rs
@@ -4,12 +4,13 @@
 // LICENSE file in the root directory of this source tree.
 #![allow(clippy::float_cmp)]
 
-use expression::{Expression, ExpressionType};
+use crate::expression::{Expression, ExpressionType};
+use crate::summaries::PersistentSummaryCache;
+use crate::utils::is_rust_intrinsic;
+
 use rustc::hir::def_id::DefId;
 use rustc::ty::TyCtxt;
 use std::collections::HashMap;
-use summaries::PersistentSummaryCache;
-use utils::is_rust_intrinsic;
 
 /// Abstracts over constant values referenced in MIR and adds information
 /// that is useful for the abstract interpreter. More importantly, this

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -3,9 +3,10 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use abstract_domains::AbstractDomain;
-use abstract_value::{self, AbstractValue, Path};
-use expression::Expression;
+use crate::abstract_domains::AbstractDomain;
+use crate::abstract_value::{self, AbstractValue, Path};
+use crate::expression::Expression;
+
 use rpds::HashTrieMap;
 use rustc::mir::BasicBlock;
 use std::collections::HashMap;

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -3,9 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use abstract_domains::AbstractDomain;
-use abstract_value::Path;
-use constant_domain::ConstantDomain;
+use crate::abstract_domains::AbstractDomain;
+use crate::abstract_value::Path;
+use crate::constant_domain::ConstantDomain;
 
 /// Closely based on the expressions found in MIR.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/src/interval_domain.rs
+++ b/src/interval_domain.rs
@@ -4,7 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-use expression::ExpressionType::{self, *};
+use crate::expression::ExpressionType::{self, *};
+
 use std::cmp;
 use std::convert::TryFrom;
 

--- a/src/smt_solver.rs
+++ b/src/smt_solver.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use expression::Expression;
+use crate::expression::Expression;
 
 /// The result of using the solver to solve an expression.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
@@ -19,10 +19,10 @@ pub enum SmtResult {
 /// The functionality that a solver must expose in order for MIRAI to use it.
 pub trait SmtSolver<SmtExpressionType> {
     /// Returns a string representation of the given expression for use in debugging.
-    fn as_debug_string(&self, &SmtExpressionType) -> String;
+    fn as_debug_string(&self, expression: &SmtExpressionType) -> String;
 
     /// Adds the given expression to the current context.
-    fn assert(&mut self, &SmtExpressionType);
+    fn assert(&mut self, expression: &SmtExpressionType);
 
     /// Destroy the current context and restore the containing context as current.
     fn backtrack(&mut self);

--- a/src/summaries.rs
+++ b/src/summaries.rs
@@ -3,14 +3,15 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use abstract_value::{AbstractValue, Path};
-use environment::Environment;
+use crate::abstract_value::{AbstractValue, Path};
+use crate::environment::Environment;
+use crate::utils;
+
 use rustc::hir::def_id::DefId;
 use rustc::ty::TyCtxt;
 use sled::Db;
 use std::collections::HashMap;
 use std::ops::Deref;
-use utils;
 
 /// A summary is a declarative abstract specification of what a function does.
 /// This is calculated once per function and is used by callers of the function.

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -3,25 +3,26 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use abstract_domains::AbstractDomain;
-use abstract_value::{self, AbstractValue, Path, PathSelector};
-use constant_domain::{ConstantDomain, ConstantValueCache};
-use environment::Environment;
-use expression::{Expression, ExpressionType};
-use k_limits;
+use crate::abstract_domains::AbstractDomain;
+use crate::abstract_value::{self, AbstractValue, Path, PathSelector};
+use crate::constant_domain::{ConstantDomain, ConstantValueCache};
+use crate::environment::Environment;
+use crate::expression::{Expression, ExpressionType};
+use crate::k_limits;
+use crate::smt_solver::{SmtResult, SmtSolver};
+use crate::summaries;
+use crate::summaries::{PersistentSummaryCache, Summary};
+use crate::utils::{self, is_public};
+
 use rustc::session::Session;
 use rustc::ty::{Const, LazyConst, Ty, TyCtxt, TyKind, UserTypeAnnotationIndex};
 use rustc::{hir, mir};
-use smt_solver::{SmtResult, SmtSolver};
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
-use summaries;
-use summaries::{PersistentSummaryCache, Summary};
 use syntax::errors::{Diagnostic, DiagnosticBuilder};
 use syntax_pos;
-use utils::{self, is_public};
 
 pub struct MirVisitorCrateContext<'a, 'b: 'a, 'tcx: 'b, E> {
     /// A place where diagnostic messages can be buffered by the test harness.
@@ -1693,7 +1694,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     TyKind::FnDef(def_id, ..) => self.visit_function_reference(def_id),
                     TyKind::Int(..) => match val {
                         ConstValue::Scalar(Scalar::Bits { bits, size }) => {
-                            let mut value: i128 = match *size {
+                            let value: i128 = match *size {
                                 1 => i128::from(*bits as i8),
                                 2 => i128::from(*bits as i16),
                                 4 => i128::from(*bits as i32),


### PR DESCRIPTION
## Description

This adds a constraint to Cargo.toml to require use of Rust 2018. It also fixes some minor issues that that the rust compiler consequently complains about.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test

