### PR TITLE
Provide a dedicated selector for Enum discriminants.

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -149,6 +149,16 @@ impl From<Expression> for AbstractDomain {
 impl AbstractDomain {
     /// Returns an element that is "self + other".
     pub fn addition(self, other: Self) -> Self {
+        if let Expression::Add { left, right } = &self.expression {
+            if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
+                (&right.expression, &other.expression)
+            {
+                let folded = v1.add(v2);
+                if folded != ConstantDomain::Bottom {
+                    return left.clone().addition(folded.into());
+                }
+            }
+        }
         self.try_to_simplify_binary_op(other, ConstantDomain::add, |left, right| {
             Expression::Add {
                 left: box left,
@@ -388,6 +398,34 @@ impl AbstractDomain {
                     }
                 }
             }
+            // (c ? 0 : 1) == 0 is the same as c
+            // (c ? 1 : 0) == 1 is the same as c
+            // (c ? 0 : 1) == 1 is the same as !c
+            // (c ? 1 : 0) == 0 is the same as !c
+            (
+                Expression::ConditionalExpression {
+                    condition,
+                    consequent,
+                    alternate,
+                },
+                Expression::CompileTimeConstant(ConstantDomain::U128(result_val)),
+            ) => {
+                if let (
+                    Expression::CompileTimeConstant(ConstantDomain::U128(cons_val)),
+                    Expression::CompileTimeConstant(ConstantDomain::U128(alt_val)),
+                ) = (&consequent.expression, &alternate.expression)
+                {
+                    match (*cons_val, *alt_val, *result_val) {
+                        (0, 1, 0) | (1, 0, 1) => {
+                            return (**condition).clone();
+                        }
+                        (0, 1, 1) | (1, 0, 0) => {
+                            return (**condition).clone().logical_not();
+                        }
+                        _ => (),
+                    }
+                }
+            }
             // !x == 0 is the same as x when x is Boolean. Canonicalize it to the latter.
             (
                 Expression::Not { operand },
@@ -398,12 +436,14 @@ impl AbstractDomain {
                 }
             }
             // x == 0 is the same as !x when x is a Boolean. Canonicalize it to the latter.
+            // x == 1 is the same as x when x is a Boolean. Canonicalize it to the latter.
             (x, Expression::CompileTimeConstant(ConstantDomain::U128(val))) => {
-                if *val == 0 && (x.infer_type() == ExpressionType::Bool) {
-                    return Expression::Not {
-                        operand: box x.clone().into(),
+                if x.infer_type() == ExpressionType::Bool {
+                    if *val == 0 {
+                        return self.logical_not();
+                    } else if *val == 1 {
+                        return self.clone();
                     }
-                    .into();
                 }
             }
             (x, y) => {
@@ -1012,7 +1052,10 @@ impl AbstractDomain {
             Expression::Or { left, right } => left
                 .refine_paths(environment)
                 .or(right.refine_paths(environment)),
-            Expression::Reference(..) => self,
+            Expression::Reference(path) => {
+                let refined_path = path.refine_paths(environment);
+                Expression::Reference(refined_path).into()
+            }
             Expression::Rem { left, right } => left
                 .refine_paths(environment)
                 .remainder(right.refine_paths(environment)),
@@ -1179,7 +1222,21 @@ impl AbstractDomain {
             Expression::Or { left, right } => left
                 .refine_parameters(arguments)
                 .or(right.refine_parameters(arguments)),
-            Expression::Reference(..) => self,
+            Expression::Reference(path) => {
+                // if the path is a parameter, the reference is an artifact of its type
+                // and needs to be removed in the call context
+                match path {
+                    Path::LocalVariable { ordinal }
+                        if 0 < ordinal && ordinal <= arguments.len() =>
+                    {
+                        arguments[ordinal - 1].1.domain.clone()
+                    }
+                    _ => {
+                        let refined_path = path.refine_parameters(arguments);
+                        Expression::Reference(refined_path).into()
+                    }
+                }
+            }
             Expression::Rem { left, right } => left
                 .refine_parameters(arguments)
                 .remainder(right.refine_parameters(arguments)),
@@ -1430,7 +1487,7 @@ impl AbstractDomain {
     ) -> Self {
         match (&self.expression, &other.expression) {
             (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) => {
-                let result = const_op(&v1, &v2);
+                let result = const_op(v1, v2);
                 if result == ConstantDomain::Bottom {
                     self.try_to_distribute_binary_op(other, operation)
                 } else {
@@ -1486,6 +1543,9 @@ impl AbstractDomain {
     /// in memory at the given path.
     pub fn widen(self, path: Path) -> Self {
         if let Widen { .. } = self.expression {
+            return self;
+        }
+        if let Expression::CompileTimeConstant(..) = self.expression {
             return self;
         }
         Expression::Widen {

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -934,6 +934,9 @@ pub enum PathSelector {
     /// Given a path that denotes a reference, select the thing the reference points to.
     Deref,
 
+    /// The tag used to indicate which case of an enum is used for a particular enum value.
+    Discriminant,
+
     /// Select the struct field with the given index.
     Field(usize),
 

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -93,7 +93,7 @@ impl ConstantDomain {
             .get_argument_types_key_for(def_id, ty)
             .to_owned();
         let known_name = match summary_cache_key.as_str() {
-            "core.slice.impl.len" => KnownFunctionNames::CoreSliceLen,
+            "core.slice.implement.len" => KnownFunctionNames::CoreSliceLen,
             "mirai_annotations.mirai_assume" => KnownFunctionNames::MiraiAssume,
             "mirai_annotations.mirai_get_model_field" => KnownFunctionNames::MiraiGetModelField,
             "mirai_annotations.mirai_precondition" => KnownFunctionNames::MiraiPrecondition,

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -228,7 +228,7 @@ pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         let component_name = component.data.as_interned_str().as_str();
         let component_name = component_name.get();
         if component_name == "{{impl}}" {
-            name.push_str("impl");
+            name.push_str("implement");
         } else {
             name.push_str(component_name);
         }

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -46,11 +46,9 @@ impl Z3Solver {
         unsafe {
             let _guard = Z3_MUTEX.lock().unwrap();
             let z3_sys_cfg = z3_sys::Z3_mk_config();
-            if !cfg!(target_os = "linux") {
-                let time_out = CString::new("timeout").unwrap().into_raw();
-                let ms = CString::new("100").unwrap().into_raw();
-                z3_sys::Z3_set_param_value(z3_sys_cfg, time_out, ms);
-            }
+            let time_out = CString::new("timeout").unwrap().into_raw();
+            let ms = CString::new("100").unwrap().into_raw();
+            z3_sys::Z3_set_param_value(z3_sys_cfg, time_out, ms);
 
             let z3_context = z3_sys::Z3_mk_context(z3_sys_cfg);
             let z3_solver = z3_sys::Z3_mk_solver(z3_context);
@@ -1077,13 +1075,13 @@ impl Z3Solver {
                 }
             }
             Expression::CompileTimeConstant(const_domain) => match const_domain {
-                //                ConstantDomain::Char(v) => unsafe {
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 16, v as *const char as *const bool)
-                //                },
-                //                ConstantDomain::False => unsafe {
-                //                    let v = false;
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
-                //                },
+                ConstantDomain::Char(v) => unsafe {
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 16, v as *const char as *const bool)
+                },
+                ConstantDomain::False => unsafe {
+                    let v = false;
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
+                },
                 ConstantDomain::F32(v) => unsafe {
                     let fv = f32::from_bits(*v);
                     z3_sys::Z3_mk_fpa_numeral_float(self.z3_context, fv, self.f32_sort)
@@ -1092,16 +1090,16 @@ impl Z3Solver {
                     let fv = f64::from_bits(*v);
                     z3_sys::Z3_mk_fpa_numeral_double(self.z3_context, fv, self.f64_sort)
                 },
-                //                ConstantDomain::I128(v) => unsafe {
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const i128 as *const bool)
-                //                },
-                //                ConstantDomain::U128(v) => unsafe {
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const u128 as *const bool)
-                //                },
-                //                ConstantDomain::True => unsafe {
-                //                    let v = true;
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
-                //                },
+                ConstantDomain::I128(v) => unsafe {
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const i128 as *const bool)
+                },
+                ConstantDomain::U128(v) => unsafe {
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const u128 as *const bool)
+                },
+                ConstantDomain::True => unsafe {
+                    let v = true;
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
+                },
                 _ => unsafe {
                     let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
                     z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)

--- a/checker/tests/run-pass/deref_ref_param_vals.rs
+++ b/checker/tests/run-pass/deref_ref_param_vals.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that tracks slice length data across calls.
+// The most interesting thing about this test is that S::new models the value of parameter s
+// as a Reference to the parameter. When this gets back to the caller via the return result
+// special handling is needed so that the caller does not end up with a reference to a reference.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+struct S<'a> {
+    slice: &'a [i64],
+}
+
+impl<'a> S<'a> {
+    pub fn new(s: &'a [i64]) -> S<'a> {
+        S { slice: s }
+    }
+
+    pub fn get_length(&self) -> usize {
+        self.slice.len()
+    }
+}
+
+pub fn main() {
+    let a = [1; 100];
+    let s = S::new(&a);
+    let n = s.get_length();
+    verify!(n == 100);
+}

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -51,7 +51,7 @@ pub mod foreign_contracts {
                 }
             }
 
-            pub mod impl_5 {
+            pub mod implement_5 {
                 use crate::foreign_contracts::core::option::Option;
 
                 pub fn unwrap_or_default<T: Default>(v: Option<T>) -> T {
@@ -65,7 +65,7 @@ pub mod foreign_contracts {
 
         pub mod ops {
             pub mod range {
-                pub mod impl_12 {
+                pub mod implement_12 {
                     pub struct RangeInclusive_usize {
                         pub start: usize,
                         pub end: usize,
@@ -99,7 +99,7 @@ pub mod foreign_contracts {
         pub mod iter {
             pub mod traits {
                 pub mod collect {
-                    use crate::foreign_contracts::core::ops::range::impl_12::RangeInclusive_usize;
+                    use crate::foreign_contracts::core::ops::range::implement_12::RangeInclusive_usize;
 
                     pub trait IntoIterator {
                         fn into_iter__core_ops_range_RangeInclusive_usize(
@@ -111,7 +111,7 @@ pub mod foreign_contracts {
                 }
 
                 pub mod iterator {
-                    use crate::foreign_contracts::core::ops::range::impl_12::{
+                    use crate::foreign_contracts::core::ops::range::implement_12::{
                         compute_is_empty__usize, RangeInclusive_usize,
                     };
 

--- a/checker/tests/run-pass/path_refinement.rs
+++ b/checker/tests/run-pass/path_refinement.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses an inferred post condition.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn check_index(a: &[i64], i: usize) -> Option<usize> {
+    if i < a.len() {
+        Some(i)
+    } else {
+        None
+    }
+}
+
+pub fn foo(i: usize) {
+    if let Some(j) = check_index(&[0; 100], i) {
+        verify!(j < 100);
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

The discriminant value of an Enum was treated bizarrely by associating it with the path of the entire enum. Made things more explicit, more like array lengths and less likely to cause subtle bugs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
