### PR TITLE
Support array constants

### DIFF
--- a/tests/run-pass/lazy_const_array.rs
+++ b/tests/run-pass/lazy_const_array.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that generates a LazyConst::Unevaluated reference to a constant array
+// and that checks that MIRAI finds the constant in the summary cache via the def_id
+
+const FOO: [u8; 3] = [1, 2, 3];
+const BAR: u8 = FOO[0]; // The reference to FOO is unevaluated in the MIR body that computes BAR
+
+pub fn main() {
+    debug_assert_eq!(BAR, 1);
+}

--- a/tests/run-pass/promoted_array.rs
+++ b/tests/run-pass/promoted_array.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses MIR constant array literals.
+
+//todo: This is the only way I can find to generate such literals.
+// Find out for sure if there is no other way.
+
+pub fn main() {
+    let _x = f(b"x");
+//    debug_assert!(f(b"x")); //todo: enable this once path refinement has been implemented
+}
+
+fn f(value: &[u8]) -> bool {
+    g(b"x", value)
+}
+
+fn g(x: &[u8], y: &[u8]) -> bool {
+    x[0] == y[0]
+}

--- a/tests/run-pass/promoted_slice.rs
+++ b/tests/run-pass/promoted_slice.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses MIR constant array slice literals.
+
+//todo: since the only way I can find to generate such literals is by using them in
+// tags of match expressions, and these call to std::cmp::PartialEq::eq, there is currently
+// no way to check that these constants are read correctly, other than by logging.
+// Once we have a really precise summary for std::cmp::PartialEq::eq, we should be able
+// to prove things, for example we should be able to assert that promote_u8 returns 10
+// if called with &[1, 2, 3].
+
+pub fn promote_u8(value: &[u8]) -> u8 {
+    const TAG: &[u8] = &[1, 2, 3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_u16(value: &[u16]) -> u16 {
+    const TAG: &[u16] = &[1, 2, 3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_u32(value: &[u32]) -> u32 {
+    const TAG: &[u32] = &[1, 2, 3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_u64(value: &[u64]) -> u64 {
+    const TAG: &[u64] = &[1, 2, 3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_u128(value: &[u128]) -> u128 {
+    const TAG: &[u128] = &[1, 2, 3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_usize(value: &[usize]) -> usize {
+    const TAG: &[usize] = &[1, 2, 3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_i8(value: &[i8]) -> i8 {
+    const TAG: &[i8] = &[1, 2, -3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_i16(value: &[i16]) -> i16 {
+    const TAG: &[i16] = &[1, 2, -3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_i32(value: &[i32]) -> i32 {
+    const TAG: &[i32] = &[1, 2, -3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_i64(value: &[i64]) -> i64 {
+    const TAG: &[i64] = &[1, 2, -3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_i128(value: &[i128]) -> i128 {
+    const TAG: &[i128] = &[1, 2, -3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}
+
+pub fn promote_isize(value: &[isize]) -> isize {
+    const TAG: &[isize] = &[1, 2, -3];
+    match value {
+        TAG => 10,
+        _ => 20
+    }
+}


### PR DESCRIPTION
## Description

Somewhat surprisingly, MIR has two ways to encode structured compile time constants: 1) As MIR instructions in a promoted constants body and 2) As a string of bytes that contain a runtime image of the constant (along with a map of undefined bytes and a map of pointers to relocate).

To add insult to injury, a single source literal can be encoded both ways. Oh well.

This PR deals with array literals that are compile time constants and that are encoded as byte strings. Things are a bit more involved than it may seem because you can refer to an array directly or you can refer to a slice of the array. The former only seems to happen if the array is in fact a "byte string" such as b"a", while the latter happens when a fixed length array is referenced via an unsized reference (i.e. when a runtime length is added to the reference by referring to a slice of the array).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and validate.sh
New test cases.

