### PR TITLE
Add methods to SMT solver trait.

### DIFF
--- a/checker/src/smt_solver.rs
+++ b/checker/src/smt_solver.rs
@@ -30,6 +30,14 @@ pub trait SmtSolver<SmtExpressionType> {
     /// Translate the MIRAI expression into a corresponding expression for the Solver.
     fn get_as_smt_predicate(&mut self, mirai_expression: &Expression) -> SmtExpressionType;
 
+    /// Provides a string that contains a set of variable assignments that satisfied the
+    /// assertions in the solver. Can only be called after self.solve return SmtResult::Satisfiable.
+    fn get_model_as_string(&self) -> String;
+
+    /// Provides a string that contains a listing of all of the definitions and assertions that
+    /// have been added to the solver.
+    fn get_solver_state_as_string(&self) -> String;
+
     /// Create a nested context. When a matching backtrack is called, the current context (state)
     /// of the solver will be restored to what it was when this was called.
     fn set_backtrack_position(&mut self);
@@ -62,6 +70,14 @@ impl SmtSolver<()> for SolverStub {
     fn backtrack(&mut self) {}
 
     fn get_as_smt_predicate(&mut self, _mirai_expression: &Expression) {}
+
+    fn get_model_as_string(&self) -> String {
+        String::from("not implemented")
+    }
+
+    fn get_solver_state_as_string(&self) -> String {
+        String::from("not implemented")
+    }
 
     fn set_backtrack_position(&mut self) {}
 


### PR DESCRIPTION
## Description

When debugging problems with SMT solvers it is helpful to get string representations of the solver's state and of the models that satisfy the state.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
Used in the Z3 solver hookup.
