### PR TITLE
Keep track of references as distinct types of values from non primitives

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -94,6 +94,17 @@ impl<'a> From<&TyKind<'a>> for ExpressionType {
             TyKind::Uint(ast::UintTy::U128) => ExpressionType::U128,
             TyKind::Float(ast::FloatTy::F32) => ExpressionType::F32,
             TyKind::Float(ast::FloatTy::F64) => ExpressionType::F64,
+            TyKind::Closure(..)
+            | TyKind::Dynamic(..)
+            | TyKind::Foreign(..)
+            | TyKind::FnDef(..)
+            | TyKind::FnPtr(..)
+            | TyKind::Generator(..)
+            | TyKind::GeneratorWitness(..)
+            | TyKind::RawPtr(..)
+            | TyKind::Ref(..)
+            | TyKind::Slice(..)
+            | TyKind::Str => ExpressionType::Reference,
             _ => ExpressionType::NonPrimitive,
         }
     }

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -276,7 +276,7 @@ impl Expression {
         match self {
             Expression::Top => NonPrimitive,
             Expression::Bottom => NonPrimitive,
-            Expression::AbstractHeapAddress(_) => NonPrimitive,
+            Expression::AbstractHeapAddress(_) => Reference,
             Expression::Add { left, .. } => left.expression.infer_type(),
             Expression::AddOverflows { .. } => Bool,
             Expression::And { .. } => Bool,
@@ -300,8 +300,8 @@ impl Expression {
             Expression::Neg { operand } => operand.expression.infer_type(),
             Expression::Not { .. } => Bool,
             Expression::Or { .. } => Bool,
-            Expression::Offset { .. } => NonPrimitive,
-            Expression::Reference(_) => NonPrimitive,
+            Expression::Offset { .. } => Reference,
+            Expression::Reference(_) => Reference,
             Expression::Rem { left, .. } => left.expression.infer_type(),
             Expression::Shl { left, .. } => left.expression.infer_type(),
             Expression::ShlOverflows { .. } => Bool,
@@ -377,6 +377,7 @@ pub enum ExpressionType {
     I128,
     Isize,
     NonPrimitive,
+    Reference,
     U8,
     U16,
     U32,
@@ -392,14 +393,14 @@ impl From<&ConstantDomain> for ExpressionType {
             ConstantDomain::Bottom => NonPrimitive,
             ConstantDomain::Char(..) => Char,
             ConstantDomain::False => Bool,
-            ConstantDomain::Function { .. } => NonPrimitive,
+            ConstantDomain::Function { .. } => Reference,
             ConstantDomain::I128(..) => I128,
             ConstantDomain::F64(..) => F64,
             ConstantDomain::F32(..) => F32,
-            ConstantDomain::Str(..) => NonPrimitive,
+            ConstantDomain::Str(..) => Reference,
             ConstantDomain::True => Bool,
             ConstantDomain::U128(..) => U128,
-            ConstantDomain::Unimplemented => NonPrimitive,
+            ConstantDomain::Unimplemented => Reference,
         }
     }
 }
@@ -453,7 +454,8 @@ impl ExpressionType {
             U64 => 64,
             U128 => 128,
             Usize => 64,
-            _ => 64,
+            Reference => 128,
+            NonPrimitive => 128,
         }
     }
 


### PR DESCRIPTION
## Description

Non primitive values that are actually references to other structures need to be handled differently from structures when copying. In the latter case, all of the paths that are rooted in the value are copied, whereas in the former case only the reference should be copied.

To make this possible, a new ExpressionType case, Reference, is introduced by this PR. With that in hand, a few other places become more precise as well and the Z3 translation is facilitated.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh

match_guard.rs exercises references and this PR is necessary for eventually making that test case pass.




