### PR TITLE
Handle case of callee returning a moved arg

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -521,8 +521,12 @@ impl AbstractDomain {
         if self.is_bottom() {
             return other;
         }
-        // x union {} just x
+        // x union {} is just x
         if other.is_bottom() {
+            return self;
+        }
+        // x union x is just x
+        if self == other {
             return self;
         }
         Expression::Join {

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -1540,6 +1540,13 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                 .clone()
                 .refine_parameters(arguments)
                 .refine_paths(&mut self.current_environment);
+            for (arg_path, arg_val) in arguments.iter() {
+                if arg_val.eq(&rvalue) {
+                    let rtype = rvalue.domain.expression.infer_type();
+                    self.copy_or_move_elements(tpath, arg_path.clone(), rtype, false);
+                    return;
+                }
+            }
             self.current_environment.update_value_at(tpath, rvalue);
         }
     }

--- a/checker/tests/run-pass/assume.rs
+++ b/checker/tests/run-pass/assume.rs
@@ -11,15 +11,24 @@ extern crate mirai_annotations;
 
 pub fn main() {
     foo(2); // This breaks an assumed pre-condition and leads to a runtime failure.
-    // It is not checked by Mirai, because of the assumption.
-    // Unlike this test case, in real life assumptions are made for complicated reasons that are
-    // hard to encode in checked preconditions.
+            // It is not checked by Mirai, because of the assumption.
+            // Unlike this test case, in real life assumptions are made for complicated reasons that are
+            // hard to encode in checked preconditions.
+    foo2(2); //~ possible false verification condition
 }
 
 pub fn foo(i: i32) {
     checked_assume!(i == 3); // this is a pre-condition that is assumed to hold.
-    // It is not promoted, but it is checked here at runtime.
+                             // It is not promoted, but it is checked here at runtime.
     let x = if i == 3 { 1 } else { 2 };
-    verify!(x == 1);  // This is neither true, nor checked at runtime, but it can only fail if
-    // the assumption above, which is checked at runtime does not fail.
+    verify!(x == 1); // This is neither true, nor checked at runtime, but it can only fail if
+                     // the assumption above, which is checked at runtime, does not fail.
+}
+
+pub fn foo2(i: i32) {
+    verify!(i == 3); //~ possible false verification condition
+                     //~ related location
+    let x = if i == 3 { 1 } else { 2 };
+    verify!(x == 1); // This is neither true, nor checked at runtime, but it can only fail if
+                     // the first verify fails, so the problem is already pointed out and we need not repeat ourselves.
 }

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -16,6 +16,14 @@ extern crate mirai_annotations;
 pub mod foreign_contracts {
     pub mod core {
 
+        pub mod default {
+            pub trait Default {
+                fn default_() {
+                    result!()
+                }
+            }
+        }
+
         pub mod option {
             pub enum Option<T> {
                 None,

--- a/checker/tests/run-pass/move_return.rs
+++ b/checker/tests/run-pass/move_return.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls std::intrinsics::unreachable conditionally.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn id<T>(x: T) -> T {
+    x
+}
+
+struct Foo {
+    x: i32,
+    y: i32,
+}
+
+pub fn main() {
+    let foo = Foo { x: 1, y: 2 };
+    verify!(foo.x == 1);
+    let foo2 = id(foo);
+    verify!(foo2.y == 2);
+}


### PR DESCRIPTION
## Description

When a structured value is passed to a function with a move and then returned by the function in some way, the caller does not see the structure of the returned value because the function does not have to know the structure or reveal it via its side-effects.

Fixed this by checking if a leaf side-effect assignment refers to a structured value that came from the caller and then doing a deep copy.

Also fixed a small problem with join, which did not optimize` x join x` into just `x`, which caused constants to get widened away.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
New test case
