### PR TITLE
Fix widen operation and other loop related bugs.

### DIFF
--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -426,10 +426,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             };
             // Analyze the basic block
             in_state.insert(*bb, i_state.clone());
-            if i_state.entry_condition.as_bool_if_known().unwrap_or(true) {
-                self.current_environment = i_state;
-                self.visit_basic_block(*bb);
-            }
+            self.current_environment = i_state;
+            self.visit_basic_block(*bb);
 
             // Check for a fixed point.
             if !self.current_environment.subset(&out_state[bb]) {
@@ -1530,6 +1528,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     self.check_condition_value_and_reachability(&cond_val);
 
                 // Quick exit if things are known.
+                if let Some(false) = entry_cond_as_bool {
+                    // We can't reach this assertion, so just return.
+                    return;
+                }
                 if cond_as_bool.is_some() {
                     if expected == cond_as_bool.unwrap() {
                         // If the condition is always as expected when we get here, so there is nothing to report.

--- a/checker/tests/run-pass/nested_while_loops.rs
+++ b/checker/tests/run-pass/nested_while_loops.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Tests a nested loop that uses a loop variable from the outer loop to modify the inner loop variable
+
+pub fn main() {
+    let mut i = 1;
+    while i < 100 {
+        let mut j = i;
+        while j <= 100 {
+            j += i; //~ possible attempt to add with overflow
+        }
+        i += 1; //~ possible attempt to add with overflow
+    }
+}


### PR DESCRIPTION
## Description

Once a joined value has been widened, further widening operations should be idempotent, otherwise the fixed point loop won't converge (and values will blow up in size so much that performance tanks).

While debugging this I also noticed that excluding blocks with false entry conditions slows down fixed point convergence by delaying path propagation. I also noticed that assertions that are definitely not reachable are still reported as (potentially) failing and fixed that too. 

## Type of change

- [x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Added a new test case involving nested loops.
