### PR TITLE
Use factory functions to construct ConditionalExpression, Join, Widen

### DIFF
--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -133,6 +133,8 @@ pub enum Expression {
     /// either its initial value or the value computed in the first loop body iteration and we
     /// don't have a way to tell which value it is.
     Join {
+        /// The path of the location where the two flows join together.
+        path: Box<Path>,
         // The value of the left operand.
         left: Box<AbstractDomain>,
         // The value of the right operand.
@@ -378,7 +380,7 @@ impl Expression {
                 consequent.expression.record_heap_addresses(result);
                 alternate.expression.record_heap_addresses(result);
             }
-            Expression::Join { left, right } => {
+            Expression::Join { left, right, .. } => {
                 left.expression.record_heap_addresses(result);
                 right.expression.record_heap_addresses(result);
             }


### PR DESCRIPTION
## Description

All Expression values should be constructed solely via factory methods on AbstractDomain, so that appropriate simplification can be done consistently and in one place only. ConditionalExpression, Join and Widen did not follow this pattern. This PR makes them conform.

While I'm at it, I've also added a path to Join expressions, which will help with translating them into Z3 expressions.

Also, the existing factory method called join actually constructed ConditionalExpression instances most of the time. This has been unbundled and now makes more sense.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh

