### PR TITLE
DefId is not unique w.r.t. generic instantiations

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -152,7 +152,7 @@ impl MiraiCallbacks {
         compiler: &'a interface::Compiler,
         tcx: &'a TyCtxt<'a, 'tcx, 'tcx>,
         mut persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
-        mut constant_value_cache: &mut ConstantValueCache,
+        mut constant_value_cache: &mut ConstantValueCache<'tcx>,
         def_sets: &mut DefSets,
         diagnostics_for: &mut HashMap<DefId, Vec<DiagnosticBuilder<'a>>>,
         iteration_count: usize,
@@ -277,7 +277,7 @@ impl MiraiCallbacks {
         name: &str,
         compiler: &'b interface::Compiler,
         tcx: &'b TyCtxt<'b, 'tcx, 'tcx>,
-        mut constant_value_cache: &'a mut ConstantValueCache,
+        mut constant_value_cache: &'a mut ConstantValueCache<'tcx>,
         mut persistent_summary_cache: &'a mut PersistentSummaryCache<'b, 'tcx>,
         mut buffered_diagnostics: &'a mut Vec<DiagnosticBuilder<'b>>,
     ) -> (Option<Summary>, u64) {

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -121,11 +121,9 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'_, '_
             str.push_str(qualified_type_name(tcx, def_id).as_str());
         }
         Str => str.push_str("str"),
-        Array(ty, len) => {
+        Array(ty, _) => {
             str.push_str("array_");
             append_mangled_type(str, ty, tcx);
-            str.push('_');
-            str.push_str(&format!("{:?}", len));
         }
         Slice(ty) => {
             str.push_str("slice_");
@@ -158,8 +156,12 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'_, '_
             });
         }
         Param(param_ty) => {
-            let ty: Ty<'tcx> = param_ty.to_ty(*tcx);
-            str.push_str(&format!("{:?}", ty));
+            let pty: Ty<'tcx> = param_ty.to_ty(*tcx);
+            if ty.eq(pty) {
+                str.push_str(&format!("{:?}", ty));
+            } else {
+                append_mangled_type(str, pty, tcx);
+            }
         }
         _ => {
             //todo: add cases as the need arises, meanwhile make the need obvious.

--- a/checker/tests/run-pass/def_id_not_unique.rs
+++ b/checker/tests/run-pass/def_id_not_unique.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that call two distinct instantiations of the same generic functions in such a way
+// that both calls will use the same DefId, with the result that the second call will use
+// the wrong summary if using a cache that is keyed by DefId.
+
+// This example is highly contrived, but inspired by a larger way more subtle code fragment.
+
+#![feature(type_alias_enum_variants)]
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn foo<T: Foo>(bar: &T) {
+    let i: i32 = 0;
+    verify!(bar.one(i) == 2);
+    let d: i64 = 0;
+    verify!(bar.one(d) == 3);
+}
+
+pub mod foreign_contracts {
+    pub mod def_id_not_unique {
+        pub trait Foo {
+            fn one__ref_T_i32(&self, _t: i32) -> i32 {
+                2
+            }
+
+            fn one__ref_T_i64(_t: i64) -> i64 {
+                3
+            }
+        }
+    }
+}
+
+pub trait Foo {
+    fn one<T>(&self, t: T) -> T;
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/inferred_precondition.rs
+++ b/checker/tests/run-pass/inferred_precondition.rs
@@ -14,4 +14,3 @@ pub fn main() {
 fn foo(arr: &mut [i32], i: usize) {
     arr[i] = 12; //~ related location
 }
-


### PR DESCRIPTION
## Description

The DefId of a function constant is not a unique identifier if the constant is a method of a generic Trait instantiation. To ensure uniqueness, the type of the constant is now added to the key used to retrieve a function constant.

Also in this PR are two small tweaks to make type suffixes be valid identifiers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Added a new test case that fails without this fix.
