### PR TITLE
Don't widen addresses

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -1542,16 +1542,16 @@ impl AbstractDomain {
     /// deterministically lead to a set of values that include of the values that could be stored
     /// in memory at the given path.
     pub fn widen(self, path: Path) -> Self {
-        if let Widen { .. } = self.expression {
-            return self;
+        match self.expression {
+            Expression::Widen { .. }
+            | Expression::CompileTimeConstant(..)
+            | Expression::Reference(..)
+            | Expression::Variable { .. } => self,
+            _ => Expression::Widen {
+                path: box path,
+                operand: box self,
+            }
+            .into(),
         }
-        if let Expression::CompileTimeConstant(..) = self.expression {
-            return self;
-        }
-        Expression::Widen {
-            path: box path,
-            operand: box self,
-        }
-        .into()
     }
 }

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -816,9 +816,13 @@ impl Path {
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
     pub fn refine_paths(self, environment: &mut Environment) -> Self {
-        if environment.value_map.contains_key(&self) {
-            // if the environment has self as a key, then self is canonical.
-            return self;
+        if let Some(val) = environment.value_at(&self) {
+            // if the environment has self as a key, then self is canonical,
+            // except if val is a Reference to another path.
+            return match &val.domain.expression {
+                Expression::Reference(dereferenced_path) => dereferenced_path.clone(),
+                _ => self,
+            };
         };
         if let Path::QualifiedPath {
             qualifier,


### PR DESCRIPTION
## Description

Reference and variable expressions represent stack addresses, which are effectively constants and therefore should not be widened. The contents of the (referenced) variables are tracked and widened separately.

Also did a further tweak to path refinement.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
