### PR TITLE
Remove deprecated use extern directives from lib.rs

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -6,11 +6,12 @@
 use crate::abstract_value::{AbstractValue, Path};
 use crate::constant_domain::ConstantDomain;
 use crate::environment::Environment;
+use crate::expression::Expression::ConditionalExpression;
 use crate::expression::{Expression, ExpressionType};
 use crate::interval_domain::{self, IntervalDomain};
 
-use crate::expression::Expression::ConditionalExpression;
 use rustc::ty::TyKind;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter, Result};
 use std::hash::Hash;
 use std::hash::Hasher;

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -9,7 +9,10 @@ use crate::environment::Environment;
 use crate::expression::{Expression, ExpressionType};
 use crate::k_limits;
 
+use log::debug;
+use mirai_annotations::{assume, checked_assume};
 use rustc::hir::def_id::DefId;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter, Result};
 use std::hash::{Hash, Hasher};

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -11,6 +11,7 @@ use crate::smt_solver::SolverStub;
 use crate::summaries;
 use crate::visitors::{MirVisitor, MirVisitorCrateContext};
 
+use log::{info, warn};
 use rustc::hir::def_id::DefId;
 use rustc_interface::interface;
 use std::collections::{HashMap, HashSet};

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -10,6 +10,7 @@ use crate::utils::is_rust_intrinsic;
 
 use rustc::hir::def_id::DefId;
 use rustc::ty::TyCtxt;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Abstracts over constant values referenced in MIR and adds information

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -7,6 +7,8 @@ use crate::abstract_domains::AbstractDomain;
 use crate::abstract_value::{self, AbstractValue, Path};
 use crate::expression::Expression;
 
+use log::debug;
+use mirai_annotations::checked_assume;
 use rpds::HashTrieMap;
 use rustc::mir::BasicBlock;
 use std::collections::HashMap;

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -7,6 +7,7 @@ use crate::abstract_domains::AbstractDomain;
 use crate::abstract_value::Path;
 use crate::constant_domain::ConstantDomain;
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Closely based on the expressions found in MIR.

--- a/checker/src/interval_domain.rs
+++ b/checker/src/interval_domain.rs
@@ -6,6 +6,7 @@
 
 use crate::expression::ExpressionType::{self, *};
 
+use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::convert::TryFrom;
 

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -25,13 +25,6 @@ extern crate rustc_target;
 extern crate syntax;
 extern crate syntax_pos;
 
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate mirai_annotations;
-
 pub mod abstract_domains;
 pub mod abstract_value;
 pub mod callbacks;

--- a/checker/src/smt_solver.rs
+++ b/checker/src/smt_solver.rs
@@ -5,6 +5,8 @@
 
 use crate::expression::Expression;
 
+use serde::{Deserialize, Serialize};
+
 /// The result of using the solver to solve an expression.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum SmtResult {

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -9,6 +9,7 @@ use crate::utils;
 
 use rustc::hir::def_id::DefId;
 use rustc::ty::TyCtxt;
+use serde::{Deserialize, Serialize};
 use sled::Db;
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use log::debug;
 use rustc::hir::def_id::DefId;
 use rustc::hir::ItemKind;
 use rustc::hir::Node;

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -14,6 +14,8 @@ use crate::summaries;
 use crate::summaries::{PersistentSummaryCache, Summary};
 use crate::utils::{self, is_public};
 
+use log::{debug, info};
+use mirai_annotations::{assume, checked_assume, checked_assume_eq, precondition, verify};
 use rustc::session::Session;
 use rustc::ty::{Ty, TyCtxt, TyKind, UserTypeAnnotationIndex};
 use rustc::{hir, mir};


### PR DESCRIPTION
## Description

Stop using "use extern" directives for crates that export macros.

## How Has This Been Tested?
travis

