### PR TITLE
Add contracts and fix complaint

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -917,7 +917,7 @@ impl Path {
                 Path::QualifiedPath {
                     qualifier: box new_qualifier,
                     selector: selector.clone(),
-                    length: new_qualifier_path_length + 1,
+                    length: new_qualifier_path_length.wrapping_add(1), //todo: this should not be necessary
                 }
             }
             _ => new_root,


### PR DESCRIPTION
## Description

Shut up an irritating false positive message by using wrapping_add. Also use the new model field feature to provide a sanity check for some abstract SmtSolver methods.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh

