### PR TITLE
Break up some big functions to reduce timeouts

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -912,11 +912,12 @@ impl Path {
                 } else {
                     qualifier.replace_root(old_root, new_root)
                 };
-                assume!(new_qualifier.path_length() < 1_000_000_000); // We'll run out of memory long before this happens
+                let new_qualifier_path_length = new_qualifier.path_length();
+                assume!(new_qualifier_path_length < 1_000_000_000); // We'll run out of memory long before this happens
                 Path::QualifiedPath {
-                    length: new_qualifier.path_length() + 1,
                     qualifier: box new_qualifier,
                     selector: selector.clone(),
+                    length: new_qualifier_path_length + 1,
                 }
             }
             _ => new_root,

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -8,11 +8,12 @@ use crate::constant_domain::ConstantValueCache;
 use crate::expected_errors;
 use crate::k_limits;
 use crate::smt_solver::SolverStub;
-use crate::summaries;
+use crate::summaries::{PersistentSummaryCache, Summary};
 use crate::visitors::{MirVisitor, MirVisitorCrateContext};
 
 use log::{info, warn};
 use rustc::hir::def_id::DefId;
+use rustc::ty::TyCtxt;
 use rustc_interface::interface;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
@@ -73,118 +74,225 @@ impl rustc_driver::Callbacks for MiraiCallbacks {
     /// If this method returns false, the compilation will stop.
     fn after_analysis(&mut self, compiler: &interface::Compiler) -> bool {
         compiler.session().abort_if_errors();
-        compiler.global_ctxt().unwrap().peek_mut().enter(|tcx| {
-            self.output_directory.set_file_name(".summary_store");
-            self.output_directory.set_extension("sled");
-            let summary_store_path = String::from(self.output_directory.to_str().unwrap());
-            info!("storing summaries at {}", summary_store_path);
-            let mut persistent_summary_cache =
-                summaries::PersistentSummaryCache::new(&tcx, summary_store_path);
-            let mut constant_value_cache = ConstantValueCache::default();
-            let mut defs_to_analyze: HashSet<DefId> = HashSet::from_iter(tcx.body_owners());
-            let mut defs_to_reanalyze: HashSet<DefId> = HashSet::new();
-            let mut defs_to_check: HashSet<DefId> = HashSet::new();
-            let mut defs_to_not_reanalyze: HashSet<DefId> = HashSet::new();
-            let mut diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'_>>> = HashMap::new();
-            let mut not_done = true;
-            let mut iteration_count = 0;
-            while not_done && iteration_count < k_limits::MAX_OUTER_FIXPOINT_ITERATIONS {
-                for def_id in tcx.body_owners() {
-                    if defs_to_not_reanalyze.contains(&def_id) {
-                        continue;
-                    }
-                    let analyze_it = defs_to_analyze.contains(&def_id);
-                    let check_it = !analyze_it && defs_to_check.contains(&def_id);
-                    if !analyze_it && !check_it {
-                        continue;
-                    }
-                    not_done = true;
-                    let name: String;
-                    {
-                        name = persistent_summary_cache.get_summary_key_for(def_id).clone();
-                        if check_it {
-                            info!("checking({:?})", name)
-                        } else if iteration_count == 0 {
-                            info!("analyzing({:?})", name);
-                        } else {
-                            info!("reanalyzing({:?})", name);
-                        }
-                    }
-                    // By this time all analyses have been carried out, so it should be safe to borrow this now.
-                    let old_summary_if_changed = {
-                        let mir = tcx.optimized_mir(def_id);
-                        // todo: #3 provide a helper that returns the solver as specified by a compiler switch.
-                        let mut smt_solver = SolverStub::default();
-                        let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
-                            session: compiler.session(),
-                            tcx,
-                            def_id,
-                            mir,
-                            summary_cache: &mut persistent_summary_cache,
-                            constant_value_cache: &mut constant_value_cache,
-                            smt_solver: &mut smt_solver,
-                        });
-                        let (r, analysis_time_in_seconds) = mir_visitor.visit_body(&name);
-                        if analysis_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
-                            // This body is beyond MIRAI for now
-                            warn!(
-                                "analysis of {} timed out after {} seconds",
-                                name, analysis_time_in_seconds,
-                            );
-                            defs_to_not_reanalyze.insert(def_id);
-                        }
-                        fn cancel(mut db: DiagnosticBuilder<'_>) {
-                            db.cancel();
-                        }
-                        if let Some(old_diags) =
-                            diagnostics_for.insert(def_id, mir_visitor.buffered_diagnostics)
-                        {
-                            old_diags.into_iter().for_each(cancel)
-                        }
-                        r
-                    };
-                    if let Some(old_summary) = old_summary_if_changed {
-                        // Bodies should not get checked before their summaries have reached a fixed point.
-                        if check_it {
-                            info!("body summary changed after it supposedly reached a fixed point");
-                            info!("*********** old summary: {:?}", old_summary);
-                            info!(
-                                "*********** new summary: {:?}",
-                                persistent_summary_cache.get_summary_for(def_id, None)
-                            );
-                        }
-                        for dep_id in persistent_summary_cache.get_dependents(&def_id).iter() {
-                            defs_to_reanalyze.insert(dep_id.clone());
-                        }
-                    } else {
-                        // Provided that no other body that def_id depends on has changed in this round,
-                        // the summary for def_id should now be at a fixed point.
-                        defs_to_check.insert(def_id);
-                    }
-                }
-                defs_to_analyze = defs_to_reanalyze;
-                defs_to_reanalyze = HashSet::new();
-                iteration_count += 1;
-                info!("outer fixed point iteration {}", iteration_count);
-            }
-            if self.test_run {
-                let mut expected_errors =
-                    expected_errors::ExpectedErrors::new(self.file_name.as_str());
-                let mut diags = vec![];
-                diagnostics_for.values_mut().flatten().for_each(|db| {
-                    db.cancel();
-                    db.clone().buffer(&mut diags)
-                });
-                expected_errors.check_messages(diags);
-            } else {
-                fn emit(db: &mut DiagnosticBuilder<'_>) {
-                    db.emit();
-                }
-                diagnostics_for.values_mut().flatten().for_each(emit);
-            }
-            info!("done with analysis");
-        });
-        !self.test_run // Although MIRAI is only a checker we still need code generation for build scripts.
+        if self.output_directory.to_str().unwrap().contains("/build/") {
+            // No need to analyze a build script, but do generate code.
+            return true;
+        }
+        compiler
+            .global_ctxt()
+            .unwrap()
+            .peek_mut()
+            .enter(|tcx| self.analyze_with_mirai(compiler, &tcx));
+        !self.test_run // Although MIRAI is only a checker, cargo still needs code generation to work.
                        // We avoid code gen for test cases because LLVM is not used in a thread safe manner.
+    }
+}
+
+struct DefSets {
+    defs_to_analyze: HashSet<DefId>,
+    defs_to_reanalyze: HashSet<DefId>,
+    defs_to_not_reanalyze: HashSet<DefId>,
+}
+
+impl MiraiCallbacks {
+    /// Analyze the crate currently being compiled, using the information given in compiler and tcx.
+    fn analyze_with_mirai<'a, 'tcx: 'a>(
+        &mut self,
+        compiler: &interface::Compiler,
+        tcx: &'a TyCtxt<'a, 'tcx, 'tcx>,
+    ) {
+        self.output_directory.set_file_name(".summary_store");
+        self.output_directory.set_extension("sled");
+        let summary_store_path = String::from(self.output_directory.to_str().unwrap());
+        info!(
+            "storing summaries for {} at {}",
+            self.file_name, summary_store_path
+        );
+        let mut persistent_summary_cache = PersistentSummaryCache::new(tcx, summary_store_path);
+        let mut constant_value_cache = ConstantValueCache::default();
+        let mut def_sets = DefSets {
+            defs_to_analyze: HashSet::from_iter(tcx.body_owners()),
+            defs_to_reanalyze: HashSet::new(),
+            defs_to_not_reanalyze: HashSet::new(),
+        };
+        let mut diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'_>>> = HashMap::new();
+        for iteration_count in 1..=k_limits::MAX_OUTER_FIXPOINT_ITERATIONS {
+            info!("outer fixed point iteration {}", iteration_count);
+            Self::analyze_bodies(
+                compiler,
+                tcx,
+                &mut persistent_summary_cache,
+                &mut constant_value_cache,
+                &mut def_sets,
+                &mut diagnostics_for,
+                iteration_count,
+            );
+            if def_sets.defs_to_reanalyze.is_empty() {
+                info!("done with analysis");
+                break;
+            }
+            let defs_to_reanalyze = def_sets.defs_to_reanalyze;
+            def_sets.defs_to_reanalyze = HashSet::new();
+            def_sets.defs_to_analyze = defs_to_reanalyze;
+            info!(" ");
+        }
+        self.emit_or_check_diagnostics(&mut diagnostics_for);
+    }
+
+    /// Analyze each function body in the crate that does not yet have a summary that has reached
+    /// a fixed point and add them to. The set of such functions are provided by def_sets.defs_to_analyze.
+    /// Also analyze function bodies in the def_sets.defs_to_check set, which are those bodies
+    /// whose summaries reached a fixed point during the previous call to this function.
+    /// Returns true if all summaries have reached a fixed point after this call.
+    /// If a summary has changed from the previous iteration (i.e. not reached a fixed point), add
+    /// the def_id of the function, as well as the def_id of any function that calls the function,
+    /// to def_sets.defs_to_reanalyze.
+    fn analyze_bodies<'a, 'tcx: 'a>(
+        compiler: &'a interface::Compiler,
+        tcx: &'a TyCtxt<'a, 'tcx, 'tcx>,
+        mut persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        mut constant_value_cache: &mut ConstantValueCache,
+        def_sets: &mut DefSets,
+        diagnostics_for: &mut HashMap<DefId, Vec<DiagnosticBuilder<'a>>>,
+        iteration_count: usize,
+    ) {
+        for def_id in tcx.body_owners() {
+            if def_sets.defs_to_not_reanalyze.contains(&def_id) {
+                // Analysis of this body time-out previously, so there is no previous summary
+                // and no expectation that this time it won't time out again. Just ignore it for
+                // now.
+                continue;
+            }
+            if !def_sets.defs_to_analyze.contains(&def_id) {
+                // The function summary reached a fixed point in the previous iteration
+                // as have all of the function summaries that this function depends on.
+                continue;
+            }
+            let name = MiraiCallbacks::get_and_log_name(
+                &mut persistent_summary_cache,
+                iteration_count,
+                def_id,
+            );
+            let old_summary_if_changed = {
+                let mut buffered_diagnostics: Vec<DiagnosticBuilder<'_>> = vec![];
+                let (r, analysis_time_in_seconds) = Self::visit_body(
+                    def_id,
+                    &name,
+                    compiler,
+                    tcx,
+                    &mut constant_value_cache,
+                    &mut persistent_summary_cache,
+                    &mut buffered_diagnostics,
+                );
+                if analysis_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+                    // This body is beyond MIRAI for now
+                    warn!(
+                        "analysis of {} timed out after {} seconds",
+                        name, analysis_time_in_seconds,
+                    );
+                    // Prevent the function from being analyzed again.
+                    def_sets.defs_to_not_reanalyze.insert(def_id);
+                }
+                // We want diagnostics even for function that are not yet a fixed point, since
+                // the outer fixed point loop currently diverges in many cases.
+                fn cancel(mut db: DiagnosticBuilder<'_>) {
+                    db.cancel();
+                }
+                if let Some(old_diags) = diagnostics_for.insert(def_id, buffered_diagnostics) {
+                    old_diags.into_iter().for_each(cancel)
+                }
+                r
+            };
+            MiraiCallbacks::select_defs_to_reanalyze(
+                &mut persistent_summary_cache,
+                &mut def_sets.defs_to_reanalyze,
+                def_id,
+                old_summary_if_changed,
+            )
+        }
+    }
+
+    /// Add def_id (and its dependents) to defs_to_reanalyze if the old summary differs from the
+    /// newly produced summary.
+    fn select_defs_to_reanalyze<'a, 'tcx: 'a>(
+        persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        defs_to_reanalyze: &mut HashSet<DefId>,
+        def_id: DefId,
+        old_summary_if_changed: Option<Summary>,
+    ) {
+        if let Some(_old_summary) = old_summary_if_changed {
+            // the old summary is only used during debugging.
+            for dep_id in persistent_summary_cache.get_dependents(&def_id).iter() {
+                defs_to_reanalyze.insert(*dep_id);
+            }
+            defs_to_reanalyze.insert(def_id);
+        }
+    }
+
+    /// Logs the summary key of the function that is about to be analyzed.
+    fn get_and_log_name<'a, 'tcx: 'a>(
+        persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        iteration_count: usize,
+        def_id: DefId,
+    ) -> String {
+        let name: String;
+        {
+            name = persistent_summary_cache.get_summary_key_for(def_id).clone();
+            if iteration_count == 1 {
+                info!("analyzing({:?})", name);
+            } else {
+                info!("reanalyzing({:?})", name);
+            }
+        }
+        name
+    }
+
+    /// The outer fixed point loop has been terminated, so emit any diagnostics or, if testing,
+    /// check that they are as expected.
+    fn emit_or_check_diagnostics(
+        &mut self,
+        diagnostics_for: &mut HashMap<DefId, Vec<DiagnosticBuilder<'_>>>,
+    ) {
+        if self.test_run {
+            let mut expected_errors = expected_errors::ExpectedErrors::new(self.file_name.as_str());
+            let mut diags = vec![];
+            diagnostics_for.values_mut().flatten().for_each(|db| {
+                db.cancel();
+                db.clone().buffer(&mut diags)
+            });
+            expected_errors.check_messages(diags);
+        } else {
+            fn emit(db: &mut DiagnosticBuilder<'_>) {
+                db.emit();
+            }
+            diagnostics_for.values_mut().flatten().for_each(emit);
+        }
+    }
+
+    /// Run the abstract interpreter over the function body and produce a summary of its effects
+    /// and collect any diagnostics into the buffer.
+    fn visit_body<'a, 'b, 'tcx: 'b>(
+        def_id: DefId,
+        name: &str,
+        compiler: &'b interface::Compiler,
+        tcx: &'b TyCtxt<'b, 'tcx, 'tcx>,
+        mut constant_value_cache: &'a mut ConstantValueCache,
+        mut persistent_summary_cache: &'a mut PersistentSummaryCache<'b, 'tcx>,
+        mut buffered_diagnostics: &'a mut Vec<DiagnosticBuilder<'b>>,
+    ) -> (Option<Summary>, u64) {
+        let mir = tcx.optimized_mir(def_id);
+        // todo: #3 provide a helper that returns the solver as specified by a compiler switch.
+        let mut smt_solver = SolverStub::default();
+        let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
+            session: compiler.session(),
+            tcx,
+            def_id,
+            mir,
+            summary_cache: &mut persistent_summary_cache,
+            constant_value_cache: &mut constant_value_cache,
+            smt_solver: &mut smt_solver,
+            buffered_diagnostics: &mut buffered_diagnostics,
+        });
+        mir_visitor.visit_body(&name)
     }
 }

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -12,6 +12,9 @@ pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
 
+/// Double the observed maximum used in practice.
+pub const MAX_FIXPOINT_ITERATIONS: usize = 50;
+
 /// The point at which diverging summaries experience exponential blowup right now.
 pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
 

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -148,6 +148,16 @@ fn extract_side_effects(env: &Environment, argument_count: usize) -> Vec<(Path, 
             result.push((path.clone(), value.clone()));
         }
     }
+    extract_reachable_heap_allocations(env, &mut heap_roots, &mut result);
+    result
+}
+
+/// Adds roots for all new heap allocated objects that are reachable by the caller.
+fn extract_reachable_heap_allocations(
+    env: &Environment,
+    heap_roots: &mut HashSet<usize>,
+    result: &mut Vec<(Path, AbstractValue)>,
+) {
     let mut visited_heap_roots: HashSet<usize> = HashSet::new();
     while heap_roots.len() > visited_heap_roots.len() {
         let mut new_roots: HashSet<usize> = HashSet::new();
@@ -167,7 +177,6 @@ fn extract_side_effects(env: &Environment, argument_count: usize) -> Vec<(Path, 
         }
         heap_roots.extend(new_roots.into_iter());
     }
-    result
 }
 
 /// A persistent map from DefId to Summary.


### PR DESCRIPTION
## Description

Functions with lots of loops take too long to analyze, so break up such functions in MIRAI to make it more amenable to analysis. While at it, also make the outer fixed point loop a bit more sensible and better documented. Also tweak things so that build scripts don't get analyzed (and don't interfere destructively with summary caching).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh

