### PR TITLE
Keep up with API changes in latest nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly-2019-02-27
+- nightly
 cache: cargo
 
 before_script:


### PR DESCRIPTION
## Description

There has been a small API change in the latest nightly build of Rustc. The problem with Clippy also seems fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and validate.sh
