### PR TITLE
Support widen operations.

### DIFF
--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -279,6 +279,19 @@ pub enum Expression {
         path: Box<Path>,
         var_type: ExpressionType,
     },
+
+    /// The partly known value of a place in memory.
+    /// The value in operand will be the join of several expressions that all reference
+    /// the path of this value. This models a variable that is assigned to from inside a loop
+    /// body.
+    Widen {
+        /// The path of the location where an indeterminate number of flows join together.
+        path: Box<Path>,
+        /// The join of some of the flows to come together at this path.
+        /// The first few iterations do joins. Once widening happens, further iterations
+        /// all result in the same widened value.
+        operand: Box<AbstractDomain>,
+    },
 }
 
 impl Expression {
@@ -324,6 +337,7 @@ impl Expression {
             Expression::Sub { left, .. } => left.expression.infer_type(),
             Expression::SubOverflows { .. } => Bool,
             Expression::Variable { var_type, .. } => var_type.clone(),
+            Expression::Widen { operand, .. } => operand.expression.infer_type(),
         }
     }
 

--- a/checker/src/interval_domain.rs
+++ b/checker/src/interval_domain.rs
@@ -169,20 +169,6 @@ impl IntervalDomain {
         self.lower_bound == std::i128::MIN && self.upper_bound == std::i128::MAX
     }
 
-    // [x...y] * [a...b] = [x*a...y*b]
-    pub fn mul(&self, other: &Self) -> Self {
-        if self.is_bottom() || other.is_bottom() {
-            return BOTTOM.clone();
-        }
-        if self.is_top() || other.is_top() {
-            return TOP.clone();
-        }
-        IntervalDomain {
-            lower_bound: self.lower_bound.saturating_mul(other.lower_bound),
-            upper_bound: self.upper_bound.saturating_mul(other.upper_bound),
-        }
-    }
-
     // [x...y] <= [a...b] = y <= a
     // !([x...y] <= [a...b]) = [a...b] < [x...y] = b < x
     pub fn less_equal(&self, other: &Self) -> Option<bool> {
@@ -208,6 +194,50 @@ impl IntervalDomain {
             Some(false)
         } else {
             None
+        }
+    }
+
+    pub fn lower_bound(&self) -> Option<i128> {
+        if self.lower_bound == TOP.lower_bound {
+            None
+        } else {
+            Some(self.lower_bound)
+        }
+    }
+
+    pub fn upper_bound(&self) -> Option<i128> {
+        if self.upper_bound == TOP.upper_bound {
+            None
+        } else {
+            Some(self.upper_bound)
+        }
+    }
+
+    pub fn remove_lower_bound(&self) -> Self {
+        IntervalDomain {
+            lower_bound: TOP.lower_bound,
+            upper_bound: self.upper_bound,
+        }
+    }
+
+    pub fn remove_upper_bound(&self) -> Self {
+        IntervalDomain {
+            lower_bound: self.lower_bound,
+            upper_bound: TOP.upper_bound,
+        }
+    }
+
+    // [x...y] * [a...b] = [x*a...y*b]
+    pub fn mul(&self, other: &Self) -> Self {
+        if self.is_bottom() || other.is_bottom() {
+            return BOTTOM.clone();
+        }
+        if self.is_top() || other.is_top() {
+            return TOP.clone();
+        }
+        IntervalDomain {
+            lower_bound: self.lower_bound.saturating_mul(other.lower_bound),
+            upper_bound: self.upper_bound.saturating_mul(other.upper_bound),
         }
     }
 


### PR DESCRIPTION
## Description

Currently widen always results in Top, which makes any variable written to inside a loop pretty much of a black box to MIRAI.

With this PR, the widen operation performs a normal join and then wraps the join in a Widen value, along with the path where the widened value will be stored (widen is always called when environments are joined/widened, so paths are available). Further widens just leave the value as is. 

When an interval is constructed from a widened join, the leftmost (i.e. earliest) value in the join tree is used to determine if the values in the widened set increase with every iteration, or decrease. If it is the one or the other, the upper (or lower) bound is removed from the returned interval.

Taken together with the path condition, it then becomes possible to constrain loop variables to ranges, which makes it possible to verify overflow checks and index out of bounds checks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test and validate.sh

