### PR TITLE
Use the path of an unknown model field as the Z3 expression name

### DIFF
--- a/checker/src/smt_solver.rs
+++ b/checker/src/smt_solver.rs
@@ -50,7 +50,7 @@ pub trait SmtSolver<SmtExpressionType> {
         set_model_field!(
             &self,
             number_of_backtracks,
-            get_model_field!(&self, number_of_backtracks, 0) + 1 //todo: the precondition should allow this
+            get_model_field!(&self, number_of_backtracks, 0) + 1
         );
     }
 

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -382,7 +382,7 @@ impl Z3Solver {
             Expression::Widen { path, operand } => {
                 self.get_ast_for_widened(path, operand, operand.expression.infer_type())
             }
-            Expression::Join { path, .. } => {
+            Expression::Join { path, .. } | Expression::UnknownModelField { path, .. } => {
                 let path_str = CString::new(format!("{:?}", path)).unwrap();
                 unsafe {
                     let path_symbol =

--- a/checker/tests/run-pass/unknown_model_field.rs
+++ b/checker/tests/run-pass/unknown_model_field.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that constrains an unknown model field and then relies on the constraint.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub trait Foo {
+    fn bar(&mut self) {
+        precondition!(get_model_field!(&self, f, 0) < 1000);
+        set_model_field!(&self, f, get_model_field!(&self, f, 0) + 1);
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

An unknown model field (for example when the qualifier is an unknown parameter value) can be constrained and needs to be modeled as named (i.e. not fresh) variable in Z3 so that the constraints can be used to discharge proof obligations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
Added a test case
