### PR TITLE
Klimit config

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -7,7 +7,6 @@ use crate::abstract_domains::{self, AbstractDomain};
 use crate::constant_domain::ConstantDomain;
 use crate::environment::Environment;
 use crate::expression::{Expression, ExpressionType};
-use crate::k_limits;
 
 use log::debug;
 use mirai_annotations::{assume, checked_assume};
@@ -873,7 +872,7 @@ impl Path {
     }
 
     /// Returns a copy path with the root replaced by new_root.
-    pub fn replace_root(&self, old_root: &Path, new_root: Path) -> Path {
+    pub fn replace_root(&self, old_root: &Path, new_root: Path, max_path_length: usize) -> Path {
         match self {
             Path::QualifiedPath {
                 qualifier,
@@ -883,9 +882,9 @@ impl Path {
                 let new_qualifier = if **qualifier == *old_root {
                     new_root
                 } else {
-                    qualifier.replace_root(old_root, new_root)
+                    qualifier.replace_root(old_root, new_root, max_path_length)
                 };
-                checked_assume!(new_qualifier.path_length() <= k_limits::MAX_PATH_LENGTH);
+                checked_assume!(new_qualifier.path_length() <= max_path_length);
                 Path::QualifiedPath {
                     length: new_qualifier.path_length() + 1,
                     qualifier: box new_qualifier,

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -2,7 +2,6 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-
 // Somewhat arbitrary constants used to limit things in the abstract interpreter that may
 // take too long or use too much memory.
 
@@ -17,3 +16,38 @@ pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
 
 /// The maximum number of seconds that MIRAI is willing to analyze a function body for.
 pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
+
+#[derive(Debug, Clone)]
+pub struct KLimitConfig {
+    pub max_inferred_preconditions: usize,
+    pub max_path_length: usize,
+    pub max_outer_fixpoint_iterations: usize,
+    pub max_analysis_time_for_body: u64,
+}
+
+impl KLimitConfig {
+    pub fn new(
+        max_inferred_preconditions: usize,
+        max_path_length: usize,
+        max_outer_fixpoint_iterations: usize,
+        max_analysis_time_for_body: u64,
+    ) -> KLimitConfig {
+        KLimitConfig {
+            max_inferred_preconditions,
+            max_path_length,
+            max_outer_fixpoint_iterations,
+            max_analysis_time_for_body,
+        }
+    }
+}
+
+impl Default for KLimitConfig {
+    fn default() -> Self {
+        Self::new(
+            self::MAX_INFERRED_PRECONDITIONS,
+            self::MAX_PATH_LENGTH,
+            self::MAX_OUTER_FIXPOINT_ITERATIONS,
+            self::MAX_ANALYSIS_TIME_FOR_BODY,
+        )
+    }
+}

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -6,16 +6,16 @@
 // take too long or use too much memory.
 
 /// Helps to limit the size of summaries.
-pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
+pub const MAX_INFERRED_PRECONDITIONS_DEFAULT: usize = 50;
 
 /// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
-pub const MAX_PATH_LENGTH: usize = 10;
+pub const MAX_PATH_LENGTH_DEFAULT: usize = 10;
 
 /// The point at which diverging summaries experience exponential blowup right now.
-pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
+pub const MAX_OUTER_FIXPOINT_ITERATIONS_DEFAULT: usize = 3;
 
 /// The maximum number of seconds that MIRAI is willing to analyze a function body for.
-pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
+pub const MAX_ANALYSIS_TIME_FOR_BODY_DEFAULT: u64 = 3;
 
 #[derive(Debug, Clone)]
 pub struct KLimitConfig {
@@ -44,10 +44,10 @@ impl KLimitConfig {
 impl Default for KLimitConfig {
     fn default() -> Self {
         Self::new(
-            self::MAX_INFERRED_PRECONDITIONS,
-            self::MAX_PATH_LENGTH,
-            self::MAX_OUTER_FIXPOINT_ITERATIONS,
-            self::MAX_ANALYSIS_TIME_FOR_BODY,
+            self::MAX_INFERRED_PRECONDITIONS_DEFAULT,
+            self::MAX_PATH_LENGTH_DEFAULT,
+            self::MAX_OUTER_FIXPOINT_ITERATIONS_DEFAULT,
+            self::MAX_ANALYSIS_TIME_FOR_BODY_DEFAULT,
         )
     }
 }

--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
             usize::from_str_radix(&command_line_arguments.remove(i), 10) //return corresponding value
         })
         .transpose()?
-        .unwrap_or(k_limits::MAX_INFERRED_PRECONDITIONS);
+        .unwrap_or(k_limits::MAX_INFERRED_PRECONDITIONS_DEFAULT);
 
     let max_path_length = command_line_arguments
         .iter_mut()
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
             usize::from_str_radix(&command_line_arguments.remove(i), 10) //return corresponding value
         })
         .transpose()?
-        .unwrap_or(k_limits::MAX_PATH_LENGTH);
+        .unwrap_or(k_limits::MAX_PATH_LENGTH_DEFAULT);
 
     let max_outer_fixpoint_iterations = command_line_arguments
         .iter_mut()
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
             usize::from_str_radix(&command_line_arguments.remove(i), 10) //return corresponding value
         })
         .transpose()?
-        .unwrap_or(k_limits::MAX_OUTER_FIXPOINT_ITERATIONS);
+        .unwrap_or(k_limits::MAX_OUTER_FIXPOINT_ITERATIONS_DEFAULT);
 
     let max_analysis_time_for_body = command_line_arguments
         .iter_mut()
@@ -87,7 +87,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
             u64::from_str_radix(&command_line_arguments.remove(i), 10) //return corresponding value
         })
         .transpose()?
-        .unwrap_or(k_limits::MAX_ANALYSIS_TIME_FOR_BODY);
+        .unwrap_or(k_limits::MAX_ANALYSIS_TIME_FOR_BODY_DEFAULT);
 
     // Tell compiler where to find the std library and so on.
     // The compiler relies on the standard rustc driver to tell it, so we have to do likewise.

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -153,3 +153,14 @@ fn invoke_driver(
         }
     }
 }
+
+#[test]
+fn test_config(){
+    let config1 = KLimitConfig::default();
+    let config2 = KLimitConfig::new(50, 10, 3, 3);
+
+    assert_eq!(config1.max_analysis_time_for_body, config2.max_analysis_time_for_body);
+    assert_eq!(config1.max_path_length, config2.max_path_length);
+    assert_eq!(config1.max_analysis_time_for_body, config2.max_analysis_time_for_body);
+    assert_eq!(config1.max_outer_fixpoint_iterations, config2.max_outer_fixpoint_iterations);
+}

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -155,12 +155,24 @@ fn invoke_driver(
 }
 
 #[test]
-fn test_config(){
+fn test_config() {
     let config1 = KLimitConfig::default();
     let config2 = KLimitConfig::new(50, 10, 3, 3);
 
-    assert_eq!(config1.max_analysis_time_for_body, config2.max_analysis_time_for_body);
-    assert_eq!(config1.max_path_length, config2.max_path_length);
-    assert_eq!(config1.max_analysis_time_for_body, config2.max_analysis_time_for_body);
-    assert_eq!(config1.max_outer_fixpoint_iterations, config2.max_outer_fixpoint_iterations);
+    assert_eq!(
+        config1.max_analysis_time_for_body,
+        config2.max_analysis_time_for_body
+    );
+    assert_eq!(
+        config1.max_path_length,
+        config2.max_path_length
+    );
+    assert_eq!(
+        config1.max_analysis_time_for_body,
+        config2.max_analysis_time_for_body
+    );
+    assert_eq!(
+        config1.max_outer_fixpoint_iterations,
+        config2.max_outer_fixpoint_iterations
+    );
 }

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -24,6 +24,7 @@ extern crate syntax;
 extern crate tempdir;
 
 use mirai::callbacks;
+use mirai::k_limits::KLimitConfig;
 use mirai::utils;
 use rustc_rayon::iter::IntoParallelIterator;
 use rustc_rayon::iter::ParallelIterator;
@@ -134,7 +135,8 @@ fn invoke_driver(
         annotations_option,
     ];
 
-    let mut call_backs = callbacks::MiraiCallbacks::test_runner();
+    let config = KLimitConfig::new(50, 10, 3, 3);
+    let mut call_backs = callbacks::MiraiCallbacks::test_runner(config);
     let result = std::panic::catch_unwind(move || {
         rustc_driver::run_compiler(
             &command_line_arguments,

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -163,10 +163,7 @@ fn test_config() {
         config1.max_analysis_time_for_body,
         config2.max_analysis_time_for_body
     );
-    assert_eq!(
-        config1.max_path_length,
-        config2.max_path_length
-    );
+    assert_eq!(config1.max_path_length, config2.max_path_length);
     assert_eq!(
         config1.max_analysis_time_for_body,
         config2.max_analysis_time_for_body


### PR DESCRIPTION
## Description

Updated k-limits to command line options.  A default constructor will initialize an instance of KLimitsConfig with default values specified in k_limits.rs.  User can also initialize a custom config instance with the new constructor. 

Command line flags are as follows:
--max_analysis_time_for_body -> max_analysis_time_for_body
--max_outer_fixpoint_iterations -> max_outer_fixpoint_iterations
--max_path_length -> max_path_length
--max_inferred_preconditions -> max_inferred_preconditions

Fixes #112 (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [-] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

