### PR TITLE
Use the new Rust compiler interface

### DIFF
--- a/src/expected_errors.rs
+++ b/src/expected_errors.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use syntax::errors::Diagnostic;
+
+/// A collection of error strings that are expected for a test case.
+pub struct ExpectedErrors {
+    messages: Vec<String>,
+}
+
+impl ExpectedErrors {
+    /// Reads the file at the given path and scans it for instances of "//~ message".
+    /// Each message becomes an element of ExpectedErrors.messages.
+    pub fn new(path: &str) -> ExpectedErrors {
+        let exp = load_errors(&PathBuf::from_str(&path).unwrap());
+        ExpectedErrors { messages: exp }
+    }
+
+    /// Checks if the given set of diagnostics matches the expected diagnostics.
+    pub fn check_messages(&mut self, diagnostics: Vec<Diagnostic>) {
+        diagnostics.iter().for_each(|diag| {
+            self.remove_message(&diag.message());
+            for child in &diag.children {
+                self.remove_message(&child.message());
+            }
+        });
+        if !self.messages.is_empty() {
+            panic!("Expected errors not reported: {:?}", self.messages);
+        }
+    }
+
+    /// Removes the first element of self.messages and checks if it matches msg.
+    fn remove_message(&mut self, msg: &str) {
+        if self.messages.remove_item(&String::from(msg)).is_none() {
+            panic!("Unexpected error: {} Expected: {:?}", msg, self.messages);
+        }
+    }
+}
+
+/// Scans the contents of test file for patterns of the form "//~ message"
+/// and returns a vector of the matching messages.
+fn load_errors(testfile: &Path) -> Vec<String> {
+    let rdr = BufReader::new(File::open(testfile).unwrap());
+    let tag = "//~";
+    rdr.lines()
+        .enumerate()
+        .filter_map(|(_line_num, line)| parse_expected(&line.unwrap(), &tag))
+        .collect()
+}
+
+/// Returns the message part of the pattern "//~ message" if there is a match, otherwise None.
+fn parse_expected(line: &str, tag: &str) -> Option<String> {
+    let start = line.find(tag)? + tag.len();
+    Some(String::from(line[start..].trim()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@
 #![feature(rustc_private)]
 #![feature(box_syntax)]
 #![feature(const_vec_new)]
+#![feature(vec_remove_item)]
 
-extern crate getopts;
 extern crate rustc;
-extern crate rustc_codegen_utils;
 extern crate rustc_driver;
+extern crate rustc_interface;
 extern crate rustc_metadata;
 extern crate rustc_target;
 extern crate syntax;
@@ -35,6 +35,7 @@ pub mod abstract_value;
 pub mod callbacks;
 pub mod constant_domain;
 pub mod environment;
+pub mod expected_errors;
 pub mod expression;
 pub mod interval_domain;
 pub mod k_limits;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@
 extern crate env_logger;
 extern crate mirai;
 extern crate rustc_driver;
+extern crate rustc_interface;
 
 use mirai::callbacks;
 use mirai::utils;
@@ -25,39 +26,41 @@ use std::env;
 use std::path::Path;
 
 fn main() {
-    rustc_driver::run(|| {
-        // Initialize loggers.
-        if env::var("RUST_LOG").is_ok() {
-            rustc_driver::init_rustc_env_logger();
-        }
-        if env::var("MIRAI_LOG").is_ok() {
-            let e = env_logger::Env::new()
-                .filter("MIRAI_LOG")
-                .write_style("MIRAI_LOG_STYLE");
-            env_logger::init_from_env(e);
-        }
+    // Initialize loggers.
+    if env::var("RUST_LOG").is_ok() {
+        rustc_driver::init_rustc_env_logger();
+    }
+    if env::var("MIRAI_LOG").is_ok() {
+        let e = env_logger::Env::new()
+            .filter("MIRAI_LOG")
+            .write_style("MIRAI_LOG_STYLE");
+        env_logger::init_from_env(e);
+    }
 
-        // Get command line arguments from environment and massage them a bit.
-        let mut command_line_arguments: Vec<_> = env::args().collect();
+    // Get command line arguments from environment and massage them a bit.
+    let mut command_line_arguments: Vec<_> = env::args().collect();
 
-        // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
-        // We're invoking the compiler programmatically, so we remove it if present.
-        if command_line_arguments.len() > 1
-            && Path::new(&command_line_arguments[1]).file_stem() == Some("rustc".as_ref())
-        {
-            command_line_arguments.remove(1);
-        }
+    // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
+    // We're invoking the compiler programmatically, so we remove it if present.
+    if command_line_arguments.len() > 1
+        && Path::new(&command_line_arguments[1]).file_stem() == Some("rustc".as_ref())
+    {
+        command_line_arguments.remove(1);
+    }
 
-        // Tell compiler where to find the std library and so on.
-        // The compiler relies on the standard rustc driver to tell it, so we have to do likewise.
-        command_line_arguments.push(String::from("--sysroot"));
-        command_line_arguments.push(utils::find_sysroot());
+    // Tell compiler where to find the std library and so on.
+    // The compiler relies on the standard rustc driver to tell it, so we have to do likewise.
+    command_line_arguments.push(String::from("--sysroot"));
+    command_line_arguments.push(utils::find_sysroot());
 
+    let result = rustc_driver::report_ices_to_stderr_if_any(move || {
         rustc_driver::run_compiler(
             &command_line_arguments,
-            box callbacks::MiraiCallbacks::default(),
+            &mut callbacks::MiraiCallbacks::default(),
             None, // use default file loader
             None, // emit output to default destination
         )
-    });
+    })
+    .and_then(|result| result);
+    std::process::exit(result.is_err() as i32);
 }

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -21,16 +21,11 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
-use syntax::errors::{Diagnostic, DiagnosticBuilder};
+use syntax::errors::DiagnosticBuilder;
 use syntax_pos;
 
 pub struct MirVisitorCrateContext<'a, 'b: 'a, 'tcx: 'b, E> {
-    /// A place where diagnostic messages can be buffered by the test harness.
-    pub buffered_diagnostics: &'a mut Vec<Diagnostic>,
-    /// A call back that the test harness can use to buffer the diagnostic message.
-    /// By default this just calls emit on the diagnostic.
-    pub emit_diagnostic: fn(&mut DiagnosticBuilder<'_>, buf: &mut Vec<Diagnostic>) -> (),
-    pub session: &'tcx Session,
+    pub session: &'b Session,
     pub tcx: TyCtxt<'b, 'tcx, 'tcx>,
     pub def_id: hir::def_id::DefId,
     pub mir: &'a mir::Mir<'tcx>,
@@ -41,9 +36,7 @@ pub struct MirVisitorCrateContext<'a, 'b: 'a, 'tcx: 'b, E> {
 
 /// Holds the state for the MIR test visitor.
 pub struct MirVisitor<'a, 'b: 'a, 'tcx: 'b, E> {
-    buffered_diagnostics: &'a mut Vec<Diagnostic>,
-    emit_diagnostic: fn(&mut DiagnosticBuilder<'_>, buf: &mut Vec<Diagnostic>) -> (),
-    session: &'tcx Session,
+    session: &'b Session,
     tcx: TyCtxt<'b, 'tcx, 'tcx>,
     def_id: hir::def_id::DefId,
     mir: &'a mir::Mir<'tcx>,
@@ -61,6 +54,8 @@ pub struct MirVisitor<'a, 'b: 'a, 'tcx: 'b, E> {
     preconditions: Vec<(AbstractValue, String)>,
     unwind_condition: Option<AbstractValue>,
     unwind_environment: Environment,
+
+    pub buffered_diagnostics: Vec<DiagnosticBuilder<'b>>,
 }
 
 /// A visitor that simply traverses enough of the MIR associated with a particular code body
@@ -70,8 +65,6 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         crate_context: MirVisitorCrateContext<'a, 'b, 'tcx, E>,
     ) -> MirVisitor<'a, 'b, 'tcx, E> {
         MirVisitor {
-            buffered_diagnostics: crate_context.buffered_diagnostics,
-            emit_diagnostic: crate_context.emit_diagnostic,
             session: crate_context.session,
             tcx: crate_context.tcx,
             def_id: crate_context.def_id,
@@ -90,6 +83,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             preconditions: Vec::new(),
             unwind_condition: None,
             unwind_environment: Environment::default(),
+
+            buffered_diagnostics: vec![],
         }
     }
 
@@ -105,6 +100,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         self.preconditions = Vec::new();
         self.unwind_condition = None;
         self.unwind_environment = Environment::default();
+    }
+
+    fn emit_diagnostic(&mut self, diagnostic_builder: DiagnosticBuilder<'b>) {
+        self.buffered_diagnostics.push(diagnostic_builder);
     }
 
     /// Use the local and global environments to resolve Path to an abstract value.
@@ -454,11 +453,11 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         );
         if self.check_for_errors {
             let span = self.current_span;
-            let mut err = self.session.struct_span_warn(
+            let err = self.session.struct_span_warn(
                 span,
                 "Inline assembly code cannot be analyzed by MIRAI. Unsoundly ignoring this.",
             );
-            (self.emit_diagnostic)(&mut err, &mut self.buffered_diagnostics);
+            self.emit_diagnostic(err);
         }
     }
 
@@ -612,10 +611,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             }
             if entry_cond_as_bool.unwrap_or(false) {
                 let span = self.current_span;
-                let mut err = self
+                let err = self
                     .session
                     .struct_span_warn(span, "Execution might panic.");
-                (self.emit_diagnostic)(&mut err, &mut self.buffered_diagnostics);
+                self.emit_diagnostic(err);
             } else {
                 self.preconditions.push((
                     self.current_environment
@@ -771,7 +770,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         for related_span in related_spans.iter() {
             err.span_note(**related_span, "related location");
         }
-        (self.emit_diagnostic)(&mut err, &mut self.buffered_diagnostics);
+        self.emit_diagnostic(err);
     }
 
     /// Updates the current state to reflect the effects of a normal return from the function call.
@@ -878,8 +877,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                 if path_cond.unwrap_or(false) && is_public(self.def_id, &self.tcx) {
                     // We always get to this call and we have to assume that the function will
                     // get called, so keep the message certain.
-                    let mut err = self.session.struct_span_warn(span, msg.as_str());
-                    (self.emit_diagnostic)(&mut err, &mut self.buffered_diagnostics);
+                    let err = self.session.struct_span_warn(span, msg.as_str());
+                    self.emit_diagnostic(err);
                 } else {
                     // We might get to this call, depending on the state at the call site.
 
@@ -894,8 +893,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
 
                     let mut maybe_message = String::from("possible error: ");
                     maybe_message.push_str(msg.as_str());
-                    let mut err = self.session.struct_span_warn(span, maybe_message.as_str());
-                    (self.emit_diagnostic)(&mut err, &mut self.buffered_diagnostics);
+                    let err = self.session.struct_span_warn(span, maybe_message.as_str());
+                    self.emit_diagnostic(err);
 
                     // We also push a precondition in both cases.
                     self.preconditions.push((
@@ -979,8 +978,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     if entry_cond_as_bool.is_some() && entry_cond_as_bool.unwrap() {
                         let error = msg.description();
                         let span = self.current_span;
-                        let mut error = self.session.struct_span_err(span, error);
-                        (self.emit_diagnostic)(&mut error, &mut self.buffered_diagnostics);
+                        let error = self.session.struct_span_err(span, error);
+                        self.emit_diagnostic(error);
                         // No need to push a precondition, the caller can never satisfy it.
                         return;
                     }
@@ -994,8 +993,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     // complain a bit.
                     let warning = format!("possible {}", msg.description());
                     let span = self.current_span;
-                    let mut warning = self.session.struct_span_warn(span, warning.as_str());
-                    (self.emit_diagnostic)(&mut warning, &mut self.buffered_diagnostics);
+                    let warning = self.session.struct_span_warn(span, warning.as_str());
+                    self.emit_diagnostic(warning);
                 }
 
                 // Regardless, it is still the caller's problem, so push a precondition.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28,13 +28,8 @@ use mirai::utils;
 use rustc_rayon::iter::IntoParallelIterator;
 use rustc_rayon::iter::ParallelIterator;
 use std::fs;
-use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
-use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
-use syntax::errors::{Diagnostic, DiagnosticBuilder};
 use tempdir::TempDir;
 
 // Run the tests in the tests/run-pass directory.
@@ -81,105 +76,39 @@ fn run_directory(directory_path: PathBuf) -> usize {
 // Runs the single test case found in file_name, using temp_dir_path as the place
 // to put compiler output, which for Mirai includes the persistent summary store.
 fn invoke_driver(file_name: String, temp_dir_path: String, sys_root: String) -> usize {
-    let f_name = file_name.clone();
-    let result = std::panic::catch_unwind(|| {
-        rustc_driver::run(|| {
-            let f_name = file_name.clone();
-            let command_line_arguments: Vec<String> = vec![
-                String::from("--crate-name mirai"),
-                file_name,
-                String::from("--crate-type"),
-                String::from("lib"),
-                String::from("-C"),
-                String::from("debuginfo=2"),
-                String::from("--out-dir"),
-                temp_dir_path,
-                String::from("--sysroot"),
-                sys_root,
-                String::from("-Z"),
-                String::from("span_free_formats"),
-                String::from("-Z"),
-                String::from("mir-emit-retag"),
-                String::from("-Z"),
-                String::from("mir-opt-level=0"),
-            ];
+    let command_line_arguments: Vec<String> = vec![
+        String::from("--crate-name mirai"),
+        file_name.clone(),
+        String::from("--crate-type"),
+        String::from("lib"),
+        String::from("-C"),
+        String::from("debuginfo=2"),
+        String::from("--out-dir"),
+        temp_dir_path,
+        String::from("--sysroot"),
+        sys_root,
+        String::from("-Z"),
+        String::from("span_free_formats"),
+        String::from("-Z"),
+        String::from("mir-emit-retag"),
+        String::from("-Z"),
+        String::from("mir-opt-level=0"),
+    ];
 
-            let call_backs = callbacks::MiraiCallbacks::with_buffered_diagnostics(
-                box move |diagnostics| {
-                    let mut expected_errors = ExpectedErrors::new(&f_name);
-                    expected_errors.check_messages(diagnostics)
-                },
-                |db: &mut DiagnosticBuilder, buf: &mut Vec<Diagnostic>| {
-                    db.cancel();
-                    db.clone().buffer(buf);
-                },
-            );
-
-            rustc_driver::run_compiler(
-                &command_line_arguments,
-                box call_backs,
-                None, // use default file loader
-                None, // emit output to default destination
-            )
-        })
+    let mut call_backs = callbacks::MiraiCallbacks::test_runner();
+    let result = std::panic::catch_unwind(move || {
+        rustc_driver::run_compiler(
+            &command_line_arguments,
+            &mut call_backs,
+            None, // use default file loader
+            None, // emit output to default destination
+        )
     });
-
     match result {
         Ok(_) => 0,
         Err(_) => {
-            println!("{} failed", f_name);
+            println!("{} failed", file_name);
             1
         }
     }
-}
-
-/// A collection of error strings that are expected for a test case.
-struct ExpectedErrors {
-    messages: Vec<String>,
-}
-
-impl ExpectedErrors {
-    /// Reads the file at the given path and scans it for instances of "//~ message".
-    /// Each message becomes an element of ExpectedErrors.messages.
-    pub fn new(path: &str) -> ExpectedErrors {
-        let exp = load_errors(&PathBuf::from_str(&path).unwrap());
-        ExpectedErrors { messages: exp }
-    }
-
-    /// Checks if the given set of diagnostics matches the expected diagnostics.
-    pub fn check_messages(&mut self, diagnostics: &Vec<Diagnostic>) {
-        diagnostics.iter().for_each(|diag| {
-            self.remove_message(&diag.message());
-            for child in &diag.children {
-                self.remove_message(&child.message());
-            }
-        });
-        if self.messages.len() > 0 {
-            panic!("Expected errors not reported: {:?}", self.messages);
-        }
-    }
-
-    /// Removes the first element of self.messages and checks if it matches msg.
-    fn remove_message(&mut self, msg: &str) {
-        if self.messages.remove_item(&String::from(msg)).is_none() {
-            panic!("Unexpected error: {} Expected: {:?}", msg, self.messages);
-        }
-    }
-}
-
-/// Scans the contents of test file for patterns of the form "//~ message"
-/// and returns a vector of the matching messages.
-fn load_errors(testfile: &Path) -> Vec<String> {
-    let rdr = BufReader::new(File::open(testfile).unwrap());
-    let tag = "//~";
-    rdr.lines()
-        .enumerate()
-        .filter_map(|(_line_num, line)| parse_expected(&line.unwrap(), &tag))
-        .collect()
-}
-
-/// Returns the message part of the pattern "//~ message" if there is a match, otherwise None.
-fn parse_expected(line: &str, tag: &str) -> Option<String> {
-    let start = line.find(tag)? + tag.len();
-    Some(String::from(line[start..].trim()))
 }


### PR DESCRIPTION
## Description

Updates MIRAI to use the new compiler plug-in interface for analyzers.

The new interface required a rewrite of the diagnostic handling code. In the rewrite the problem with duplicate messages because of the outer fixed point loop is now resolved. As a side effect, there is no output from the compiler until it has finished the run.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and validate.sh

