### PR TITLE
Path refinement with Rc

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -21,4 +21,4 @@ cd ..; cargo build
 cargo uninstall mirai || true
 cargo install --debug --path ./checker
 cargo clean -p mirai
-time RUSTC_WRAPPER=mirai RUST_BACKTRACE=1 MIRAI_LOG=warn cargo build --lib -p mirai
+RUSTC_WRAPPER=mirai RUST_BACKTRACE=1 MIRAI_LOG=warn cargo build --lib -p mirai


### PR DESCRIPTION
## Description

Path refinement operations now work on paths inside Rc wrappers and produce wrapped paths.

## How Has This Been Tested?
cargo test; validate.sh
