### PR TITLE
Do not warn that unreachable blocks may actually be reachable

### DIFF
--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -645,32 +645,11 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
     /// Indicates a terminator that can never be reached.
     fn visit_unreachable(&mut self) {
         debug!("default visit_unreachable()");
-        // Complain if we are quite sure control gets here.
-        if self.check_for_errors {
-            let mut entry_cond_as_bool =
-                self.current_environment.entry_condition.as_bool_if_known();
-            if entry_cond_as_bool.is_none() {
-                let entry_cond_val = &self.current_environment.entry_condition.clone();
-                entry_cond_as_bool = self.solve_condition(entry_cond_val);
-            }
-            if entry_cond_as_bool.unwrap_or(false)
-                || self.preconditions.len() >= k_limits::MAX_INFERRED_PRECONDITIONS
-            {
-                let span = self.current_span;
-                let err = self
-                    .session
-                    .struct_span_warn(span, "Execution might panic.");
-                self.emit_diagnostic(err);
-            } else {
-                self.preconditions.push((
-                    self.current_environment
-                        .entry_condition
-                        .not(None)
-                        .replacing_provenance(self.current_span),
-                    String::from("Execution might panic."),
-                ));
-            }
-        }
+        // An unreachable terminator is the compiler's way to tell us that this block will
+        // actually never be reached because the type system says so.
+        // Why it is necessary in such a case to actually generate unreachable code is something
+        // to ponder, but it is not our concern.
+        // We don't have to do anything more here because this block precedes no other block.
     }
 
     /// Drop the Place

--- a/checker/tests/run-pass/crate_traversal.rs
+++ b/checker/tests/run-pass/crate_traversal.rs
@@ -38,7 +38,7 @@ pub unsafe fn test1() {
     enum Void {}
     union A { a: (), v: Void }
     let a = A { a: () };
-    match a.v { //~  Execution might panic.
+    match a.v {
     }
 }
 


### PR DESCRIPTION
## Description

The unreachable terminator in MIR is something MIRAI should assume rather than verify since the type system guarantees that blocks terminated by unreachable are never reached.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
