### PR TITLE
Limit the number of inferred preconditions that a summary can have

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly
+- nightly-2019-03-09
 cache: cargo
 
 before_script:

--- a/src/k_limits.rs
+++ b/src/k_limits.rs
@@ -6,6 +6,9 @@
 // Somewhat arbitrary constants used to limit things in the abstract interpreter that may
 // take too long or use too much memory.
 
+/// Helps to limit the size of summaries.
+pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
+
 /// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
 pub const MAX_PATH_LENGTH: usize = 10;
 


### PR DESCRIPTION
## Description

Large self recursive functions, such as those found in Mirai can end up with many hundreds of inferred preconditions and this is one source of noticeable slowdown for Mirai.

This change limits the number of preconditions that can be pushed for any function. Once the limit is reached, warnings are issued at the source of a panic, rather than at call sites. This increases false positives because some infeasible paths will now be treated as feasible.

Imposing this restriction claws back about 1 minute of execution time when running Mirai on Mirai. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and validate.sh
