### PR TITLE
transfer heap effects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly
+- nightly-2019-03-23
 cache: cargo
 
 before_script:

--- a/src/abstract_domains.rs
+++ b/src/abstract_domains.rs
@@ -982,15 +982,22 @@ impl AbstractDomain {
             } => left
                 .refine_paths(environment)
                 .sub_overflows(&mut right.refine_paths(environment), result_type.clone()),
-            Expression::Variable { path, .. } => {
+            Expression::Variable { path, var_type } => {
                 if let Some(val) = environment.value_at(path) {
                     val.domain.clone()
                 } else {
                     let refined_path = path.refine_paths(environment);
+                    if refined_path == **path {
+                        return self.clone();
+                    }
                     if let Some(val) = environment.value_at(&refined_path) {
                         val.domain.clone()
                     } else {
-                        self.clone()
+                        Expression::Variable {
+                            path: box refined_path,
+                            var_type: var_type.clone(),
+                        }
+                        .into()
                     }
                 }
             }

--- a/tests/run-pass/array_copy.rs
+++ b/tests/run-pass/array_copy.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that arrays passed as parameters are copied
+
+fn f(arr: &mut [i32; 3]) {
+    arr[2] = 345;
+}
+
+pub fn g(_x: i32, arr: &mut [i32; 3]) {
+    let mut a = *arr;
+    f(&mut a);
+}
+
+pub fn main() {
+    let mut arr = [1, 2, 3];
+    g(0, &mut arr);
+    debug_assert!(arr[2] == 3);
+}

--- a/tests/run-pass/promoted_array.rs
+++ b/tests/run-pass/promoted_array.rs
@@ -9,15 +9,15 @@
 //todo: This is the only way I can find to generate such literals.
 // Find out for sure if there is no other way.
 
-pub fn main() {
-    let _x = f(b"x");
-//    debug_assert!(f(b"x")); //todo: enable this once path refinement has been implemented
+fn g(x: &[u8], y: &[u8]) -> bool {
+    x[0] == y[0]
 }
 
 fn f(value: &[u8]) -> bool {
     g(b"x", value)
 }
 
-fn g(x: &[u8], y: &[u8]) -> bool {
-    x[0] == y[0]
+pub fn main() {
+    assert!(f(b"x"));
 }
+


### PR DESCRIPTION
## Description

Heap allocated structured values are represented by sets of paths all rooted in 
 Path::AbstractHeapAddress instances. These roots correspond to abstracts values with expressions of the form  Expression::AbstractHeapAddress. These values can be referenced by expressions reachable from paths rooted in parameters, so they need to be in a summaries as well.

Consequently this PR provides logic for tracing through all of the memory reachable from parameters (and the return result) and building up a set of heap roots that are leaked to the caller. Any paths rooted by such abstract heap addresses are then added to the effects list.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
New test case.
