### PR TITLE
Make sure that parameters get widened if written to inside loops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: osx
 language: rust
 rust:
-- nightly
+- nightly-2019-05-22
 
 before_install:
 - curl -L https://github.com/mozilla/grcov/releases/download/v0.4.3/grcov-osx-x86_64.tar.bz2 | tar jxf -

--- a/checker/src/smt_solver.rs
+++ b/checker/src/smt_solver.rs
@@ -50,7 +50,7 @@ pub trait SmtSolver<SmtExpressionType> {
         set_model_field!(
             &self,
             number_of_backtracks,
-            get_model_field!(&self, number_of_backtracks, 0) + 1 //todo: the precondition should allow this
+            get_model_field!(&self, number_of_backtracks, 0) + 1
         );
     }
 

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -382,7 +382,7 @@ impl Z3Solver {
             Expression::Widen { path, operand } => {
                 self.get_ast_for_widened(path, operand, operand.expression.infer_type())
             }
-            Expression::Join { path, .. } => {
+            Expression::Join { path, .. } | Expression::UnknownModelField { path, .. } => {
                 let path_str = CString::new(format!("{:?}", path)).unwrap();
                 unsafe {
                     let path_symbol =

--- a/checker/tests/run-pass/unknown_model_field.rs
+++ b/checker/tests/run-pass/unknown_model_field.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that constrains an unknown model field and then relies on the constraint.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub trait Foo {
+    fn bar(&mut self) {
+        precondition!(get_model_field!(&self, f, 0) < 1000);
+        set_model_field!(&self, f, get_model_field!(&self, f, 0) + 1);
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/widen_param.rs
+++ b/checker/tests/run-pass/widen_param.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that increments a parameter inside a while loop
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn foo(v: &[i32], mut i: usize) {
+    precondition!(i <= v.len());
+    let n = v.len();
+    while i < n {
+        i += 1;
+    }
+    verify!(i == n);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

The join/widen logic assumed that variables reaching join points will always be defined in both the incoming edges. This assumption was broken quite some time ago when parameter values became lazy. The resulting mayhem was misunderstood and caused fix points to not converge in the few cases where parameters were being modified inside loops.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; validate.sh
New test case
