### PR TITLE
Turn call to core.slice.len into lookup of ArrayLength path.

### DIFF
--- a/checker/tests/run-pass/match_guard.rs
+++ b/checker/tests/run-pass/match_guard.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a match guard to check that an index is within bounds
+
+pub enum Path {
+    LocalVariable { ordinal: usize },
+}
+
+pub struct AbstractValue {}
+
+impl Path {
+    pub fn refine_parameters(&self, arguments: &[(i32, AbstractValue)]) -> i32 {
+        match self {
+            Path::LocalVariable { ordinal } if 0 < *ordinal && *ordinal <= arguments.len() => {
+                arguments[*ordinal - 1].0 //~ possible attempt to subtract with overflow
+                                          //~ possible array index out of bounds
+            }
+            _ => 0,
+        }
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

The core.slice.len function is particularly problematic for MIRAI in its current state. Firstly it is a standard method, and building summaries for the standard library is still a ways away (see #2). Secondly, it is a trait method so there is no one body that provides a summary for it. Thirdly, it is generic, which is something that we generally don't need to support. Lastly, it is actually impossible to write a summary for it in Rust itself, since there is not syntactic operator that corresponds to getting the length of a slice.

Unfortunately there is one place in the MIRAI code base where using this function in unavoidable. So, in order to get MIRAI to check MIRAI, this pull requests add special handling for calls to this function. In effect, the summary for this call is now built into MIRAI.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Note that this PR by itself is not enough for the test case to have no diagnostics.
