### PR TITLE
Implement model fields.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libssl-dev
 language: rust
 rust:
-- nightly-2019-04-13
+- nightly-2019-04-23
 cache: cargo
 
 before_script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
  "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 0.1.0",
+ "mirai-annotations 0.2.0",
  "rpds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "nodrop"

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -966,6 +966,11 @@ pub enum PathSelector {
     /// "Downcast" to a variant of an ADT. Currently, MIR only introduces
     /// this for ADTs with more than one variant. The value is the ordinal of the variant.
     Downcast(usize),
+
+    /// Select the struct model field with the given name.
+    /// A model field is a specification construct used during MIRAI verification
+    /// and does not have a runtime location.
+    ModelField(String),
 }
 
 impl PathSelector {

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -59,8 +59,12 @@ pub enum KnownFunctionNames {
     CoreSliceLen,
     /// mirai_annotations.mirai_assume
     MiraiAssume,
+    /// mirai_annotations.mirai_get_model_field
+    MiraiGetModelField,
     /// mirai_annotations.mirai_precondition
     MiraiPrecondition,
+    /// mirai_annotations.mirai_set_model_field
+    MiraiSetModelField,
     /// mirai_annotations.mirai_verify
     MiraiVerify,
     /// std.panicking.begin_panic
@@ -78,7 +82,9 @@ impl ConstantDomain {
         let known_name = match summary_cache_key.as_str() {
             "core.slice.{{impl}}.len" => KnownFunctionNames::CoreSliceLen,
             "mirai_annotations.mirai_assume" => KnownFunctionNames::MiraiAssume,
+            "mirai_annotations.mirai_get_model_field" => KnownFunctionNames::MiraiGetModelField,
             "mirai_annotations.mirai_precondition" => KnownFunctionNames::MiraiPrecondition,
+            "mirai_annotations.mirai_set_model_field" => KnownFunctionNames::MiraiSetModelField,
             "mirai_annotations.mirai_verify" => KnownFunctionNames::MiraiVerify,
             "std.panicking.begin_panic" => KnownFunctionNames::StdBeginPanic,
             _ => KnownFunctionNames::None,

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -272,6 +272,14 @@ pub enum Expression {
         result_type: ExpressionType,
     },
 
+    /// Like a variable, but during refinement the default value is used
+    /// when the qualifier becomes a known value without a defined value for the model field.
+    UnknownModelField {
+        /// Must be a qualified path with a model field selector.
+        path: Box<Path>,
+        default: Box<AbstractDomain>,
+    },
+
     /// The unknown value of a place in memory.
     /// This is distinct from Top in that we known something: the place and the type.
     /// This is a useful distinction because it allows us to simplify some expressions
@@ -338,6 +346,7 @@ impl Expression {
             Expression::ShrOverflows { .. } => Bool,
             Expression::Sub { left, .. } => left.expression.infer_type(),
             Expression::SubOverflows { .. } => Bool,
+            Expression::UnknownModelField { default, .. } => default.expression.infer_type(),
             Expression::Variable { var_type, .. } => var_type.clone(),
             Expression::Widen { operand, .. } => operand.expression.infer_type(),
         }

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(box_syntax)]
 #![feature(const_vec_new)]
 #![feature(vec_remove_item)]
+#![feature(bind_by_move_pattern_guards)]
 
 extern crate rustc;
 extern crate rustc_data_structures;
@@ -24,6 +25,9 @@ extern crate rustc_interface;
 extern crate rustc_metadata;
 extern crate syntax;
 extern crate syntax_pos;
+
+#[macro_use]
+extern crate log;
 
 pub mod abstract_domains;
 pub mod abstract_value;

--- a/checker/tests/run-pass/taint.rs
+++ b/checker/tests/run-pass/taint.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub struct Foo {
+    bar: i64,
+}
+
+fn source() -> Foo {
+    let result = Foo { bar: 1 };
+    set_model_field!(&result, tainted, true);
+    result
+}
+
+pub fn sink(foo: Foo) {
+    // If foo has not been explicitly tainted by a source, it is not tainted.
+    precondition!(!get_model_field!(&foo, tainted, false)); //~ related location
+    let _x = foo.bar;
+}
+
+fn sanitize(foo: &Foo) {
+    set_model_field!(foo, tainted, false);
+}
+
+pub fn test1() {
+    let untainted = Foo { bar: 2 };
+    sink(untainted);
+}
+
+pub fn test2() {
+    let tainted = source();
+    sanitize(&tainted);
+    sink(tainted);
+}
+
+pub fn test3() {
+    let tainted = source();
+    sink(tainted); //~ unsatisfied precondition
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

This PR adds the ability to attach specification only (model/ghost) fields to arbitrary values and to inspect them inside of verification conditions that are not checked at runtime (assume!, verify! and precondition!).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
See the new test case, taint.rs, that shows how model fields can be used to check that tainted values are sanitized before being used in dangerous places.
