### PR TITLE
Tweak fixed point loop.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -7,10 +7,9 @@ use crate::abstract_domains::{self, AbstractDomain};
 use crate::constant_domain::ConstantDomain;
 use crate::environment::Environment;
 use crate::expression::{Expression, ExpressionType};
-use crate::k_limits;
 
 use log::debug;
-use mirai_annotations::{assume, checked_assume};
+use mirai_annotations::assume;
 use rustc::hir::def_id::DefId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -497,7 +496,7 @@ impl AbstractValue {
         provenance.extend_from_slice(&self.provenance);
         AbstractValue {
             provenance,
-            domain: self.domain.refine_with(&path_condition.domain),
+            domain: self.domain.refine_with(&path_condition.domain, 0),
         }
     }
 
@@ -885,7 +884,7 @@ impl Path {
                 } else {
                     qualifier.replace_root(old_root, new_root)
                 };
-                checked_assume!(new_qualifier.path_length() <= k_limits::MAX_PATH_LENGTH);
+                assume!(new_qualifier.path_length() < 1_000_000_000); // We'll run out of memory long before this happens
                 Path::QualifiedPath {
                     length: new_qualifier.path_length() + 1,
                     qualifier: box new_qualifier,

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -124,7 +124,7 @@ impl rustc_driver::Callbacks for MiraiCallbacks {
                             constant_value_cache: &mut constant_value_cache,
                             smt_solver: &mut smt_solver,
                         });
-                        let (r, analysis_time_in_seconds) = mir_visitor.visit_body();
+                        let (r, analysis_time_in_seconds) = mir_visitor.visit_body(&name);
                         if analysis_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
                             // This body is beyond MIRAI for now
                             warn!(
@@ -184,6 +184,7 @@ impl rustc_driver::Callbacks for MiraiCallbacks {
             }
             info!("done with analysis");
         });
-        true // Although MIRAI is only a checker we still need code generation for build scripts.
+        !self.test_run // Although MIRAI is only a checker we still need code generation for build scripts.
+                       // We avoid code gen for test cases because LLVM is not used in a thread safe manner.
     }
 }

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -6,14 +6,17 @@
 // Somewhat arbitrary constants used to limit things in the abstract interpreter that may
 // take too long or use too much memory.
 
+/// The maximum number of seconds that MIRAI is willing to analyze a function body for.
+pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
+
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
-
-/// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
-pub const MAX_PATH_LENGTH: usize = 10;
 
 /// The point at which diverging summaries experience exponential blowup right now.
 pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
 
-/// The maximum number of seconds that MIRAI is willing to analyze a function body for.
-pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
+/// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
+pub const MAX_PATH_LENGTH: usize = 10;
+
+/// Refining values with a path condition that is a really big expression leads to exponential blow up.
+pub const MAX_REFINE_DEPTH: usize = 9;

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(vec_remove_item)]
 
 extern crate rustc;
+extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_metadata;

--- a/checker/tests/run-pass/for.rs
+++ b/checker/tests/run-pass/for.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a loop over an iterator.
+
+pub fn to_be(dst: &mut [u16]) {
+    for v in dst.iter_mut() {
+        *v = v.to_be();
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a loop counter incremented via a for-in.
+
+pub fn foo(n: usize) {
+    for ordinal in 2..=n {
+        assert!(ordinal - 1 >= 1); //~ possible attempt to subtract with overflow
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/while.rs
+++ b/checker/tests/run-pass/while.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that increments a counter inside a while loop
+
+pub fn foo(n: usize) {
+    let mut i: usize = 0;
+    while i < n {
+        i += 1;
+    }
+}
+
+pub fn bar(n: usize) {
+    let mut i: usize = 10;
+    while i > n {
+        i -= 1;
+    }
+}
+
+pub fn main() {}

--- a/validate.sh
+++ b/validate.sh
@@ -21,4 +21,4 @@ cd ..; cargo build
 cargo uninstall mirai || true
 cargo install --debug --path ./checker
 cargo clean -p mirai
-time RUSTC_WRAPPER=mirai RUST_BACKTRACE=1 cargo build --lib -p mirai
+time RUSTC_WRAPPER=mirai RUST_BACKTRACE=1 MIRAI_LOG=warn cargo build --lib -p mirai


### PR DESCRIPTION
## Description

The real change here is that the basic block list is now sorted so that for non loopy code a block is always analyzed after its predecessors. This speeds things up and makes widening better behaved (widening will come in a later PR).

However, while debugging this, I found an omission in the fixed point algorithm that stopped path conditions from propagating via blocks that do nothing of interest to MIRAI (other than propagating). Fixing this makes things more precise and making things more precise makes them more costly. Consequently there is now more aggressive time outs and another k-limit. Moreover a function whose analysis blows up, has been split in two.

Some of these regressions will be clawed back as I fix joining (in my next PR) and implement widening (in the PR after that).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Also ran MIRAI on some of the crates it depends on.
