### PR TITLE
Use name mangling to connect contracts to abstract/generic funcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode/
 .idea/
 target/
-.summary_store.rocksdb
+examples/

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -69,6 +69,11 @@ impl Environment {
             self.update_value_at(true_path, true_val);
             self.update_value_at(false_path, false_val);
         }
+        //todo: if the path contains an Index selector where the index is abstract, then
+        //this entry should be weakly updated with any paths that are contained by it and already
+        //in the environment.
+        //Conversely, if this path is contained in a path that is already in the environment, then
+        //that path should be updated weakly.
         self.value_map = self.value_map.insert(path, value);
     }
 

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -7,7 +7,8 @@ use log::debug;
 use rustc::hir::def_id::DefId;
 use rustc::hir::ItemKind;
 use rustc::hir::Node;
-use rustc::ty::TyCtxt;
+use rustc::ty::subst::UnpackedKind;
+use rustc::ty::{Ty, TyCtxt, TyKind};
 
 /// Returns the location of the rust system binaries that are associated with this build of Mirai.
 /// The location is obtained by looking at the contents of the environmental variables that were
@@ -58,6 +59,139 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
     }
 }
 
+/// Returns a string that is a valid identifier, made up from the concatenation of
+/// the string representationss of the given list of argument types.
+pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) -> String {
+    let mut result = "_".to_string();
+    let bound_sig = ty.fn_sig(*tcx);
+    let sig = bound_sig.skip_binder();
+    for arg_ty in sig.inputs().iter() {
+        result.push('_');
+        append_mangled_type(&mut result, arg_ty, tcx);
+    }
+    result
+}
+
+/// Appends a string to str with the constraint that it must uniquely identify ty and also
+/// be a valid identifier (so that core library contracts can be written for type specialized
+/// generic trait methods).
+fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'_, '_, 'tcx>) {
+    use syntax::ast;
+    use TyKind::*;
+    match ty.sty {
+        Bool => str.push_str("bool"),
+        Char => str.push_str("char"),
+        Int(int_ty) => {
+            str.push_str(match int_ty {
+                ast::IntTy::Isize => "isize",
+                ast::IntTy::I8 => "i8",
+                ast::IntTy::I16 => "i16",
+                ast::IntTy::I32 => "i32",
+                ast::IntTy::I64 => "i64",
+                ast::IntTy::I128 => "i128",
+            });
+        }
+        Uint(uint_ty) => {
+            str.push_str(match uint_ty {
+                ast::UintTy::Usize => "usize",
+                ast::UintTy::U8 => "u8",
+                ast::UintTy::U16 => "u16",
+                ast::UintTy::U32 => "u32",
+                ast::UintTy::U64 => "u64",
+                ast::UintTy::U128 => "u128",
+            });
+        }
+        Float(float_ty) => {
+            str.push_str(match float_ty {
+                ast::FloatTy::F32 => "f32",
+                ast::FloatTy::F64 => "f64",
+            });
+        }
+        Adt(def, subs) => {
+            str.push_str(qualified_type_name(tcx, def.did).as_str());
+            for sub in subs {
+                if let UnpackedKind::Type(ty) = sub.unpack() {
+                    str.push('_');
+                    append_mangled_type(str, ty, tcx);
+                }
+            }
+        }
+        Foreign(def_id) => {
+            str.push_str("extern_type_");
+            str.push_str(qualified_type_name(tcx, def_id).as_str());
+        }
+        Str => str.push_str("str"),
+        Array(ty, len) => {
+            str.push_str("array_");
+            append_mangled_type(str, ty, tcx);
+            str.push('_');
+            str.push_str(&format!("{:?}", len));
+        }
+        Slice(ty) => {
+            str.push_str("slice_");
+            append_mangled_type(str, ty, tcx);
+        }
+        RawPtr(ty_and_mut) => {
+            str.push_str("pointer_");
+            match ty_and_mut.mutbl {
+                rustc::hir::MutMutable => str.push_str("mut_"),
+                rustc::hir::MutImmutable => str.push_str("const_"),
+            }
+            append_mangled_type(str, ty_and_mut.ty, tcx);
+        }
+        Ref(_, ty, mutability) => {
+            str.push_str("ref_");
+            if mutability == rustc::hir::MutMutable {
+                str.push_str("mut_");
+            }
+            append_mangled_type(str, ty, tcx);
+        }
+        FnPtr(psig) => {
+            str.push_str(&format!("FnPtr {:?}", psig));
+        }
+        Tuple(types) => {
+            str.push_str("tuple_");
+            str.push_str(&format!("{}", types.len()));
+            types.iter().for_each(|t| {
+                str.push('_');
+                append_mangled_type(str, t, tcx);
+            });
+        }
+        Param(param_ty) => {
+            let ty: Ty<'tcx> = param_ty.to_ty(*tcx);
+            str.push_str(&format!("{:?}", ty));
+        }
+        _ => {
+            //todo: add cases as the need arises, meanwhile make the need obvious.
+            str.push_str(&format!("default formatted {:?}", ty))
+        }
+    }
+}
+
+/// Pretty much the same as summary_key_str but with _ used rather than . so that
+/// the result can be appended to a valid identifier.
+fn qualified_type_name(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
+    let mut name = if def_id.is_local() {
+        tcx.crate_name.as_interned_str().as_str().to_string()
+    } else {
+        let cdata = tcx.crate_data_as_rc_any(def_id.krate);
+        let cdata = cdata
+            .downcast_ref::<rustc_metadata::cstore::CrateMetadata>()
+            .unwrap();
+        cdata.name.as_str().to_string()
+    };
+    for component in &tcx.def_path(def_id).data {
+        name.push('_');
+        name.push_str(component.data.as_interned_str().as_str().get());
+        if component.disambiguator != 0 {
+            name.push('_');
+            let da = component.disambiguator.to_string();
+            name.push_str(da.as_str());
+        }
+    }
+    name
+}
+
 /// Constructs a string that uniquely identifies a definition to serve as a key to
 /// the summary cache, which is a key value store. The string will always be the same as
 /// long as the definition does not change its name or location, so it can be used to
@@ -91,9 +225,15 @@ pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         } else {
             name.push('.');
         }
-        name.push_str(component.data.as_interned_str().as_str().get());
+        let component_name = component.data.as_interned_str().as_str();
+        let component_name = component_name.get();
+        if component_name == "{{impl}}" {
+            name.push_str("impl");
+        } else {
+            name.push_str(component_name);
+        }
         if component.disambiguator != 0 {
-            name.push(':');
+            name.push('_');
             let da = component.disambiguator.to_string();
             name.push_str(da.as_str());
         }

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -6,9 +6,139 @@
 
 // A test that uses a loop counter incremented via a for-in.
 
+#![feature(type_alias_enum_variants)]
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub mod foreign_contracts {
+    pub mod core {
+
+        pub mod option {
+            pub enum Option<T> {
+                None,
+                Some(T),
+            }
+
+            impl<T> Option<T> {
+                pub fn is_none(&self) -> bool {
+                    match self {
+                        Self::None => true,
+                        _ => false,
+                    }
+                }
+
+                pub fn is_some(&self) -> bool {
+                    match self {
+                        Self::None => false,
+                        _ => true,
+                    }
+                }
+
+                pub fn unwrap(self) -> T {
+                    precondition!(self.is_some(), "self may not be None");
+                    result!()
+                }
+            }
+
+            pub mod impl_5 {
+                use crate::foreign_contracts::core::option::Option;
+
+                pub fn unwrap_or_default<T: Default>(v: Option<T>) -> T {
+                    match v {
+                        Option::None => Default::default(),
+                        Option::Some(v) => v,
+                    }
+                }
+            }
+        }
+
+        pub mod ops {
+            pub mod range {
+                pub mod impl_12 {
+                    pub struct RangeInclusive_usize {
+                        pub start: usize,
+                        pub end: usize,
+                        pub is_empty: Option<bool>,
+                        // This field is:
+                        //  - `None` when next() or next_back() was never called
+                        //  - `Some(false)` when `start <= end` assuming no overflow
+                        //  - `Some(true)` otherwise
+                        // The field cannot be a simple `bool` because the `..=` constructor can
+                        // accept non-PartialOrd types, also we want the constructor to be const.
+                    }
+
+                    pub fn new__usize_usize(start: usize, end: usize) -> RangeInclusive_usize {
+                        RangeInclusive_usize {
+                            start,
+                            end,
+                            is_empty: None,
+                        }
+                    }
+
+                    // If this range's `is_empty` is field is unknown (`None`), update it to be a concrete value.
+                    pub fn compute_is_empty__usize(range: &mut RangeInclusive_usize) {
+                        if range.is_empty.is_none() {
+                            range.is_empty = Some(!(range.start <= range.end));
+                        }
+                    }
+                }
+            }
+        }
+
+        pub mod iter {
+            pub mod traits {
+                pub mod collect {
+                    use crate::foreign_contracts::core::ops::range::impl_12::RangeInclusive_usize;
+
+                    pub trait IntoIterator {
+                        fn into_iter__core_ops_range_RangeInclusive_usize(
+                            range: RangeInclusive_usize,
+                        ) -> RangeInclusive_usize {
+                            range
+                        }
+                    }
+                }
+
+                pub mod iterator {
+                    use crate::foreign_contracts::core::ops::range::impl_12::{
+                        compute_is_empty__usize, RangeInclusive_usize,
+                    };
+
+                    pub trait Iterator {
+                        fn next__ref_mut_core_ops_range_RangeInclusive_usize(
+                            mut range: &mut RangeInclusive_usize,
+                        ) -> Option<usize> {
+                            compute_is_empty__usize(&mut range);
+                            if range.is_empty.unwrap_or_default() {
+                                return None;
+                            }
+                            let is_iterating = range.start < range.end;
+                            range.is_empty = Some(!is_iterating);
+                            Some(if is_iterating {
+                                let n = range.start;
+                                verify!(n < range.end);
+                                range.start = n + 1; //~ possible attempt to add with overflow
+                                n
+                            } else {
+                                range.start
+                            })
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}
+
 pub fn foo(n: usize) {
     for ordinal in 2..=n {
-        assert!(ordinal - 1 >= 1); //~ possible attempt to subtract with overflow
+        //~ possible attempt to add with overflow
+        verify!(ordinal - 1 >= 1); //~ possible attempt to subtract with overflow
+                                   //~ possible false verification condition
     }
 }
 


### PR DESCRIPTION
## Description

See #150 
