### PR TITLE
Limit the number of diagnostics given for self recursive calls

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -523,6 +523,13 @@ impl AbstractValue {
         }
     }
 
+    /// Returns a clone of the value with the given span replacing its provenance.
+    pub fn replacing_provenance(&self, provenance: Span) -> AbstractValue {
+        let mut result = self.clone();
+        result.provenance = vec![provenance];
+        result
+    }
+
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "<<" to each element of the cross product of the concrete
     /// values or self and other.
@@ -643,7 +650,7 @@ impl AbstractValue {
         }
     }
 
-    /// Returns a clone of the value with the given span prepended to its provence.
+    /// Returns a clone of the value with the given span prepended to its provenance.
     pub fn with_provenance(&self, provenance: Span) -> AbstractValue {
         let mut result = self.clone();
         result.provenance.insert(0, provenance);

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -227,6 +227,15 @@ impl AbstractValue {
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
+    /// values resulting from applying "as target_type" to each element of the concrete values of self.
+    pub fn cast(&self, target_type: ExpressionType) -> AbstractValue {
+        AbstractValue {
+            provenance: self.provenance.clone(),
+            domain: self.domain.cast(target_type),
+        }
+    }
+
+    /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "/" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn div(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -75,6 +75,12 @@ pub enum Expression {
         right: Box<AbstractDomain>,
     },
 
+    /// An expression that is the operand cast to the target_type. as
+    Cast {
+        operand: Box<AbstractDomain>,
+        target_type: ExpressionType,
+    },
+
     /// An expression that is a compile time constant value, such as a numeric literal or a function.
     CompileTimeConstant(ConstantDomain),
 
@@ -341,6 +347,15 @@ impl ExpressionType {
         use self::ExpressionType::*;
         match self {
             I8 | I16 | I32 | I64 | I128 | Isize => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if this type is one of the unsigned integer types.
+    pub fn is_unsigned_integer(&self) -> bool {
+        use self::ExpressionType::*;
+        match self {
+            U8 | U16 | U32 | U64 | U128 | Usize => true,
             _ => false,
         }
     }

--- a/checker/tests/run-pass/relational_intervals.rs
+++ b/checker/tests/run-pass/relational_intervals.rs
@@ -27,3 +27,4 @@ pub fn t2(cond: bool) {
     verify!(bottom <= bottom); //~ possibly false assertion
 }
 
+pub fn main() {}


### PR DESCRIPTION
## Description

Self recursive functions that do not satisfy their own preconditions should not add additional preconditions to make the problem of their callers, since, well, they are their callers already.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
