### PR TITLE
Use RC instead of Box so that common expressions can be shared.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,6 @@ dependencies = [
  "mirai-annotations 0.2.1",
  "rpds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "z3-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -24,8 +24,7 @@ lazy_static = "*"
 log = "*"
 mirai-annotations = { path = "../annotations" }
 rpds = { version = "*", features = ["serde"] }
-serde = "*"
-serde_derive = "*"
+serde = {version = "*", features = ["derive", "alloc", "rc"] }
 sled = "*"
 tempdir = "*"
 z3-sys = "*"

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -13,6 +13,7 @@ use rpds::HashTrieMap;
 use rustc::mir::BasicBlock;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Result};
+use std::rc::Rc;
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Environment {
@@ -93,12 +94,12 @@ impl Environment {
                 {
                     let true_path = Path::QualifiedPath {
                         length: true_path.path_length() + 1,
-                        qualifier: box true_path,
+                        qualifier: Rc::new(true_path),
                         selector: selector.clone(),
                     };
                     let false_path = Path::QualifiedPath {
                         length: false_path.path_length() + 1,
-                        qualifier: box false_path,
+                        qualifier: Rc::new(false_path),
                         selector: selector.clone(),
                     };
                     return Some((join_condition, true_path, false_path));
@@ -147,8 +148,8 @@ impl Environment {
                                 provenance: provenance.clone(),
                                 domain: (**condition).clone(),
                             },
-                            path1.clone(),
-                            path2.clone(),
+                            path1.as_ref().clone(),
+                            path2.as_ref().clone(),
                         ));
                     }
                     _ => (),
@@ -212,7 +213,7 @@ impl Environment {
                 None => {
                     checked_assume!(!val1.is_bottom());
                     let val2 = Expression::Variable {
-                        path: box path.clone(),
+                        path: Rc::new(path.clone()),
                         var_type: val1.domain.expression.infer_type(),
                     }
                     .into();
@@ -225,7 +226,7 @@ impl Environment {
             if !value_map1.contains_key(path) {
                 checked_assume!(!val2.is_bottom());
                 let val1 = Expression::Variable {
-                    path: box path.clone(),
+                    path: Rc::new(path.clone()),
                     var_type: val2.domain.expression.infer_type(),
                 }
                 .into();

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -9,6 +9,7 @@ use crate::constant_domain::ConstantDomain;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::rc::Rc;
 
 /// Closely based on the expressions found in MIR.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -134,7 +135,7 @@ pub enum Expression {
     /// don't have a way to tell which value it is.
     Join {
         /// The path of the location where the two flows join together.
-        path: Box<Path>,
+        path: Rc<Path>,
         // The value of the left operand.
         left: Box<AbstractDomain>,
         // The value of the right operand.
@@ -206,7 +207,7 @@ pub enum Expression {
     },
 
     /// The corresponding concrete value is the runtime address of location identified by the path.
-    Reference(Path),
+    Reference(Rc<Path>),
 
     /// An expression that is the remainder of left divided by right. %
     Rem {
@@ -276,7 +277,7 @@ pub enum Expression {
     /// when the qualifier becomes a known value without a defined value for the model field.
     UnknownModelField {
         /// Must be a qualified path with a model field selector.
-        path: Box<Path>,
+        path: Rc<Path>,
         default: Box<AbstractDomain>,
     },
 
@@ -286,7 +287,7 @@ pub enum Expression {
     /// like x == x. The type is needed to prevent this particular optimization if
     /// the variable is a floating point number that could be NaN.
     Variable {
-        path: Box<Path>,
+        path: Rc<Path>,
         var_type: ExpressionType,
     },
 
@@ -296,7 +297,7 @@ pub enum Expression {
     /// body.
     Widen {
         /// The path of the location where an indeterminate number of flows join together.
-        path: Box<Path>,
+        path: Rc<Path>,
         /// The join of some of the flows to come together at this path.
         /// The first few iterations do joins. Once widening happens, further iterations
         /// all result in the same widened value.

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -17,6 +17,7 @@ use mirai_annotations::{checked_assume, checked_assume_eq};
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::rc::Rc;
 use std::sync::Mutex;
 use z3_sys;
 
@@ -430,7 +431,7 @@ impl Z3Solver {
             let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
             if target_type.is_integer() {
                 let domain: AbstractDomain = AbstractDomain::from(Expression::Widen {
-                    path: box path.clone(),
+                    path: Rc::new(path.clone()),
                     operand: box operand.clone(),
                 });
                 let interval = domain.get_as_interval();


### PR DESCRIPTION
## Description

This is the first of many large refactors to replace Box with Rc, so that common expressions and paths can be shared.

## How Has This Been Tested?
cargo test; validate.sh