### PR TITLE
Make function values indicate if they are well known.

### DIFF
--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -22,7 +22,6 @@ extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_metadata;
-extern crate rustc_target;
 extern crate syntax;
 extern crate syntax_pos;
 

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -8,7 +8,6 @@ use rustc::hir::def_id::DefId;
 use rustc::hir::ItemKind;
 use rustc::hir::Node;
 use rustc::ty::TyCtxt;
-use rustc_target::spec::abi::Abi;
 
 /// Returns the location of the rust system binaries that are associated with this build of Mirai.
 /// The location is obtained by looking at the contents of the environmental variables that were
@@ -28,17 +27,6 @@ pub fn find_sysroot() -> String {
                  or use rustup to set the compiler to use for Mirai",
             )
             .to_owned(),
-    }
-}
-
-/// Returns true if the function identified by def_id is a Rust intrinsic function.
-/// Warning: it is not clear what will happen if def_id does not identify a function.
-pub fn is_rust_intrinsic(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
-    let binder = tcx.fn_sig(def_id);
-    let sig = binder.skip_binder();
-    match sig.abi {
-        Abi::RustIntrinsic => true,
-        _ => false,
     }
 }
 


### PR DESCRIPTION
## Description

Rather than lazily caching the function values that correspond to well known functions that MIRAI needs to treat in special ways, we now include an enum in all function values that identify the function as well known or not.

While at it, the PR also remove the unused is_intrinsic flag from function values.

Fixes #125

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
