### PR TITLE
Report fewer related locations for promoted preconditions.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -523,6 +523,13 @@ impl AbstractValue {
         }
     }
 
+    /// Returns a clone of the value with the given span replacing its provenance.
+    pub fn replacing_provenance(&self, provenance: Span) -> AbstractValue {
+        let mut result = self.clone();
+        result.provenance = vec![provenance];
+        result
+    }
+
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "<<" to each element of the cross product of the concrete
     /// values or self and other.
@@ -643,7 +650,7 @@ impl AbstractValue {
         }
     }
 
-    /// Returns a clone of the value with the given span prepended to its provence.
+    /// Returns a clone of the value with the given span prepended to its provenance.
     pub fn with_provenance(&self, provenance: Span) -> AbstractValue {
         let mut result = self.clone();
         result.provenance.insert(0, provenance);


### PR DESCRIPTION
## Description

When a panic point in a function is promoted into a precondition (because the function containing it is not public) and made its caller's problem, the number of source locations that are reported quickly become overwhelming and confusing because it includes not just the "call stack" but also every location that leads to a condition that is on a path to the panic point.

This PR reduces the related locations to be just the call stack, so it will be the call to the function with the precondition that may not hold and then the location where the panic may occur in the called function (which itself may be a call to another function and so on).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
