### PR TITLE
Use name mangling to connect contracts to abstract/generic funcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode/
 .idea/
 target/
-.summary_store.rocksdb
+examples/

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -69,6 +69,11 @@ impl Environment {
             self.update_value_at(true_path, true_val);
             self.update_value_at(false_path, false_val);
         }
+        //todo: if the path contains an Index selector where the index is abstract, then
+        //this entry should be weakly updated with any paths that are contained by it and already
+        //in the environment.
+        //Conversely, if this path is contained in a path that is already in the environment, then
+        //that path should be updated weakly.
         self.value_map = self.value_map.insert(path, value);
     }
 

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -6,9 +6,139 @@
 
 // A test that uses a loop counter incremented via a for-in.
 
+#![feature(type_alias_enum_variants)]
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub mod foreign_contracts {
+    pub mod core {
+
+        pub mod option {
+            pub enum Option<T> {
+                None,
+                Some(T),
+            }
+
+            impl<T> Option<T> {
+                pub fn is_none(&self) -> bool {
+                    match self {
+                        Self::None => true,
+                        _ => false,
+                    }
+                }
+
+                pub fn is_some(&self) -> bool {
+                    match self {
+                        Self::None => false,
+                        _ => true,
+                    }
+                }
+
+                pub fn unwrap(self) -> T {
+                    precondition!(self.is_some(), "self may not be None");
+                    result!()
+                }
+            }
+
+            pub mod impl_5 {
+                use crate::foreign_contracts::core::option::Option;
+
+                pub fn unwrap_or_default<T: Default>(v: Option<T>) -> T {
+                    match v {
+                        Option::None => Default::default(),
+                        Option::Some(v) => v,
+                    }
+                }
+            }
+        }
+
+        pub mod ops {
+            pub mod range {
+                pub mod impl_12 {
+                    pub struct RangeInclusive_usize {
+                        pub start: usize,
+                        pub end: usize,
+                        pub is_empty: Option<bool>,
+                        // This field is:
+                        //  - `None` when next() or next_back() was never called
+                        //  - `Some(false)` when `start <= end` assuming no overflow
+                        //  - `Some(true)` otherwise
+                        // The field cannot be a simple `bool` because the `..=` constructor can
+                        // accept non-PartialOrd types, also we want the constructor to be const.
+                    }
+
+                    pub fn new_usize_usize(start: usize, end: usize) -> RangeInclusive_usize {
+                        RangeInclusive_usize {
+                            start,
+                            end,
+                            is_empty: None,
+                        }
+                    }
+
+                    // If this range's `is_empty` is field is unknown (`None`), update it to be a concrete value.
+                    pub fn compute_is_empty_usize(range: &mut RangeInclusive_usize) {
+                        if range.is_empty.is_none() {
+                            range.is_empty = Some(!(range.start <= range.end));
+                        }
+                    }
+                }
+            }
+        }
+
+        pub mod iter {
+            pub mod traits {
+                pub mod collect {
+                    use crate::foreign_contracts::core::ops::range::impl_12::RangeInclusive_usize;
+
+                    pub trait IntoIterator {
+                        fn into_iter_core_ops_range_RangeInclusive_usize(
+                            range: RangeInclusive_usize,
+                        ) -> RangeInclusive_usize {
+                            range
+                        }
+                    }
+                }
+
+                pub mod iterator {
+                    use crate::foreign_contracts::core::ops::range::impl_12::{
+                        compute_is_empty_usize, RangeInclusive_usize,
+                    };
+
+                    pub trait Iterator {
+                        fn next_ref_mut_core_ops_range_RangeInclusive_usize(
+                            mut range: &mut RangeInclusive_usize,
+                        ) -> Option<usize> {
+                            compute_is_empty_usize(&mut range);
+                            if range.is_empty.unwrap_or_default() {
+                                return None;
+                            }
+                            let is_iterating = range.start < range.end;
+                            range.is_empty = Some(!is_iterating);
+                            Some(if is_iterating {
+                                let n = range.start;
+                                verify!(n < range.end);
+                                range.start = n + 1; //~ possible attempt to add with overflow
+                                n
+                            } else {
+                                range.start
+                            })
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}
+
 pub fn foo(n: usize) {
     for ordinal in 2..=n {
-        assert!(ordinal - 1 >= 1); //~ possible attempt to subtract with overflow
+        //~ possible attempt to add with overflow
+        verify!(ordinal - 1 >= 1); //~ possible attempt to subtract with overflow
+                                   //~ possible false verification condition
     }
 }
 


### PR DESCRIPTION
## Description

Some traits have contracts that are difficult to describe accurately in the abstract. For example, the contract the generic iterator next function cannot say much that is definitive about the elements it returns. Certainly not enough for widening to come up with an expression that has a useful interval domain.

One way to deal with such situations is to have separate contracts for particular instantiations of the generic trait. For example, a separate contract for the iterator trait returned by RangeInclusive.into_iter function can result in a summary that allows the underlying counter increment to to become visible to the Abstract Interpreter.

This PR introduces the necessary mechanism to do this. The basic idea is to use the the type of the function constant used to call a generic trait function to discover the generic argument types and then to append the fully qualified signature of those types to the function summary key. If the summary cache has a summary for this key, that is used. If not, we fall back to using the generic key and its generic summary.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Beefed up the for_in.rs test case with foreign contracts for the core methods used under the cover of the the` for ordinal in 2..=n` construct.

