### PR TITLE
Fix some path problems

### DIFF
--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -665,12 +665,13 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         for i in 0..values.len() {
             let val: AbstractValue = ConstantDomain::U128(values[i]).into();
             let cond = discr.equals(&val, None);
+            let exit_condition = self.current_environment.entry_condition.and(&cond, None);
             let not_cond = cond.not(None);
             default_exit_condition = default_exit_condition.and(&not_cond, None);
             let target = targets[i];
             self.current_environment
                 .exit_conditions
-                .insert(target, cond);
+                .insert(target, exit_condition);
         }
         self.current_environment
             .exit_conditions


### PR DESCRIPTION
## Description

Visitor::visit_int_switch did not propagate its entry condition to its successor blocks, which inadvertently speeds things up nicely at the regrettable cost of precision.

Refining paths that are references or aliases diverged because the recursive refinement did not reduce the input.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
