### PR TITLE
Satisfy the -D rust-2018-idioms compiler flag

### DIFF
--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -32,7 +32,7 @@ pub struct AbstractDomain {
 }
 
 impl Debug for AbstractDomain {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.expression.fmt(f)
     }
 }
@@ -75,7 +75,7 @@ pub const TRUE: AbstractDomain = AbstractDomain {
 };
 
 impl<'a> From<&TyKind<'a>> for ExpressionType {
-    fn from(ty_kind: &TyKind) -> ExpressionType {
+    fn from(ty_kind: &TyKind<'a>) -> ExpressionType {
         match ty_kind {
             TyKind::Bool => ExpressionType::Bool,
             TyKind::Char => ExpressionType::Char,

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -62,7 +62,7 @@ pub const TRUE: AbstractValue = AbstractValue {
 };
 
 impl Debug for AbstractValue {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.domain.fmt(f)
     }
 }

--- a/src/constant_domain.rs
+++ b/src/constant_domain.rs
@@ -57,8 +57,8 @@ impl ConstantDomain {
     /// Returns a constant value that is a reference to a function
     pub fn for_function(
         def_id: DefId,
-        tcx: &TyCtxt,
-        summary_cache: &mut PersistentSummaryCache,
+        tcx: &TyCtxt<'_, '_, '_>,
+        summary_cache: &mut PersistentSummaryCache<'_, '_>,
     ) -> ConstantDomain {
         let summary_cache_key = summary_cache.get_summary_key_for(def_id);
         ConstantDomain::Function {
@@ -633,8 +633,8 @@ impl ConstantValueCache {
     pub fn get_function_constant_for(
         &mut self,
         def_id: DefId,
-        tcx: &TyCtxt,
-        summary_cache: &mut PersistentSummaryCache,
+        tcx: &TyCtxt<'_, '_, '_>,
+        summary_cache: &mut PersistentSummaryCache<'_, '_>,
     ) -> &ConstantDomain {
         self.function_cache
             .entry(def_id)

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -34,7 +34,7 @@ impl Environment {
 }
 
 impl Debug for Environment {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.value_map.fmt(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,22 +19,16 @@
 extern crate getopts;
 extern crate rustc;
 extern crate rustc_codegen_utils;
-extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_metadata;
 extern crate rustc_target;
 extern crate syntax;
 extern crate syntax_pos;
 
-extern crate bincode;
 #[macro_use]
 extern crate log;
-//#[macro_use]
-extern crate rpds;
-extern crate sled;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde;
 
 pub mod abstract_domains;
 pub mod abstract_value;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,7 +32,7 @@ pub fn find_sysroot() -> String {
 
 /// Returns true if the function identified by def_id is a Rust intrinsic function.
 /// Warning: it is not clear what will happen if def_id does not identify a function.
-pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt) -> bool {
+pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
     let binder = tcx.fn_sig(def_id);
     let sig = binder.skip_binder();
     match sig.abi {
@@ -42,7 +42,7 @@ pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt) -> bool {
 }
 
 /// Returns true if the function identified by def_id is a public function.
-pub fn is_public(def_id: DefId, tcx: &TyCtxt) -> bool {
+pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
     if let Some(node) = tcx.hir().get_if_local(def_id) {
         match node {
             Node::Item(item) => {
@@ -73,7 +73,7 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt) -> bool {
 /// the summary cache, which is a key value store. The string will always be the same as
 /// long as the definition does not change its name or location, so it can be used to
 /// transfer information from one compilation to the next, making incremental analysis possible.
-pub fn summary_key_str(tcx: &TyCtxt, def_id: DefId) -> String {
+pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
     let crate_name = if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str().get()
     } else {

--- a/tests/validate.sh
+++ b/tests/validate.sh
@@ -9,7 +9,8 @@ cargo fmt --all
 # Run lint checks
 cargo clippy -- -D warnings
 # Build
-time cargo build
+cargo rustc --lib -- -D rust-2018-idioms
+cargo build
 # Run mirai on itself
 cargo uninstall mirai || true
 cargo install --debug --path .


### PR DESCRIPTION
## Description

Enhances validate.sh to call the rust compiler with the rust-2018-idioms compiler flag and fixes up all of the complaints that show up with that flag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and validate.sh


