### PR TITLE
Do one more join before widening

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -523,6 +523,13 @@ impl AbstractValue {
         }
     }
 
+    /// Returns a clone of the value with the given span replacing its provenance.
+    pub fn replacing_provenance(&self, provenance: Span) -> AbstractValue {
+        let mut result = self.clone();
+        result.provenance = vec![provenance];
+        result
+    }
+
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "<<" to each element of the cross product of the concrete
     /// values or self and other.
@@ -643,7 +650,7 @@ impl AbstractValue {
         }
     }
 
-    /// Returns a clone of the value with the given span prepended to its provence.
+    /// Returns a clone of the value with the given span prepended to its provenance.
     pub fn with_provenance(&self, provenance: Span) -> AbstractValue {
         let mut result = self.clone();
         result.provenance.insert(0, provenance);

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -227,6 +227,15 @@ impl AbstractValue {
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
+    /// values resulting from applying "as target_type" to each element of the concrete values of self.
+    pub fn cast(&self, target_type: ExpressionType) -> AbstractValue {
+        AbstractValue {
+            provenance: self.provenance.clone(),
+            domain: self.domain.cast(target_type),
+        }
+    }
+
+    /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "/" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn div(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -75,6 +75,12 @@ pub enum Expression {
         right: Box<AbstractDomain>,
     },
 
+    /// An expression that is the operand cast to the target_type. as
+    Cast {
+        operand: Box<AbstractDomain>,
+        target_type: ExpressionType,
+    },
+
     /// An expression that is a compile time constant value, such as a numeric literal or a function.
     CompileTimeConstant(ConstantDomain),
 
@@ -341,6 +347,15 @@ impl ExpressionType {
         use self::ExpressionType::*;
         match self {
             I8 | I16 | I32 | I64 | I128 | Isize => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if this type is one of the unsigned integer types.
+    pub fn is_unsigned_integer(&self) -> bool {
+        use self::ExpressionType::*;
+        match self {
+            U8 | U16 | U32 | U64 | U128 | Usize => true,
             _ => false,
         }
     }

--- a/checker/tests/benchmarks/get_elem_values.rs
+++ b/checker/tests/benchmarks/get_elem_values.rs
@@ -1,0 +1,137 @@
+use std::convert::TryFrom;
+
+struct Foo<'a> {
+    constant_value_cache: &'a mut Bar,
+}
+
+struct Bar {}
+
+impl Bar {
+    fn get_i128_for(&self, _v: i128) -> i32 {
+        0
+    }
+    fn get_u128_for(&self, _v: u128) -> i32 {
+        0
+    }
+}
+
+impl<'a> Foo<'a> {
+    fn get_element_values(
+        &mut self,
+        bytes: &[u8],
+        is_signed_type: bool,
+        bytes_per_elem: usize,
+        len: Option<u128>,
+    ) -> Vec<i32> {
+        assert!(
+            bytes_per_elem == 1
+                || bytes_per_elem == 2
+                || bytes_per_elem == 4
+                || bytes_per_elem == 8
+                || bytes_per_elem == 16
+        );
+        if let Some(len) = len {
+            if (len * (bytes_per_elem as u128)) != u128::try_from(bytes.len()).unwrap() {
+                unimplemented!()
+            }
+        }
+        let mut result = vec![];
+        for i in 0..bytes.len() / bytes_per_elem {
+            let j = i * bytes_per_elem;
+            if is_signed_type {
+                result.push(
+                    self.constant_value_cache
+                        .get_i128_for(match bytes_per_elem {
+                            1 => i128::from(i8::from_le_bytes([bytes[j]])),
+                            2 => i128::from(i16::from_le_bytes([bytes[j], bytes[j + 1]])),
+                            4 => i128::from(i32::from_le_bytes([
+                                bytes[j],
+                                bytes[j + 1],
+                                bytes[j + 2],
+                                bytes[j + 3],
+                            ])),
+                            8 => i128::from(i64::from_le_bytes([
+                                bytes[j],
+                                bytes[j + 1],
+                                bytes[j + 2],
+                                bytes[j + 3],
+                                bytes[j + 4],
+                                bytes[j + 5],
+                                bytes[j + 6],
+                                bytes[j + 7],
+                            ])),
+                            16 => i128::from_le_bytes([
+                                bytes[j],
+                                bytes[j + 1],
+                                bytes[j + 2],
+                                bytes[j + 3],
+                                bytes[j + 4],
+                                bytes[j + 5],
+                                bytes[j + 6],
+                                bytes[j + 7],
+                                bytes[j + 8],
+                                bytes[j + 9],
+                                bytes[j + 10],
+                                bytes[j + 11],
+                                bytes[j + 12],
+                                bytes[j + 13],
+                                bytes[j + 14],
+                                bytes[j + 15],
+                            ]),
+                            _ => unreachable!(),
+                        })
+                        .clone()
+                        .into(),
+                );
+            } else {
+                result.push(
+                    self.constant_value_cache
+                        .get_u128_for(match bytes_per_elem {
+                            1 => u128::from(u8::from_le_bytes([bytes[j]])),
+                            2 => u128::from(u16::from_le_bytes([bytes[j], bytes[j + 1]])),
+                            4 => u128::from(u32::from_le_bytes([
+                                bytes[j],
+                                bytes[j + 1],
+                                bytes[j + 2],
+                                bytes[j + 3],
+                            ])),
+                            8 => u128::from(u64::from_le_bytes([
+                                bytes[j],
+                                bytes[j + 1],
+                                bytes[j + 2],
+                                bytes[j + 3],
+                                bytes[j + 4],
+                                bytes[j + 5],
+                                bytes[j + 6],
+                                bytes[j + 7],
+                            ])),
+                            16 => u128::from_le_bytes([
+                                bytes[j],
+                                bytes[j + 1],
+                                bytes[j + 2],
+                                bytes[j + 3],
+                                bytes[j + 4],
+                                bytes[j + 5],
+                                bytes[j + 6],
+                                bytes[j + 7],
+                                bytes[j + 8],
+                                bytes[j + 9],
+                                bytes[j + 10],
+                                bytes[j + 11],
+                                bytes[j + 12],
+                                bytes[j + 13],
+                                bytes[j + 14],
+                                bytes[j + 15],
+                            ]),
+                            _ => unreachable!(),
+                        })
+                        .clone()
+                        .into(),
+                );
+            }
+        }
+        result
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/relational_intervals.rs
+++ b/checker/tests/run-pass/relational_intervals.rs
@@ -27,3 +27,4 @@ pub fn t2(cond: bool) {
     verify!(bottom <= bottom); //~ possibly false assertion
 }
 
+pub fn main() {}

--- a/checker/tests/run-pass/weak_update_heap.rs
+++ b/checker/tests/run-pass/weak_update_heap.rs
@@ -26,13 +26,8 @@ fn do_join(cond: bool) {
         c.f = 3;
         verify!(c.f == 3);
     }
-//    todo: enable the next two asserts when the fixed point logic gets better
-//    (if there are two asserts the second shares the unwind block of the first and does
-//    a backwards branch to it, leading to a fixed point loop that widens and thus loses
-//    precision).
-//    verify!(a.f == if cond { 3 } else { 1 });
-//    verify!(b.f == if cond { 2 } else { 3 });
-//    todo: #32 enable this when the simplifier gets better
-//    verify!(if cond { a.f == 3 } else { b.f == 3 });
-//    verify!(if !cond { a.f == 1 } else { b.f == 2 });
+    verify!(a.f == if cond { 3 } else { 1 });
+    verify!(b.f == if cond { 2 } else { 3 });
+    verify!(if cond { a.f == 3 } else { b.f == 3 });
+    verify!(if !cond { a.f == 1 } else { b.f == 2 });
 }


### PR DESCRIPTION
## Description

It turns out that one more iteration with joining is needed before widening if non loopy code is to avoid widening in all situations. See the comments in the code for more details.

This extra iteration exposes a problem with non linear behavior when there are lots of basic blocks with complicated path conditions. Rather than try to fix that, I've just fixed the one function in Mirai where this becomes a problem. The original version of the function has been captured in a new benchmarks directory for future reference.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Uncommented code in an existing test that goes wrong without this fix.

