### PR TITLE
Replace two more usages of abstract_value::TOP with variables.

### DIFF
--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -679,6 +679,8 @@ pub enum Path {
         def_id: Option<DefId>,
         /// The key to use when retrieving a summary for the static variable from the summary cache.
         summary_cache_key: String,
+        /// The type to use when the static variable value is not yet available.
+        expression_type: ExpressionType,
     },
 
     /// The ordinal is an index into a method level table of MIR bodies.


### PR DESCRIPTION
## Description

Now that we have (typed) variables as values we should avoid using Top. This removes two places where Top was still used as default value.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and MIRAI on MIRAI.

