### PR TITLE
Provide a way to return (and constrain) the result of a function spec.

### DIFF
--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -532,6 +532,24 @@ macro_rules! get_model_field {
     };
 }
 
+/// Provides a way to refer to the result value of an abstract or contract function without
+/// specifying an actual value anywhere.
+/// This macro expands to unimplemented!() unless the program is compiled with MIRAI.
+/// It result should therefore not be assigned to a variable unless the assignment is contained
+/// inside a specification macro argument list.
+/// It may, however, be the return value of the function, which should never be called and
+/// therefore unimplemented!() is the right behavior for it at runtime.
+#[macro_export]
+macro_rules! result {
+    () => {
+        if cfg!(mirai) {
+            mirai_annotations::mirai_result()
+        } else {
+            unimplemented!()
+        }
+    };
+}
+
 /// Sets the value of the specified model field.
 /// A model field does not exist at runtime and is invisible to the Rust compiler.
 /// This macro expands to nothing unless the program is compiled with MIRAI.
@@ -560,6 +578,12 @@ pub fn mirai_verify(_condition: bool, _message: &str) {}
 #[doc(hidden)]
 pub fn mirai_get_model_field<T, V>(_target: T, _field_name: &str, default_value: V) -> V {
     default_value
+}
+
+// Helper function for MIRAI. Should only be called via the result! macro.
+#[doc(hidden)]
+pub fn mirai_result<T>() -> T {
+    unreachable!()
 }
 
 // Helper function for MIRAI. Should only be called via the set_model_field macro.

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -63,6 +63,8 @@ pub enum KnownFunctionNames {
     MiraiGetModelField,
     /// mirai_annotations.mirai_precondition
     MiraiPrecondition,
+    /// mirai_annotations.mirai_result
+    MiraiResult,
     /// mirai_annotations.mirai_set_model_field
     MiraiSetModelField,
     /// mirai_annotations.mirai_verify
@@ -84,6 +86,7 @@ impl ConstantDomain {
             "mirai_annotations.mirai_assume" => KnownFunctionNames::MiraiAssume,
             "mirai_annotations.mirai_get_model_field" => KnownFunctionNames::MiraiGetModelField,
             "mirai_annotations.mirai_precondition" => KnownFunctionNames::MiraiPrecondition,
+            "mirai_annotations.mirai_result" => KnownFunctionNames::MiraiResult,
             "mirai_annotations.mirai_set_model_field" => KnownFunctionNames::MiraiSetModelField,
             "mirai_annotations.mirai_verify" => KnownFunctionNames::MiraiVerify,
             "std.panicking.begin_panic" => KnownFunctionNames::StdBeginPanic,

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -979,6 +979,24 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                 }
                 return true;
             }
+            KnownFunctionNames::MiraiResult => {
+                if let Some((place, target)) = destination {
+                    let target_path = self.visit_place(place);
+                    let target_type = self.get_place_type(place);
+                    let return_value_path = Path::LocalVariable { ordinal: 0 };
+                    let return_value =
+                        self.lookup_path_and_refine_result(return_value_path, target_type);
+                    self.current_environment
+                        .update_value_at(target_path, return_value);
+                    let exit_condition = self.exit_environment.entry_condition.clone();
+                    self.current_environment
+                        .exit_conditions
+                        .insert(*target, exit_condition);
+                } else {
+                    unreachable!();
+                }
+                return true;
+            }
             _ => {
                 let result: AbstractValue =
                     self.try_to_inline_standard_ops_func(known_name, &actual_args);

--- a/checker/tests/run-pass/core_contract.rs
+++ b/checker/tests/run-pass/core_contract.rs
@@ -27,8 +27,7 @@ pub mod foreign_contracts {
                         },
                         "self may not be None"
                     );
-                    assume!(false);
-                    unreachable!();
+                    result!()
                 }
             }
         }


### PR DESCRIPTION
## Description

Function bodies that provide contracts for foreign/imported/abstract functions can be awkward to write in normal Rust if the function has a return result, since a specification may be abstract and the return result of a normal Rust function must be concrete. This PR adds a result!() macro that looks like a concrete value to the Rust compiler and that is understood by MIRAI as an abstract value that can be constrained with assertions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
modified a test case
