### PR TITLE
Treat the assert! macro as a way of stating a precondition.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -183,6 +183,6 @@ impl rustc_driver::Callbacks for MiraiCallbacks {
             }
             info!("done with analysis");
         });
-        false // Do not proceed to code generation. MIRAI is only a checker.
+        true // Although MIRAI is only a checker we still need code generation for build scripts.
     }
 }

--- a/checker/tests/run-pass/assert_as_precondition.rs
+++ b/checker/tests/run-pass/assert_as_precondition.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses assert! to declares a precondition and report a failure to satisfy it.
+
+pub fn main() {
+    let mut a = [1, 2];
+    foo(&mut a, 3); //~ possible error: assertion failed: i < 2
+}
+
+fn foo(arr: &mut [i32; 2], i: usize) {
+    assert!(i < 2); //~ related location
+    arr[i] = 12;
+}


### PR DESCRIPTION
## Description

The panic! macro, sometimes in the guise of assert!, is sometimes (perhaps even often) used to document preconditions in existing code (in the wild, a.k.a. crates.io).

Given a diagnostic for every panic! call results in too many false positives, so they are now silently promoted to preconditions. These preconditions are in turn silently promoted by callers until the caller is public, in which case it is loudly promoted.

This still results in false positives, but this seems the best trade-off between false positives and false negatives that can be achieved without programmer annotation or very sophisticated whole program analysis.

Also in this PR, a small change that allows code generation to happen after MIRAI is done with its analysis. Although it is a non-goal for MIRAI to be the normal compiler to use in every day builds, it turns out that build scripts (build.rs) need to be compiled and run as part of a MIRAI build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
