### PR TITLE
Introduce a form of time-out to prevent MIRAI from taking too long.

### DIFF
--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -14,3 +14,6 @@ pub const MAX_PATH_LENGTH: usize = 10;
 
 /// The point at which diverging summaries experience exponential blowup right now.
 pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
+
+/// The maximum number of seconds that MIRAI is willing to analyze a function body for.
+pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -42,6 +42,11 @@ use std::ops::Deref;
 ///    with explicit contract functions.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct Summary {
+    /// The number of seconds that the analyzer used to construct this summary.
+    /// If it is >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY then this summary is not definitive
+    /// because the analyzer will omit it from the outer fixed point loop.
+    pub analysis_time_in_seconds: u64,
+
     // Conditions that should hold prior to the call.
     // Callers should substitute parameter values with argument values and simplify the results
     // under the current path condition. Any values that do not simplify to true will require the
@@ -89,6 +94,7 @@ pub struct Summary {
 /// Constructs a summary of a function body by processing state information gathered during
 /// abstract interpretation of the body.
 pub fn summarize(
+    analysis_time_in_seconds: u64,
     argument_count: usize,
     exit_environment: &Environment,
     preconditions: &[(AbstractValue, String)],
@@ -108,6 +114,7 @@ pub fn summarize(
     unwind_side_effects.sort();
 
     Summary {
+        analysis_time_in_seconds,
         preconditions,
         result: result.cloned(),
         side_effects,


### PR DESCRIPTION
## Description

A few functions consume most of the analysis time and makes the overall analysis time for MIRAI on MIRAI unacceptably long. For the time being, just ignore (and log) functions that take longer than 3 seconds to analyze.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
