### PR TITLE
Make function values indicate if they are well known.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -107,14 +107,14 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "+" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn add(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn add(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.add(&other.domain),
+            domain: self.domain.addition(other.domain),
         }
     }
 
@@ -122,8 +122,8 @@ impl AbstractValue {
     /// values resulting from applying add_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn add_overflows(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -133,21 +133,21 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: (&mut self.domain).add_overflows(&mut other.domain, target_type),
+            domain: self.domain.add_overflows(other.domain, target_type),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "&&" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn and(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn and(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.and(&other.domain),
+            domain: self.domain.and(other.domain),
         }
     }
 
@@ -179,8 +179,8 @@ impl AbstractValue {
     /// values resulting from applying "&" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn bit_and(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -189,7 +189,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.bit_and(&other.domain),
+            domain: self.domain.bit_and(other.domain),
         }
     }
 
@@ -197,8 +197,8 @@ impl AbstractValue {
     /// values resulting from applying "|" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn bit_or(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -207,7 +207,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.bit_or(&other.domain),
+            domain: self.domain.bit_or(other.domain),
         }
     }
 
@@ -215,8 +215,8 @@ impl AbstractValue {
     /// values resulting from applying "^" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn bit_xor(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -225,13 +225,13 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.bit_xor(&other.domain),
+            domain: self.domain.bit_xor(other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "as target_type" to each element of the concrete values of self.
-    pub fn cast(&self, target_type: ExpressionType) -> AbstractValue {
+    pub fn cast(self, target_type: ExpressionType) -> AbstractValue {
         AbstractValue {
             provenance: self.provenance.clone(),
             domain: self.domain.cast(target_type),
@@ -243,9 +243,9 @@ impl AbstractValue {
     /// In a context where the condition is known to be true, the result can be refined to be
     /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
     pub fn conditional_expression(
-        &self,
-        consequent: &AbstractValue,
-        alternate: &AbstractValue,
+        self,
+        consequent: AbstractValue,
+        alternate: AbstractValue,
     ) -> AbstractValue {
         let mut provenance = Vec::new();
         provenance.extend_from_slice(&self.provenance);
@@ -255,21 +255,21 @@ impl AbstractValue {
             provenance,
             domain: self
                 .domain
-                .conditional_expression(&consequent.domain, &alternate.domain),
+                .conditional_expression(consequent.domain, alternate.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "/" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn div(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn div(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.div(&other.domain),
+            domain: self.domain.divide(other.domain),
         }
     }
 
@@ -277,8 +277,8 @@ impl AbstractValue {
     /// values resulting from applying "==" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn equals(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -287,7 +287,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.equals(&other.domain),
+            domain: self.domain.equals(other.domain),
         }
     }
 
@@ -295,8 +295,8 @@ impl AbstractValue {
     /// values resulting from applying ">=" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn greater_or_equal(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -305,7 +305,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.greater_or_equal(&mut other.domain),
+            domain: self.domain.greater_or_equal(other.domain),
         }
     }
 
@@ -313,8 +313,8 @@ impl AbstractValue {
     /// values resulting from applying ">" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn greater_than(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -323,7 +323,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.greater_than(&mut other.domain),
+            domain: self.domain.greater_than(other.domain),
         }
     }
 
@@ -345,13 +345,13 @@ impl AbstractValue {
     /// corresponding to self and other.
     /// In a context where the join condition is known to be true, the result can be refined to be
     /// just self, correspondingly if it is known to be false, the result can be refined to be just other.
-    pub fn join(&self, other: &AbstractValue, path: &Path) -> AbstractValue {
+    pub fn join(self, other: AbstractValue, path: Path) -> AbstractValue {
         let mut provenance = Vec::new();
         provenance.extend_from_slice(&self.provenance);
         provenance.extend_from_slice(&other.provenance);
         AbstractValue {
             provenance,
-            domain: self.domain.join(&other.domain, path),
+            domain: self.domain.join(other.domain, path),
         }
     }
 
@@ -359,8 +359,8 @@ impl AbstractValue {
     /// values resulting from applying "<=" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn less_or_equal(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -369,7 +369,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.less_or_equal(&mut other.domain),
+            domain: self.domain.less_or_equal(other.domain),
         }
     }
 
@@ -377,8 +377,8 @@ impl AbstractValue {
     /// values resulting from applying "lt" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn less_than(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -387,21 +387,21 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.less_than(&mut other.domain),
+            domain: self.domain.less_than(other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "*" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn mul(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn mul(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.mul(&other.domain),
+            domain: self.domain.multiply(other.domain),
         }
     }
 
@@ -409,8 +409,8 @@ impl AbstractValue {
     /// values resulting from applying mul_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn mul_overflows(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -420,13 +420,13 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.mul_overflows(&mut other.domain, target_type),
+            domain: self.domain.mul_overflows(other.domain, target_type),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "neg" to each element of the concrete values of self.
-    pub fn neg(&self, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn neg(self, expression_provenance: Option<Span>) -> AbstractValue {
         let mut provenance = Vec::new();
         if expression_provenance.is_some() {
             provenance.push(expression_provenance.unwrap())
@@ -434,7 +434,7 @@ impl AbstractValue {
         provenance.extend_from_slice(&self.provenance);
         AbstractValue {
             provenance,
-            domain: self.domain.neg(),
+            domain: self.domain.negate(),
         }
     }
 
@@ -442,8 +442,8 @@ impl AbstractValue {
     /// values resulting from applying "!=" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn not_equals(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -452,13 +452,13 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.not_equals(&other.domain),
+            domain: self.domain.not_equals(other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "not" to each element of the concrete values of self.
-    pub fn not(&self, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn not(self, expression_provenance: Option<Span>) -> AbstractValue {
         let mut provenance = Vec::new();
         if expression_provenance.is_some() {
             provenance.push(expression_provenance.unwrap())
@@ -466,7 +466,7 @@ impl AbstractValue {
         provenance.extend_from_slice(&self.provenance);
         AbstractValue {
             provenance,
-            domain: self.domain.not(),
+            domain: self.domain.logical_not(),
         }
     }
 
@@ -474,8 +474,8 @@ impl AbstractValue {
     /// values resulting from applying "ptr.offset" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn offset(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
         AbstractValue {
@@ -484,21 +484,21 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.offset(&other.domain),
+            domain: self.domain.offset(other.domain),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "or" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn or(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn or(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.or(&other.domain),
+            domain: self.domain.or(other.domain),
         }
     }
 
@@ -511,7 +511,7 @@ impl AbstractValue {
     /// (conditions known to be true in the current context). If no refinement is possible
     /// the result is simply a clone of this value, but with its provenance updated by
     /// pre-pending the given span.
-    pub fn refine_with(&self, path_condition: &AbstractValue, provenance: Span) -> AbstractValue {
+    pub fn refine_with(self, path_condition: &AbstractValue, provenance: Span) -> AbstractValue {
         let mut provenance = vec![provenance];
         provenance.extend_from_slice(&self.provenance);
         AbstractValue {
@@ -524,7 +524,7 @@ impl AbstractValue {
     /// with the value at that path (if there is one). If no refinement is possible
     /// the result is simply a clone of this value. This refinement only makes sense
     /// following a call to refine_parameters.
-    pub fn refine_paths(&self, environment: &mut Environment) -> AbstractValue {
+    pub fn refine_paths(self, environment: &mut Environment) -> AbstractValue {
         AbstractValue {
             provenance: self.provenance.clone(),
             domain: self.domain.refine_paths(environment),
@@ -534,7 +534,7 @@ impl AbstractValue {
     /// Returns a value that is simplified (refined) by replacing parameter values
     /// with their corresponding argument values. If no refinement is possible
     /// the result is simply a clone of this value.
-    pub fn refine_parameters(&self, arguments: &[(Path, AbstractValue)]) -> AbstractValue {
+    pub fn refine_parameters(self, arguments: &[(Path, AbstractValue)]) -> AbstractValue {
         AbstractValue {
             provenance: self.provenance.clone(),
             domain: self.domain.refine_parameters(arguments),
@@ -544,19 +544,19 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "%" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn rem(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn rem(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.rem(&other.domain),
+            domain: self.domain.remainder(other.domain),
         }
     }
 
     /// Returns a clone of the value with the given span replacing its provenance.
-    pub fn replacing_provenance(&self, provenance: Span) -> AbstractValue {
+    pub fn replacing_provenance(self, provenance: Span) -> AbstractValue {
         let mut result = self.clone();
         result.provenance = vec![provenance];
         result
@@ -565,14 +565,14 @@ impl AbstractValue {
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "<<" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn shl(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn shl(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shl(&other.domain),
+            domain: self.domain.shift_left(other.domain),
         }
     }
 
@@ -580,8 +580,8 @@ impl AbstractValue {
     /// values resulting from applying shl_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn shl_overflows(
-        &self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -591,7 +591,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shl_overflows(&mut other.domain, target_type),
+            domain: self.domain.shl_overflows(other.domain, target_type),
         }
     }
 
@@ -599,8 +599,8 @@ impl AbstractValue {
     /// values resulting from applying ">>" to each element of the cross product of the concrete
     /// values or self and other.
     pub fn shr(
-        &self,
-        other: &AbstractValue,
+        self,
+        other: AbstractValue,
         expression_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -610,7 +610,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shr(&other.domain, expression_type),
+            domain: self.domain.shr(other.domain, expression_type),
         }
     }
 
@@ -618,8 +618,8 @@ impl AbstractValue {
     /// values resulting from applying shr_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn shr_overflows(
-        &self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -629,21 +629,21 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.shr_overflows(&mut other.domain, target_type),
+            domain: self.domain.shr_overflows(other.domain, target_type),
         }
     }
 
     /// Returns an abstract value whose corresponding set of concrete values include all of the
     /// values resulting from applying "-" to each element of the cross product of the concrete
     /// values or self and other.
-    pub fn sub(&self, other: &AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
+    pub fn sub(self, other: AbstractValue, expression_provenance: Option<Span>) -> AbstractValue {
         AbstractValue {
             provenance: Self::binary_provenance(
                 expression_provenance,
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.sub(&other.domain),
+            domain: self.domain.subtract(other.domain),
         }
     }
 
@@ -651,8 +651,8 @@ impl AbstractValue {
     /// values resulting from applying sub_overflows to each element of the cross product of the concrete
     /// values or self and other.
     pub fn sub_overflows(
-        &mut self,
-        other: &mut AbstractValue,
+        self,
+        other: AbstractValue,
         target_type: ExpressionType,
         expression_provenance: Option<Span>,
     ) -> AbstractValue {
@@ -662,7 +662,7 @@ impl AbstractValue {
                 &self.provenance,
                 &other.provenance,
             ),
-            domain: self.domain.sub_overflows(&mut other.domain, target_type),
+            domain: self.domain.sub_overflows(other.domain, target_type),
         }
     }
 
@@ -675,7 +675,7 @@ impl AbstractValue {
     /// corresponding to self and other. The set of values may be less precise (more inclusive) than
     /// the set returned by join. The chief requirement is that a small number of widen calls
     /// deterministically lead to Top.
-    pub fn widen(&self, path: &Path) -> AbstractValue {
+    pub fn widen(self, path: Path) -> AbstractValue {
         AbstractValue {
             provenance: self.provenance.clone(),
             domain: self.domain.widen(path),
@@ -683,6 +683,7 @@ impl AbstractValue {
     }
 
     /// Returns a clone of the value with the given span prepended to its provenance.
+    /// todo: do we really want a clone?
     pub fn with_provenance(&self, provenance: Span) -> AbstractValue {
         let mut result = self.clone();
         result.provenance.insert(0, provenance);
@@ -782,14 +783,14 @@ impl Path {
     }
 
     /// Refine parameters inside embedded index values with the given arguments.
-    pub fn refine_parameters(&self, arguments: &[(Path, AbstractValue)]) -> Path {
+    pub fn refine_parameters(self, arguments: &[(Path, AbstractValue)]) -> Path {
         match self {
-            Path::LocalVariable { ordinal } if 0 < *ordinal && *ordinal <= arguments.len() => {
-                arguments[*ordinal - 1].0.clone()
+            Path::LocalVariable { ordinal } if 0 < ordinal && ordinal <= arguments.len() => {
+                arguments[ordinal - 1].0.clone()
             }
             Path::QualifiedPath {
-                ref qualifier,
-                ref selector,
+                qualifier,
+                selector,
                 ..
             } => {
                 let refined_qualifier = qualifier.refine_parameters(arguments);
@@ -802,7 +803,7 @@ impl Path {
                     length: refined_length + 1,
                 }
             }
-            _ => self.clone(),
+            _ => self,
         }
     }
 
@@ -811,16 +812,16 @@ impl Path {
     /// or leaks it back to the caller in the qualifier of a path then
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
-    pub fn refine_paths(&self, environment: &mut Environment) -> Self {
+    pub fn refine_paths(self, environment: &mut Environment) -> Self {
         if let Path::QualifiedPath {
             qualifier,
             selector,
-            ..
+            length,
         } = self
         {
-            if let Some(val) = environment.value_at(&**qualifier) {
+            if let Some(val) = environment.value_at(&qualifier) {
                 match &val.domain.expression {
-                    Expression::Reference(ref dereferenced_path) => {
+                    Expression::Reference(dereferenced_path) => {
                         // The qualifier is being dereferenced, so if the value at qualifier
                         // is an explicit reference to another path, put the other path in the place
                         // of qualifier since references do not own elements directly in
@@ -830,15 +831,15 @@ impl Path {
                         let qualifier = dereferenced_path.clone().refine_paths(environment);
                         let path_len = qualifier.path_length();
                         assume!(path_len < 1_000_000_000); // We'll run out of memory long before this happens
-                        return Path::QualifiedPath {
+                        Path::QualifiedPath {
                             qualifier: box qualifier,
-                            selector: selector.clone(),
+                            selector,
                             length: path_len + 1,
-                        };
+                        }
                     }
-                    // if **path == **qualifier, this value came about as the result of a copy
+                    // if **path == *qualifier, this value came about as the result of a copy
                     // sequence that started in a formal parameter.
-                    Expression::Variable { ref path, .. } if (**path != **qualifier) => {
+                    Expression::Variable { path, .. } if (**path != *qualifier) => {
                         // In this case the qualifier is not a reference, but an alias created by
                         // by a move instruction.
                         // Normally, when local a is assigned to local b, all of the
@@ -853,20 +854,30 @@ impl Path {
                         let qualifier = path.clone().refine_paths(environment);
                         let path_len = qualifier.path_length();
                         assume!(path_len < 1_000_000_000); // We'll run out of memory long before this happens
-                        return Path::QualifiedPath {
+                        Path::QualifiedPath {
                             qualifier: box qualifier,
-                            selector: selector.clone(),
+                            selector,
                             length: path_len + 1,
-                        };
+                        }
                     }
                     Expression::CompileTimeConstant(constant_value) => {
-                        debug!("constant qualifier with path selector that is not in the environment\n{:?}\n{:?}\n{:?}", constant_value, self, environment);
+                        debug!("constant qualifier with path selector that is not in the environment\n{:?}\n{:?}", constant_value, environment);
                         //todo: at least some of these arise from qualifiers that are ADTs
+                        Path::QualifiedPath {
+                            qualifier,
+                            selector,
+                            length,
+                        }
                     }
                     _ => {
                         // Although the qualifier matches an expression, that expression
                         // is too abstract too qualify the path sufficiently that we
                         // can refine this value.
+                        Path::QualifiedPath {
+                            qualifier,
+                            selector,
+                            length,
+                        }
                     }
                 }
             } else {
@@ -877,14 +888,15 @@ impl Path {
                 let refined_selector = selector.refine_paths(environment);
                 let refined_length = refined_qualifier.path_length();
                 assume!(refined_length < 1_000_000_000); // We'll run out of memory long before this happens
-                return Path::QualifiedPath {
+                Path::QualifiedPath {
                     qualifier: box refined_qualifier,
                     selector: box refined_selector,
                     length: refined_length + 1,
-                };
+                }
             }
+        } else {
+            self
         }
-        self.clone()
     }
 
     /// Returns a copy path with the root replaced by new_root.
@@ -967,22 +979,22 @@ impl PathSelector {
     /// with the value at that path (if there is one). If no refinement is possible
     /// the result is simply a clone of this value. This refinement only makes sense
     /// following a call to refine_parameters.
-    pub fn refine_paths(&self, environment: &mut Environment) -> Self {
+    pub fn refine_paths(self, environment: &mut Environment) -> Self {
         if let PathSelector::Index(boxed_abstract_value) = self {
-            let refined_value = (**boxed_abstract_value).refine_paths(environment);
+            let refined_value = boxed_abstract_value.refine_paths(environment);
             PathSelector::Index(box refined_value)
         } else {
-            self.clone()
+            self
         }
     }
 
     /// Refine parameters inside embedded index values with the given arguments.
-    pub fn refine_parameters(&self, arguments: &[(Path, AbstractValue)]) -> Self {
+    pub fn refine_parameters(self, arguments: &[(Path, AbstractValue)]) -> Self {
         if let PathSelector::Index(boxed_abstract_value) = self {
-            let refined_value = (**boxed_abstract_value).refine_parameters(arguments);
+            let refined_value = boxed_abstract_value.refine_parameters(arguments);
             PathSelector::Index(box refined_value)
         } else {
-            self.clone()
+            self
         }
     }
 }

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -912,11 +912,12 @@ impl Path {
                 } else {
                     qualifier.replace_root(old_root, new_root)
                 };
-                assume!(new_qualifier.path_length() < 1_000_000_000); // We'll run out of memory long before this happens
+                let new_qualifier_path_length = new_qualifier.path_length();
+                assume!(new_qualifier_path_length < 1_000_000_000); // We'll run out of memory long before this happens
                 Path::QualifiedPath {
-                    length: new_qualifier.path_length() + 1,
                     qualifier: box new_qualifier,
                     selector: selector.clone(),
+                    length: new_qualifier_path_length + 1,
                 }
             }
             _ => new_root,

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -8,11 +8,12 @@ use crate::constant_domain::ConstantValueCache;
 use crate::expected_errors;
 use crate::k_limits;
 use crate::smt_solver::SolverStub;
-use crate::summaries;
+use crate::summaries::{PersistentSummaryCache, Summary};
 use crate::visitors::{MirVisitor, MirVisitorCrateContext};
 
 use log::{info, warn};
 use rustc::hir::def_id::DefId;
+use rustc::ty::TyCtxt;
 use rustc_interface::interface;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
@@ -73,118 +74,225 @@ impl rustc_driver::Callbacks for MiraiCallbacks {
     /// If this method returns false, the compilation will stop.
     fn after_analysis(&mut self, compiler: &interface::Compiler) -> bool {
         compiler.session().abort_if_errors();
-        compiler.global_ctxt().unwrap().peek_mut().enter(|tcx| {
-            self.output_directory.set_file_name(".summary_store");
-            self.output_directory.set_extension("sled");
-            let summary_store_path = String::from(self.output_directory.to_str().unwrap());
-            info!("storing summaries at {}", summary_store_path);
-            let mut persistent_summary_cache =
-                summaries::PersistentSummaryCache::new(&tcx, summary_store_path);
-            let mut constant_value_cache = ConstantValueCache::default();
-            let mut defs_to_analyze: HashSet<DefId> = HashSet::from_iter(tcx.body_owners());
-            let mut defs_to_reanalyze: HashSet<DefId> = HashSet::new();
-            let mut defs_to_check: HashSet<DefId> = HashSet::new();
-            let mut defs_to_not_reanalyze: HashSet<DefId> = HashSet::new();
-            let mut diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'_>>> = HashMap::new();
-            let mut not_done = true;
-            let mut iteration_count = 0;
-            while not_done && iteration_count < k_limits::MAX_OUTER_FIXPOINT_ITERATIONS {
-                for def_id in tcx.body_owners() {
-                    if defs_to_not_reanalyze.contains(&def_id) {
-                        continue;
-                    }
-                    let analyze_it = defs_to_analyze.contains(&def_id);
-                    let check_it = !analyze_it && defs_to_check.contains(&def_id);
-                    if !analyze_it && !check_it {
-                        continue;
-                    }
-                    not_done = true;
-                    let name: String;
-                    {
-                        name = persistent_summary_cache.get_summary_key_for(def_id).clone();
-                        if check_it {
-                            info!("checking({:?})", name)
-                        } else if iteration_count == 0 {
-                            info!("analyzing({:?})", name);
-                        } else {
-                            info!("reanalyzing({:?})", name);
-                        }
-                    }
-                    // By this time all analyses have been carried out, so it should be safe to borrow this now.
-                    let old_summary_if_changed = {
-                        let mir = tcx.optimized_mir(def_id);
-                        // todo: #3 provide a helper that returns the solver as specified by a compiler switch.
-                        let mut smt_solver = SolverStub::default();
-                        let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
-                            session: compiler.session(),
-                            tcx,
-                            def_id,
-                            mir,
-                            summary_cache: &mut persistent_summary_cache,
-                            constant_value_cache: &mut constant_value_cache,
-                            smt_solver: &mut smt_solver,
-                        });
-                        let (r, analysis_time_in_seconds) = mir_visitor.visit_body(&name);
-                        if analysis_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
-                            // This body is beyond MIRAI for now
-                            warn!(
-                                "analysis of {} timed out after {} seconds",
-                                name, analysis_time_in_seconds,
-                            );
-                            defs_to_not_reanalyze.insert(def_id);
-                        }
-                        fn cancel(mut db: DiagnosticBuilder<'_>) {
-                            db.cancel();
-                        }
-                        if let Some(old_diags) =
-                            diagnostics_for.insert(def_id, mir_visitor.buffered_diagnostics)
-                        {
-                            old_diags.into_iter().for_each(cancel)
-                        }
-                        r
-                    };
-                    if let Some(old_summary) = old_summary_if_changed {
-                        // Bodies should not get checked before their summaries have reached a fixed point.
-                        if check_it {
-                            info!("body summary changed after it supposedly reached a fixed point");
-                            info!("*********** old summary: {:?}", old_summary);
-                            info!(
-                                "*********** new summary: {:?}",
-                                persistent_summary_cache.get_summary_for(def_id, None)
-                            );
-                        }
-                        for dep_id in persistent_summary_cache.get_dependents(&def_id).iter() {
-                            defs_to_reanalyze.insert(dep_id.clone());
-                        }
-                    } else {
-                        // Provided that no other body that def_id depends on has changed in this round,
-                        // the summary for def_id should now be at a fixed point.
-                        defs_to_check.insert(def_id);
-                    }
-                }
-                defs_to_analyze = defs_to_reanalyze;
-                defs_to_reanalyze = HashSet::new();
-                iteration_count += 1;
-                info!("outer fixed point iteration {}", iteration_count);
-            }
-            if self.test_run {
-                let mut expected_errors =
-                    expected_errors::ExpectedErrors::new(self.file_name.as_str());
-                let mut diags = vec![];
-                diagnostics_for.values_mut().flatten().for_each(|db| {
-                    db.cancel();
-                    db.clone().buffer(&mut diags)
-                });
-                expected_errors.check_messages(diags);
-            } else {
-                fn emit(db: &mut DiagnosticBuilder<'_>) {
-                    db.emit();
-                }
-                diagnostics_for.values_mut().flatten().for_each(emit);
-            }
-            info!("done with analysis");
-        });
-        !self.test_run // Although MIRAI is only a checker we still need code generation for build scripts.
+        if self.output_directory.to_str().unwrap().contains("/build/") {
+            // No need to analyze a build script, but do generate code.
+            return true;
+        }
+        compiler
+            .global_ctxt()
+            .unwrap()
+            .peek_mut()
+            .enter(|tcx| self.analyze_with_mirai(compiler, &tcx));
+        !self.test_run // Although MIRAI is only a checker, cargo still needs code generation to work.
                        // We avoid code gen for test cases because LLVM is not used in a thread safe manner.
+    }
+}
+
+struct DefSets {
+    defs_to_analyze: HashSet<DefId>,
+    defs_to_reanalyze: HashSet<DefId>,
+    defs_to_not_reanalyze: HashSet<DefId>,
+}
+
+impl MiraiCallbacks {
+    /// Analyze the crate currently being compiled, using the information given in compiler and tcx.
+    fn analyze_with_mirai<'a, 'tcx: 'a>(
+        &mut self,
+        compiler: &interface::Compiler,
+        tcx: &'a TyCtxt<'a, 'tcx, 'tcx>,
+    ) {
+        self.output_directory.set_file_name(".summary_store");
+        self.output_directory.set_extension("sled");
+        let summary_store_path = String::from(self.output_directory.to_str().unwrap());
+        info!(
+            "storing summaries for {} at {}",
+            self.file_name, summary_store_path
+        );
+        let mut persistent_summary_cache = PersistentSummaryCache::new(tcx, summary_store_path);
+        let mut constant_value_cache = ConstantValueCache::default();
+        let mut def_sets = DefSets {
+            defs_to_analyze: HashSet::from_iter(tcx.body_owners()),
+            defs_to_reanalyze: HashSet::new(),
+            defs_to_not_reanalyze: HashSet::new(),
+        };
+        let mut diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'_>>> = HashMap::new();
+        for iteration_count in 1..=k_limits::MAX_OUTER_FIXPOINT_ITERATIONS {
+            info!("outer fixed point iteration {}", iteration_count);
+            Self::analyze_bodies(
+                compiler,
+                tcx,
+                &mut persistent_summary_cache,
+                &mut constant_value_cache,
+                &mut def_sets,
+                &mut diagnostics_for,
+                iteration_count,
+            );
+            if def_sets.defs_to_reanalyze.is_empty() {
+                info!("done with analysis");
+                break;
+            }
+            let defs_to_reanalyze = def_sets.defs_to_reanalyze;
+            def_sets.defs_to_reanalyze = HashSet::new();
+            def_sets.defs_to_analyze = defs_to_reanalyze;
+            info!(" ");
+        }
+        self.emit_or_check_diagnostics(&mut diagnostics_for);
+    }
+
+    /// Analyze each function body in the crate that does not yet have a summary that has reached
+    /// a fixed point and add them to. The set of such functions are provided by def_sets.defs_to_analyze.
+    /// Also analyze function bodies in the def_sets.defs_to_check set, which are those bodies
+    /// whose summaries reached a fixed point during the previous call to this function.
+    /// Returns true if all summaries have reached a fixed point after this call.
+    /// If a summary has changed from the previous iteration (i.e. not reached a fixed point), add
+    /// the def_id of the function, as well as the def_id of any function that calls the function,
+    /// to def_sets.defs_to_reanalyze.
+    fn analyze_bodies<'a, 'tcx: 'a>(
+        compiler: &'a interface::Compiler,
+        tcx: &'a TyCtxt<'a, 'tcx, 'tcx>,
+        mut persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        mut constant_value_cache: &mut ConstantValueCache,
+        def_sets: &mut DefSets,
+        diagnostics_for: &mut HashMap<DefId, Vec<DiagnosticBuilder<'a>>>,
+        iteration_count: usize,
+    ) {
+        for def_id in tcx.body_owners() {
+            if def_sets.defs_to_not_reanalyze.contains(&def_id) {
+                // Analysis of this body time-out previously, so there is no previous summary
+                // and no expectation that this time it won't time out again. Just ignore it for
+                // now.
+                continue;
+            }
+            if !def_sets.defs_to_analyze.contains(&def_id) {
+                // The function summary reached a fixed point in the previous iteration
+                // as have all of the function summaries that this function depends on.
+                continue;
+            }
+            let name = MiraiCallbacks::get_and_log_name(
+                &mut persistent_summary_cache,
+                iteration_count,
+                def_id,
+            );
+            let old_summary_if_changed = {
+                let mut buffered_diagnostics: Vec<DiagnosticBuilder<'_>> = vec![];
+                let (r, analysis_time_in_seconds) = Self::visit_body(
+                    def_id,
+                    &name,
+                    compiler,
+                    tcx,
+                    &mut constant_value_cache,
+                    &mut persistent_summary_cache,
+                    &mut buffered_diagnostics,
+                );
+                if analysis_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+                    // This body is beyond MIRAI for now
+                    warn!(
+                        "analysis of {} timed out after {} seconds",
+                        name, analysis_time_in_seconds,
+                    );
+                    // Prevent the function from being analyzed again.
+                    def_sets.defs_to_not_reanalyze.insert(def_id);
+                }
+                // We want diagnostics even for function that are not yet a fixed point, since
+                // the outer fixed point loop currently diverges in many cases.
+                fn cancel(mut db: DiagnosticBuilder<'_>) {
+                    db.cancel();
+                }
+                if let Some(old_diags) = diagnostics_for.insert(def_id, buffered_diagnostics) {
+                    old_diags.into_iter().for_each(cancel)
+                }
+                r
+            };
+            MiraiCallbacks::select_defs_to_reanalyze(
+                &mut persistent_summary_cache,
+                &mut def_sets.defs_to_reanalyze,
+                def_id,
+                old_summary_if_changed,
+            )
+        }
+    }
+
+    /// Add def_id (and its dependents) to defs_to_reanalyze if the old summary differs from the
+    /// newly produced summary.
+    fn select_defs_to_reanalyze<'a, 'tcx: 'a>(
+        persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        defs_to_reanalyze: &mut HashSet<DefId>,
+        def_id: DefId,
+        old_summary_if_changed: Option<Summary>,
+    ) {
+        if let Some(_old_summary) = old_summary_if_changed {
+            // the old summary is only used during debugging.
+            for dep_id in persistent_summary_cache.get_dependents(&def_id).iter() {
+                defs_to_reanalyze.insert(*dep_id);
+            }
+            defs_to_reanalyze.insert(def_id);
+        }
+    }
+
+    /// Logs the summary key of the function that is about to be analyzed.
+    fn get_and_log_name<'a, 'tcx: 'a>(
+        persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        iteration_count: usize,
+        def_id: DefId,
+    ) -> String {
+        let name: String;
+        {
+            name = persistent_summary_cache.get_summary_key_for(def_id).clone();
+            if iteration_count == 1 {
+                info!("analyzing({:?})", name);
+            } else {
+                info!("reanalyzing({:?})", name);
+            }
+        }
+        name
+    }
+
+    /// The outer fixed point loop has been terminated, so emit any diagnostics or, if testing,
+    /// check that they are as expected.
+    fn emit_or_check_diagnostics(
+        &mut self,
+        diagnostics_for: &mut HashMap<DefId, Vec<DiagnosticBuilder<'_>>>,
+    ) {
+        if self.test_run {
+            let mut expected_errors = expected_errors::ExpectedErrors::new(self.file_name.as_str());
+            let mut diags = vec![];
+            diagnostics_for.values_mut().flatten().for_each(|db| {
+                db.cancel();
+                db.clone().buffer(&mut diags)
+            });
+            expected_errors.check_messages(diags);
+        } else {
+            fn emit(db: &mut DiagnosticBuilder<'_>) {
+                db.emit();
+            }
+            diagnostics_for.values_mut().flatten().for_each(emit);
+        }
+    }
+
+    /// Run the abstract interpreter over the function body and produce a summary of its effects
+    /// and collect any diagnostics into the buffer.
+    fn visit_body<'a, 'b, 'tcx: 'b>(
+        def_id: DefId,
+        name: &str,
+        compiler: &'b interface::Compiler,
+        tcx: &'b TyCtxt<'b, 'tcx, 'tcx>,
+        mut constant_value_cache: &'a mut ConstantValueCache,
+        mut persistent_summary_cache: &'a mut PersistentSummaryCache<'b, 'tcx>,
+        mut buffered_diagnostics: &'a mut Vec<DiagnosticBuilder<'b>>,
+    ) -> (Option<Summary>, u64) {
+        let mir = tcx.optimized_mir(def_id);
+        // todo: #3 provide a helper that returns the solver as specified by a compiler switch.
+        let mut smt_solver = SolverStub::default();
+        let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
+            session: compiler.session(),
+            tcx,
+            def_id,
+            mir,
+            summary_cache: &mut persistent_summary_cache,
+            constant_value_cache: &mut constant_value_cache,
+            smt_solver: &mut smt_solver,
+            buffered_diagnostics: &mut buffered_diagnostics,
+        });
+        mir_visitor.visit_body(&name)
     }
 }

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -177,7 +177,7 @@ impl ConstantDomain {
 
     /// Returns a constant that is "self as target_type"
     #[allow(clippy::cast_lossless)]
-    pub fn cast(&self, target_type: ExpressionType) -> Self {
+    pub fn cast(&self, target_type: &ExpressionType) -> Self {
         match self {
             ConstantDomain::Bottom => self.clone(),
             ConstantDomain::Char(ch) => {
@@ -199,7 +199,7 @@ impl ConstantDomain {
                 }
             }
             ConstantDomain::U128(val) => {
-                if target_type == ExpressionType::Char {
+                if *target_type == ExpressionType::Char {
                     ConstantDomain::Char((*val as u8) as char)
                 } else if target_type.is_signed_integer() {
                     ConstantDomain::I128(*val as i128).cast(target_type)
@@ -228,7 +228,7 @@ impl ConstantDomain {
             }
             ConstantDomain::F32(val) => {
                 let f = f32::from_bits(*val);
-                if target_type == ExpressionType::F64 {
+                if *target_type == ExpressionType::F64 {
                     ConstantDomain::F64((f as f64).to_bits())
                 } else if target_type.is_signed_integer() {
                     ConstantDomain::I128(f as i128).cast(target_type)
@@ -240,7 +240,7 @@ impl ConstantDomain {
             }
             ConstantDomain::F64(val) => {
                 let f = f64::from_bits(*val);
-                if target_type == ExpressionType::F32 {
+                if *target_type == ExpressionType::F32 {
                     ConstantDomain::F32((f as f32).to_bits())
                 } else if target_type.is_signed_integer() {
                     ConstantDomain::I128(f as i128).cast(target_type)

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -12,6 +12,9 @@ pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
 
+/// Double the observed maximum used in practice.
+pub const MAX_FIXPOINT_ITERATIONS: usize = 50;
+
 /// The point at which diverging summaries experience exponential blowup right now.
 pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
 

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -22,7 +22,6 @@ extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_metadata;
-extern crate rustc_target;
 extern crate syntax;
 extern crate syntax_pos;
 

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -148,6 +148,16 @@ fn extract_side_effects(env: &Environment, argument_count: usize) -> Vec<(Path, 
             result.push((path.clone(), value.clone()));
         }
     }
+    extract_reachable_heap_allocations(env, &mut heap_roots, &mut result);
+    result
+}
+
+/// Adds roots for all new heap allocated objects that are reachable by the caller.
+fn extract_reachable_heap_allocations(
+    env: &Environment,
+    heap_roots: &mut HashSet<usize>,
+    result: &mut Vec<(Path, AbstractValue)>,
+) {
     let mut visited_heap_roots: HashSet<usize> = HashSet::new();
     while heap_roots.len() > visited_heap_roots.len() {
         let mut new_roots: HashSet<usize> = HashSet::new();
@@ -167,7 +177,6 @@ fn extract_side_effects(env: &Environment, argument_count: usize) -> Vec<(Path, 
         }
         heap_roots.extend(new_roots.into_iter());
     }
-    result
 }
 
 /// A persistent map from DefId to Summary.

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -8,7 +8,6 @@ use rustc::hir::def_id::DefId;
 use rustc::hir::ItemKind;
 use rustc::hir::Node;
 use rustc::ty::TyCtxt;
-use rustc_target::spec::abi::Abi;
 
 /// Returns the location of the rust system binaries that are associated with this build of Mirai.
 /// The location is obtained by looking at the contents of the environmental variables that were
@@ -28,17 +27,6 @@ pub fn find_sysroot() -> String {
                  or use rustup to set the compiler to use for Mirai",
             )
             .to_owned(),
-    }
-}
-
-/// Returns true if the function identified by def_id is a Rust intrinsic function.
-/// Warning: it is not clear what will happen if def_id does not identify a function.
-pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
-    let binder = tcx.fn_sig(def_id);
-    let sig = binder.skip_binder();
-    match sig.abi {
-        Abi::RustIntrinsic => true,
-        _ => false,
     }
 }
 


### PR DESCRIPTION
## Description

Rather than lazily caching the function values that correspond to well known functions that MIRAI needs to treat in special ways, we now include an enum in all function values that identify the function as well known or not.

While at it, the PR also remove the unused is_intrinsic flag from function values.

Fixes #125

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
