### PR TITLE
Refine path selectors with embedded parameter values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly-2019-03-09
+- nightly
 cache: cargo
 
 before_script:

--- a/src/abstract_value.rs
+++ b/src/abstract_value.rs
@@ -781,3 +781,15 @@ pub enum PathSelector {
     /// this for ADTs with more than one variant. The value is the ordinal of the variant.
     Downcast(usize),
 }
+
+impl PathSelector {
+    /// Refine embedded index values with the given arguments and environment.
+    pub fn refine_parameters(&self, arguments: &[AbstractValue]) -> Self {
+        if let PathSelector::Index(boxed_abstract_value) = self {
+            let refined_value = (**boxed_abstract_value).refine_parameters(arguments);
+            PathSelector::Index(box refined_value)
+        } else {
+            self.clone()
+        }
+    }
+}

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -716,8 +716,6 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                 .refine_parameters(actual_args)
                 .refine_paths(&mut self.current_environment)
                 .refine_with(&self.current_environment.entry_condition, self.current_span);
-            //todo: if refined_precondition is a Variable, look it up
-            // or perhaps pass in &mut self.current_environment
             let (refined_precondition_as_bool, entry_cond_as_bool) =
                 self.check_condition_value_and_reachability(&refined_precondition);
 
@@ -934,8 +932,9 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             .filter(|(p, _)| (*p) == source_path || p.is_rooted_by(&source_path))
         {
             let tpath = path.replace_root(&source_path, target_path.clone());
-            let rvalue = value.refine_parameters(arguments);
-            //todo: if refined_precondition is a Variable, look it up
+            let rvalue = value
+                .refine_parameters(arguments)
+                .refine_paths(&mut self.current_environment);
             self.current_environment.update_value_at(tpath, rvalue);
         }
     }

--- a/tests/run-pass/array_index.rs
+++ b/tests/run-pass/array_index.rs
@@ -17,3 +17,14 @@ fn bar(arr: &mut [i32], i: usize) {
     arr[i] = 123;
     debug_assert!(arr[i] == 123);
 }
+
+fn get_elem(arr: &[i32], i: usize) -> i32 {
+    arr[i]
+}
+
+pub fn main() {
+    let arr = [1, 2, 3];
+    let elem = get_elem(&arr, 1);
+    debug_assert!(elem == 2);
+}
+


### PR DESCRIPTION
## Description

When refining summaries with the actual values corresponding to formal parameters, also refine the PathSelector::Index parts of the paths because these contain AbstractValues that might contain formal parameters.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Added test code to tests/run-pass/array_index.rs