### PR TITLE
Do not let promoted constants mess up the previous summary

### DIFF
--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -41,7 +41,7 @@ use std::ops::Deref;
 ///    desirable to havoc all static variables every time such a function is called. Consequently
 ///    sound analysis is only possible one can assume that all such functions have been provided
 ///    with explicit contract functions.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq)]
 pub struct Summary {
     /// The number of seconds that the analyzer used to construct this summary.
     /// If it is >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY then this summary is not definitive
@@ -92,6 +92,30 @@ pub struct Summary {
     // under the current path condition. They should then update their current state to reflect the
     // side-effects of the call for the unwind control paths, following the call.
     pub unwind_side_effects: Vec<(Path, AbstractValue)>,
+}
+
+impl PartialEq for Summary {
+    fn eq(&self, other: &Summary) -> bool {
+        if !self.result.eq(&other.result) {
+            return false;
+        }
+        if self.preconditions != other.preconditions {
+            return false;
+        }
+        if self.side_effects != other.side_effects {
+            return false;
+        }
+        if self.post_conditions != other.post_conditions {
+            return false;
+        }
+        if self.post_conditions != other.post_conditions {
+            return false;
+        }
+        if self.unwind_side_effects != other.unwind_side_effects {
+            return false;
+        }
+        true
+    }
 }
 
 /// Constructs a summary of a function body by processing state information gathered during


### PR DESCRIPTION
## Description

Looking into why the outer fixed point does not converge I found two minor problems that are fixed in this PR:
1) The default equality comparison for summaries compared the analysis time field, which clearly is neither deterministic nor relevant to the fixed point computation.
2) When a function body has embedded bodies for promoted constants, these bodies should not be summarized. Not only were they summarized, but the summaries were written to the cache, which made the before and after comparisons useless because the current (corrupted) version of the cache was used as the before version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh

