### PR TITLE
Invalidate default summaries.

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -1548,16 +1548,16 @@ impl AbstractDomain {
     /// deterministically lead to a set of values that include of the values that could be stored
     /// in memory at the given path.
     pub fn widen(self, path: Path) -> Self {
-        if let Widen { .. } = self.expression {
-            return self;
+        match self.expression {
+            Expression::Widen { .. }
+            | Expression::CompileTimeConstant(..)
+            | Expression::Reference(..)
+            | Expression::Variable { .. } => self,
+            _ => Expression::Widen {
+                path: box path,
+                operand: box self,
+            }
+            .into(),
         }
-        if let Expression::CompileTimeConstant(..) = self.expression {
-            return self;
-        }
-        Expression::Widen {
-            path: box path,
-            operand: box self,
-        }
-        .into()
     }
 }

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -816,9 +816,13 @@ impl Path {
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
     pub fn refine_paths(self, environment: &mut Environment) -> Self {
-        if environment.value_map.contains_key(&self) {
-            // if the environment has self as a key, then self is canonical.
-            return self;
+        if let Some(val) = environment.value_at(&self) {
+            // if the environment has self as a key, then self is canonical,
+            // except if val is a Reference to another path.
+            return match &val.domain.expression {
+                Expression::Reference(dereferenced_path) => dereferenced_path.clone(),
+                _ => self,
+            };
         };
         if let Path::QualifiedPath {
             qualifier,

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -934,6 +934,9 @@ pub enum PathSelector {
     /// Given a path that denotes a reference, select the thing the reference points to.
     Deref,
 
+    /// The tag used to indicate which case of an enum is used for a particular enum value.
+    Discriminant,
+
     /// Select the struct field with the given index.
     Field(usize),
 

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -134,6 +134,7 @@ impl MiraiCallbacks {
             let defs_to_reanalyze = def_sets.defs_to_reanalyze;
             def_sets.defs_to_reanalyze = HashSet::new();
             def_sets.defs_to_analyze = defs_to_reanalyze;
+            persistent_summary_cache.invalidate_default_summaries();
             info!(" ");
         }
         self.emit_or_check_diagnostics(&mut diagnostics_for);

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -93,7 +93,7 @@ impl ConstantDomain {
             .get_argument_types_key_for(def_id, ty)
             .to_owned();
         let known_name = match summary_cache_key.as_str() {
-            "core.slice.impl.len" => KnownFunctionNames::CoreSliceLen,
+            "core.slice.implement.len" => KnownFunctionNames::CoreSliceLen,
             "mirai_annotations.mirai_assume" => KnownFunctionNames::MiraiAssume,
             "mirai_annotations.mirai_get_model_field" => KnownFunctionNames::MiraiGetModelField,
             "mirai_annotations.mirai_precondition" => KnownFunctionNames::MiraiPrecondition,

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -228,7 +228,7 @@ pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
         let component_name = component.data.as_interned_str().as_str();
         let component_name = component_name.get();
         if component_name == "{{impl}}" {
-            name.push_str("impl");
+            name.push_str("implement");
         } else {
             name.push_str(component_name);
         }

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -303,7 +303,6 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
 
         // Now create a summary of the body that can be in-lined into call sites.
         let summary = summaries::summarize(
-            elapsed_time_in_seconds,
             self.mir.arg_count,
             &self.exit_environment,
             &self.preconditions,

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -46,11 +46,9 @@ impl Z3Solver {
         unsafe {
             let _guard = Z3_MUTEX.lock().unwrap();
             let z3_sys_cfg = z3_sys::Z3_mk_config();
-            if !cfg!(target_os = "linux") {
-                let time_out = CString::new("timeout").unwrap().into_raw();
-                let ms = CString::new("100").unwrap().into_raw();
-                z3_sys::Z3_set_param_value(z3_sys_cfg, time_out, ms);
-            }
+            let time_out = CString::new("timeout").unwrap().into_raw();
+            let ms = CString::new("100").unwrap().into_raw();
+            z3_sys::Z3_set_param_value(z3_sys_cfg, time_out, ms);
 
             let z3_context = z3_sys::Z3_mk_context(z3_sys_cfg);
             let z3_solver = z3_sys::Z3_mk_solver(z3_context);
@@ -1077,13 +1075,13 @@ impl Z3Solver {
                 }
             }
             Expression::CompileTimeConstant(const_domain) => match const_domain {
-                //                ConstantDomain::Char(v) => unsafe {
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 16, v as *const char as *const bool)
-                //                },
-                //                ConstantDomain::False => unsafe {
-                //                    let v = false;
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
-                //                },
+                ConstantDomain::Char(v) => unsafe {
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 16, v as *const char as *const bool)
+                },
+                ConstantDomain::False => unsafe {
+                    let v = false;
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
+                },
                 ConstantDomain::F32(v) => unsafe {
                     let fv = f32::from_bits(*v);
                     z3_sys::Z3_mk_fpa_numeral_float(self.z3_context, fv, self.f32_sort)
@@ -1092,16 +1090,16 @@ impl Z3Solver {
                     let fv = f64::from_bits(*v);
                     z3_sys::Z3_mk_fpa_numeral_double(self.z3_context, fv, self.f64_sort)
                 },
-                //                ConstantDomain::I128(v) => unsafe {
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const i128 as *const bool)
-                //                },
-                //                ConstantDomain::U128(v) => unsafe {
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const u128 as *const bool)
-                //                },
-                //                ConstantDomain::True => unsafe {
-                //                    let v = true;
-                //                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
-                //                },
+                ConstantDomain::I128(v) => unsafe {
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const i128 as *const bool)
+                },
+                ConstantDomain::U128(v) => unsafe {
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const u128 as *const bool)
+                },
+                ConstantDomain::True => unsafe {
+                    let v = true;
+                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
+                },
                 _ => unsafe {
                     let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
                     z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)

--- a/checker/tests/run-pass/core_contract.rs
+++ b/checker/tests/run-pass/core_contract.rs
@@ -10,6 +10,13 @@
 #[macro_use]
 extern crate mirai_annotations;
 
+pub fn main() {
+    let x: Option<i64> = Some(1);
+    let _y = x.unwrap();
+    let z: Option<i64> = None;
+    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None
+}
+
 pub mod foreign_contracts {
     pub mod core {
         pub mod option {
@@ -32,11 +39,4 @@ pub mod foreign_contracts {
             }
         }
     }
-}
-
-pub fn main() {
-    let x: Option<i64> = Some(1);
-    let _y = x.unwrap();
-    let z: Option<i64> = None;
-    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None
 }

--- a/checker/tests/run-pass/deref_ref_param_vals.rs
+++ b/checker/tests/run-pass/deref_ref_param_vals.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that tracks slice length data across calls.
+// The most interesting thing about this test is that S::new models the value of parameter s
+// as a Reference to the parameter. When this gets back to the caller via the return result
+// special handling is needed so that the caller does not end up with a reference to a reference.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+struct S<'a> {
+    slice: &'a [i64],
+}
+
+impl<'a> S<'a> {
+    pub fn new(s: &'a [i64]) -> S<'a> {
+        S { slice: s }
+    }
+
+    pub fn get_length(&self) -> usize {
+        self.slice.len()
+    }
+}
+
+pub fn main() {
+    let a = [1; 100];
+    let s = S::new(&a);
+    let n = s.get_length();
+    verify!(n == 100);
+}

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -51,7 +51,7 @@ pub mod foreign_contracts {
                 }
             }
 
-            pub mod impl_5 {
+            pub mod implement_5 {
                 use crate::foreign_contracts::core::option::Option;
 
                 pub fn unwrap_or_default<T: Default>(v: Option<T>) -> T {
@@ -65,7 +65,7 @@ pub mod foreign_contracts {
 
         pub mod ops {
             pub mod range {
-                pub mod impl_12 {
+                pub mod implement_12 {
                     pub struct RangeInclusive_usize {
                         pub start: usize,
                         pub end: usize,
@@ -99,7 +99,7 @@ pub mod foreign_contracts {
         pub mod iter {
             pub mod traits {
                 pub mod collect {
-                    use crate::foreign_contracts::core::ops::range::impl_12::RangeInclusive_usize;
+                    use crate::foreign_contracts::core::ops::range::implement_12::RangeInclusive_usize;
 
                     pub trait IntoIterator {
                         fn into_iter__core_ops_range_RangeInclusive_usize(
@@ -111,7 +111,7 @@ pub mod foreign_contracts {
                 }
 
                 pub mod iterator {
-                    use crate::foreign_contracts::core::ops::range::impl_12::{
+                    use crate::foreign_contracts::core::ops::range::implement_12::{
                         compute_is_empty__usize, RangeInclusive_usize,
                     };
 

--- a/checker/tests/run-pass/path_refinement.rs
+++ b/checker/tests/run-pass/path_refinement.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses an inferred post condition.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn check_index(a: &[i64], i: usize) -> Option<usize> {
+    if i < a.len() {
+        Some(i)
+    } else {
+        None
+    }
+}
+
+pub fn foo(i: usize) {
+    if let Some(j) = check_index(&[0; 100], i) {
+        verify!(j < 100);
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/sized_array_parameter.rs
+++ b/checker/tests/run-pass/sized_array_parameter.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that indexes into a parameter of type fixed size array
+
+pub fn foo(a: [i32; 10], i: usize) -> i32 {
+    if i < a.len() {
+        a[i]
+    } else {
+        -99999
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

If a function is referenced before it has been analyzed, the summary cache for the function will be populated with a default summary. Once the function is analyzed, the cache gets updated.

This is all and good, but it does not work for functions that live in a foreign_contracts module, since those functions have DefIds that are different from the real ones. For such functions we use spoofed persistent summary keys to populate the persistent cache with summaries that look like they come from the actual functions. Now, while the persistent (DB) cache's entries are updated when the contract functions get analyzed, the default summaries in the transient cache wont be updated because the update logic uses the DefIds of the contract functions, not the actual functions.

To work around this, any default summary that remains in the transient cache following an outer fixed point run are removed from the transient cache, so that the cache logic is forced to query the persistent (DB) cache with the spoofed key.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Modified an existing test to fail without this fix
