### PR TITLE
Add precondition macros to MIRAI Annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 0.0.1",
+ "mirai-annotations 0.1.0",
  "rpds 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "0.0.1"
+version = "0.1.0"
 
 [[package]]
 name = "nodrop"

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/README.md
+++ b/annotations/README.md
@@ -6,8 +6,9 @@ They add value by allowing [MIRAI](https://github.com/facebookexperimental/MIRAI
 * distinguish between conditions that it should assume as true and conditions that it should verify
 * check conditions at compile time that should not be checked at runtime because they are too expensive
  
-From this it follows that we have two families of macros:
+From this it follows that we have three families of macros:
 * assume macros
+* precondition macros (like assume where defined and like verify for callers)
 * verify macros
 
 Each of these has three kinds
@@ -23,6 +24,13 @@ Additionally, the runtime checked kinds provides eq and ne varieties, leaving us
 * debug_checked_assume!
 * debug_checked_assume_eq!
 * debug_checked_assume_ne!
+* precondition!
+* checked_precondition!
+* checked_precondition_eq!
+* checked_precondition_ne!
+* debug_checked_precondition!
+* debug_checked_precondition_eq!
+* debug_checked_precondition_ne!
 * verify!
 * checked_verify!
 * checked_verify_eq!

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -5,6 +5,23 @@
 
 // A set of macros and functions to use for annotating source files that are being checked with MIRAI
 
+/// Equivalent to a no op when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// prove it to be false.
+#[macro_export]
+macro_rules! assume {
+    ($condition:expr) => {
+        if cfg!(mirai) {
+            mirai_annotations::mirai_assume($condition)
+        }
+    };
+    ($condition:expr, $($arg:tt)*) => {
+        if cfg!(mirai) {
+            mirai_annotations::mirai_assume($condition);
+        }
+    };
+}
+
 /// Equivalent to the standard assert! when used with an unmodified Rust compiler.
 /// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
 /// prove it to be false.
@@ -132,18 +149,168 @@ macro_rules! debug_checked_assume_ne {
 }
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
-/// prove it to be false.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
 #[macro_export]
-macro_rules! assume {
+macro_rules! precondition {
     ($condition:expr) => {
         if cfg!(mirai) {
-            mirai_annotations::mirai_assume($condition)
+            mirai_annotations::mirai_precondition($condition)
         }
     };
     ($condition:expr, $($arg:tt)*) => {
         if cfg!(mirai) {
-            mirai_annotations::mirai_assume($condition);
+            mirai_annotations::mirai_precondition($condition);
+        }
+    };
+}
+
+/// Equivalent to the standard assert! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
+#[macro_export]
+macro_rules! checked_precondition {
+    ($condition:expr) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($condition)
+        } else {
+            assert!($condition);
+        }
+    );
+    ($condition:expr, $($arg:tt)*) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($condition);
+        } else {
+            assert!($condition, $($arg)*);
+        }
+    );
+}
+
+/// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
+#[macro_export]
+macro_rules! checked_precondition_eq {
+    ($left:expr, $right:expr) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left == $right)
+        } else {
+            assert_eq!($left, $right);
+        }
+    );
+    ($left:expr, $right:expr, $($arg:tt)*) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left == $right);
+        } else {
+            assert_eq!($left, $right, $($arg)*);
+        }
+    );
+}
+
+/// Equivalent to the standard assert_ne! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
+#[macro_export]
+macro_rules! checked_precondition_ne {
+    ($left:expr, $right:expr) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left != $right)
+        } else {
+            assert_ne!($left, $right);
+        }
+    );
+    ($left:expr, $right:expr, $($arg:tt)*) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left != $right);
+        } else {
+            assert_ne!($left, $right, $($arg)*);
+        }
+    );
+}
+
+/// Equivalent to the standard debug_assert! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
+#[macro_export]
+macro_rules! debug_checked_precondition {
+    ($condition:expr) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($condition)
+        } else {
+            debug_assert!($condition);
+        }
+    );
+    ($condition:expr, $($arg:tt)*) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($condition);
+        } else {
+            debug_assert!($condition, $($arg)*);
+        }
+    );
+}
+
+/// Equivalent to the standard debug_assert_eq! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
+#[macro_export]
+macro_rules! debug_checked_precondition_eq {
+    ($left:expr, $right:expr) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left == $right)
+        } else {
+            debug_assert_eq!($left, $right);
+        }
+    );
+    ($left:expr, $right:expr, $($arg:tt)*) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left == $right);
+        } else {
+            debug_assert_eq!($left, $right, $($arg)*);
+        }
+    );
+}
+
+/// Equivalent to the standard debug_assert_ne! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// point where it appears in a function, but to also add it a precondition that must
+/// be verified by the caller of the function.
+#[macro_export]
+macro_rules! debug_checked_precondition_ne {
+    ($left:expr, $right:expr) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left != $right)
+        } else {
+            debug_assert_ne!($left, $right);
+        }
+    );
+    ($left:expr, $right:expr, $($arg:tt)*) => (
+        if cfg!(mirai) {
+            mirai_annotations::mirai_precondition($left != $right);
+        } else {
+            debug_assert_ne!($left, $right, $($arg)*);
+        }
+    );
+}
+
+/// Equivalent to a no op when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// emit a diagnostic unless it can prove it to be true.
+#[macro_export]
+macro_rules! verify {
+    ($condition:expr) => {
+        if cfg!(mirai) {
+            mirai_annotations::mirai_verify($condition)
+        }
+    };
+    ($condition:expr, $($arg:tt)*) => {
+        if cfg!(mirai) {
+            mirai_annotations::mirai_verify($condition, $message);
         }
     };
 }
@@ -253,23 +420,8 @@ macro_rules! debug_checked_verify_ne {
     );
 }
 
-/// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
-/// emit a diagnostic unless it can prove it to be true.
-#[macro_export]
-macro_rules! verify {
-    ($condition:expr) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_verify($condition)
-        }
-    };
-    ($condition:expr, $($arg:tt)*) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_verify($condition, $message);
-        }
-    };
-}
-
 pub fn mirai_assume(_condition: bool) {}
+
+pub fn mirai_precondition(_condition: bool) {}
 
 pub fn mirai_verify(_condition: bool) {}

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -55,6 +55,8 @@ pub struct Summary {
     // The string value bundled with the condition is the message that details what would go
     // wrong at runtime if the precondition is not satisfied by the caller.
     pub preconditions: Vec<(AbstractValue, String)>,
+    //todo: #124 add another string that provides provenance and or default documentation
+    // that can be used across crates.
 
     // If the function returns a value, this summarizes what is known statically of the return value.
     // Callers should substitute parameter values with argument values and simplify the result

--- a/checker/tests/run-pass/inferred_precondition.rs
+++ b/checker/tests/run-pass/inferred_precondition.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that infers a precondition and report a failure to satisfy it.
+
+pub fn main() {
+    let mut a = [1, 2];
+    foo(&mut a, 3); //~ array index out of bounds
+}
+
+fn foo(arr: &mut [i32], i: usize) {
+    arr[i] = 12; //~ related location
+}
+

--- a/checker/tests/run-pass/precondition.rs
+++ b/checker/tests/run-pass/precondition.rs
@@ -4,14 +4,24 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that infers a precondition and report a failure to satisfy it.
+// A test that declares a precondition and report a failure to satisfy it.
+
+#[macro_use]
+extern crate mirai_annotations;
 
 pub fn main() {
     let mut a = [1, 2];
-    foo(&mut a, 3); //~ array index out of bounds
+    foo(&mut a, 3); //~ unsatisfied precondition
 }
 
-fn foo(arr: &mut [i32], i: usize) {
-    arr[i] = 12; //~ related location
+fn foo(arr: &mut [i32; 2], i: usize) {
+    precondition!(i < 2); //~ related location
+    arr[i] = 12;
 }
 
+pub fn bad_foo(arr: &mut [i32; 2], i: usize) {
+    if i > 0 {
+        precondition!(i < 2); //~ preconditions should be reached unconditionally
+    }
+    arr[i] = 12; //~ possible array index out of bounds
+}


### PR DESCRIPTION
## Description

Preconditions are assumptions inside the functions that contain them, but need to be verified by callers of the functions that contain them. This makes them distinct from assume and verify and requires a separate set of macros to be added to mirai-annotations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
New test case, modified old test case.

