### PR TITLE
Replace roots in preconditions

### DIFF
--- a/tests/run-pass/array_index.rs
+++ b/tests/run-pass/array_index.rs
@@ -23,6 +23,7 @@ fn get_elem(arr: &[i32], i: usize) -> i32 {
 }
 
 pub fn main() {
+    let _x = 123; // make sure arr is not local 1
     let arr = [1, 2, 3];
     let elem = get_elem(&arr, 1);
     debug_assert!(elem == 2);

--- a/tests/run-pass/lazy_const_array.rs
+++ b/tests/run-pass/lazy_const_array.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that generates a LazyConst::Unevaluated reference to a constant array
+// A test that generates a ConstValue::Unevaluated reference to a constant array
 // and that checks that MIRAI finds the constant in the summary cache via the def_id
 
 const FOO: [u8; 3] = [1, 2, 3];


### PR DESCRIPTION
## Description

Paths that come from the summaries of called functions need to be refined (specialized) with the calling context. That means, among other things, that any references to the formal parameters of a called function must be updated to be references to the actual parameters (arguments) at its call site.

Two parts of this was already done: 
1) rerooting paths rooted by the result var of the callee with the target path of the return value in the caller (Path::replace_root) and
2) replacing paths like `par.x` with `loc.x` in cases where the actual argument corresponding to par was a reference `&loc`.

This PR generalizes the second bit by keeping track of the paths of all arguments (making up paths for constants) and replacing all references to parameters with references to the arguments. Such references occur in a number of places and requires traversal of paths, their sub paths, the expressions contained in paths and the paths contained in the expressions contained in paths.

Along the way, it also takes care of chasing down references so that paths that contain (a reference to) the location of local `x` where the value of local `x` is a reference to local `y` just refer directly to `y`. This canonicalization helps to keep down the number of paths we need to track in the environment, which helps performance and makes debugging less mind boggling.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Modified an existing test case to expose a bug where a callee parameter reference was looked up in the caller state as if it were a caller local.


