### PR TITLE
Support unconditional join operations.

### DIFF
--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -386,7 +386,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         // in_state[bb] is now complete for every basic block bb in the body.
         if iteration_count > 6 {
             warn!(
-                "Fixed point loop took {} iterations for {}, now checking for errors.",
+                "Fixed point loop took {} iterations for {}.",
                 iteration_count, function_name
             );
         }

--- a/checker/tests/run-pass/relational_intervals.rs
+++ b/checker/tests/run-pass/relational_intervals.rs
@@ -23,7 +23,7 @@ pub fn t2(cond: bool) {
     let raw = &cond as *const _;
     let bottom = interval - (raw as usize); //~ possible attempt to subtract with overflow
     verify!((interval as isize) > -2);
-    verify!(top < 3); //~ possibly false assertion
+    verify!(top < 3);
     verify!(bottom <= bottom); //~ possibly false assertion
 }
 

--- a/checker/tests/run-pass/while.rs
+++ b/checker/tests/run-pass/while.rs
@@ -9,14 +9,14 @@
 pub fn foo(n: usize) {
     let mut i: usize = 0;
     while i < n {
-        i += 1;
+        i += 1; //~ possible attempt to add with overflow
     }
 }
 
 pub fn bar(n: usize) {
     let mut i: usize = 10;
     while i > n {
-        i -= 1;
+        i -= 1; //~ possible attempt to subtract with overflow
     }
 }
 


### PR DESCRIPTION
## Description

The normal case for a join is when two branches that split on a condition come together again. The result of such a join can be expressed as a conditional expression.  Sometimes, however, two unconditional branches join together. This can happen for an infinite loop, where the dominator of the loop anchor unconditionally branches to the anchor and the backward branch also unconditionally branches to the anchor. While such loops can be expected to be rare in source form, they do show up during abstract interpretation because the loop exit condition may evaluate to false for the first few (precise) iterations of the loop and thus the backwards branch only becomes conditional once widening kicks in.

For such cases, we need a new kind of expression, which is what this PR introduces.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
