### PR TITLE
Do not track provenance of abstract values

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -18,6 +18,7 @@ use rustc_interface::interface;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::path::PathBuf;
+use std::rc::Rc;
 use syntax::errors::DiagnosticBuilder;
 
 /// Private state used to implement the callbacks.
@@ -235,8 +236,8 @@ impl MiraiCallbacks {
         persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
         iteration_count: usize,
         def_id: DefId,
-    ) -> String {
-        let name: String;
+    ) -> Rc<String> {
+        let name: Rc<String>;
         {
             name = persistent_summary_cache.get_summary_key_for(def_id).clone();
             if iteration_count == 1 {

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -12,6 +12,7 @@ use rustc::hir::def_id::DefId;
 use rustc::ty::{Ty, TyCtxt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 /// Abstracts over constant values referenced in MIR and adds information
 /// that is useful for the abstract interpreter. More importantly, this
@@ -36,11 +37,11 @@ pub enum ConstantDomain {
         /// Indicates if the function is known to be treated specially by the Rust compiler
         known_name: KnownFunctionNames,
         /// The key to use when retrieving a summary for the function from the summary cache
-        summary_cache_key: String,
+        summary_cache_key: Rc<String>,
         /// To be appended to summary_cache_key when searching for a type specific version of
         /// a summary. This is necessary when a trait method cannot be accurately summarized
         /// in a generic way. For example std::ops::eq.
-        argument_type_key: String,
+        argument_type_key: Rc<String>,
     },
     /// Signed 16 byte integer.
     I128(i128),
@@ -49,7 +50,7 @@ pub enum ConstantDomain {
     /// 32 bit floating point, stored as a u32 to make it comparable.
     F32(u32),
     /// A string literal.
-    Str(String),
+    Str(Rc<String>),
     /// The Boolean true value.
     True,
     /// Unsigned 16 byte integer.
@@ -741,7 +742,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
         let str_value = String::from(value);
         self.str_cache
             .entry(str_value)
-            .or_insert_with(|| ConstantDomain::Str(String::from(value)))
+            .or_insert_with(|| ConstantDomain::Str(Rc::new(String::from(value))))
     }
 
     /// Returns a reference to a cached Expression::U128(value).

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -21,6 +21,7 @@
 extern crate rustc;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
+extern crate rustc_errors;
 extern crate rustc_interface;
 extern crate rustc_metadata;
 extern crate syntax;
@@ -29,7 +30,6 @@ extern crate syntax_pos;
 #[macro_use]
 extern crate log;
 
-pub mod abstract_domains;
 pub mod abstract_value;
 pub mod callbacks;
 pub mod constant_domain;
@@ -38,6 +38,7 @@ pub mod expected_errors;
 pub mod expression;
 pub mod interval_domain;
 pub mod k_limits;
+pub mod path;
 pub mod smt_solver;
 pub mod summaries;
 pub mod utils;

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -1,0 +1,326 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+use crate::abstract_value::AbstractValue;
+use crate::abstract_value::AbstractValueTrait;
+use crate::environment::Environment;
+use crate::expression::{Expression, ExpressionType};
+
+use mirai_annotations::assume;
+use rustc::hir::def_id::DefId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::rc::Rc;
+
+/// A path represents a left hand side expression.
+/// When the actual expression is evaluated at runtime it will resolve to a particular memory
+/// location. During analysis it is used to keep track of state changes.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum Path {
+    /// A dynamically allocated memory block.
+    AbstractHeapAddress { ordinal: usize },
+
+    /// Sometimes a constant value needs to be treated as a path during refinement.
+    /// Don't use this unless you are really sure you know what you are doing.
+    Constant { value: Rc<AbstractValue> },
+
+    /// 0 is the return value temporary
+    /// [1 ... arg_count] are the parameters
+    /// [arg_count ... ] are the local variables and compiler temporaries.
+    LocalVariable { ordinal: usize },
+
+    /// The name is a summary cache key string.
+    StaticVariable {
+        /// The crate specific key that is used to identify the function in the current crate.
+        /// This is not available for functions returned by calls to functions from other crates,
+        /// since the def id the other crates use have no meaning for the current crate.
+        #[serde(skip)]
+        def_id: Option<DefId>,
+        /// The key to use when retrieving a summary for the static variable from the summary cache.
+        summary_cache_key: Rc<String>,
+        /// The type to use when the static variable value is not yet available.
+        expression_type: ExpressionType,
+    },
+
+    /// The ordinal is an index into a method level table of MIR bodies.
+    /// This should not be serialized into a summary since it is function private local state.
+    PromotedConstant { ordinal: usize },
+
+    /// The qualifier denotes some reference, struct, or collection.
+    /// The selector denotes a de-referenced item, field, or element, or slice.
+    QualifiedPath {
+        length: usize,
+        qualifier: Rc<Path>,
+        selector: Rc<PathSelector>,
+    },
+}
+
+impl Path {
+    /// True if path qualifies root, or another qualified path rooted by root.
+    pub fn is_rooted_by(&self, root: &Rc<Path>) -> bool {
+        match self {
+            Path::QualifiedPath { qualifier, .. } => {
+                *qualifier == *root || qualifier.is_rooted_by(root)
+            }
+            _ => false,
+        }
+    }
+
+    // Returns the length of the path.
+    pub fn path_length(&self) -> usize {
+        match self {
+            Path::QualifiedPath { length, .. } => *length,
+            _ => 1,
+        }
+    }
+
+    /// Adds any abstract heap addresses found in embedded index values to the given set.
+    pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
+        if let Path::QualifiedPath {
+            qualifier,
+            selector,
+            ..
+        } = self
+        {
+            (**qualifier).record_heap_addresses(result);
+            selector.record_heap_addresses(result);
+        }
+    }
+}
+
+pub trait PathRefinement: Sized {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Rc<Path>;
+
+    /// Refine paths that reference other paths.
+    /// I.e. when a reference is passed to a function that then returns
+    /// or leaks it back to the caller in the qualifier of a path then
+    /// we want to dereference the qualifier in order to normalize the path
+    /// and not have more than one path for the same location.
+    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path>;
+
+    /// Returns a copy path with the root replaced by new_root.
+    fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path>;
+}
+
+impl PathRefinement for Rc<Path> {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Rc<Path> {
+        match self.as_ref() {
+            Path::LocalVariable { ordinal } if 0 < *ordinal && *ordinal <= arguments.len() => {
+                arguments[*ordinal - 1].0.clone()
+            }
+            Path::QualifiedPath {
+                qualifier,
+                selector,
+                ..
+            } => {
+                let refined_qualifier = qualifier.refine_parameters(arguments);
+                let refined_selector = selector.refine_parameters(arguments);
+                let refined_length = refined_qualifier.path_length();
+                assume!(refined_length < 1_000_000_000); // We'll run out of memory long before this happens
+                Rc::new(Path::QualifiedPath {
+                    qualifier: refined_qualifier,
+                    selector: refined_selector,
+                    length: refined_length + 1,
+                })
+            }
+            _ => self.clone(),
+        }
+    }
+
+    /// Refine paths that reference other paths.
+    /// I.e. when a reference is passed to a function that then returns
+    /// or leaks it back to the caller in the qualifier of a path then
+    /// we want to dereference the qualifier in order to normalize the path
+    /// and not have more than one path for the same location.
+    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path> {
+        if let Some(val) = environment.value_at(&self) {
+            // if the environment has self as a key, then self is canonical,
+            // except if val is a Reference to another path.
+            return match &val.expression {
+                Expression::Reference(dereferenced_path) => dereferenced_path.clone(),
+                _ => self.clone(),
+            };
+        };
+        if let Path::QualifiedPath {
+            qualifier,
+            selector,
+            length,
+        } = self.as_ref()
+        {
+            if let Some(val) = environment.value_at(qualifier) {
+                match &val.expression {
+                    Expression::Reference(dereferenced_path) => {
+                        // The qualifier is being dereferenced, so if the value at qualifier
+                        // is an explicit reference to another path, put the other path in the place
+                        // of qualifier since references do not own elements directly in
+                        // the environment.
+                        let path_len = dereferenced_path.path_length();
+                        assume!(path_len < 1_000_000_000); // We'll run out of memory long before this happens
+                        Rc::new(Path::QualifiedPath {
+                            qualifier: dereferenced_path.clone(),
+                            selector: selector.clone(),
+                            length: path_len + 1,
+                        })
+                    }
+                    _ => {
+                        // Although the qualifier matches an expression, that expression
+                        // is too abstract too qualify the path sufficiently that we
+                        // can refine this value.
+                        Rc::new(Path::QualifiedPath {
+                            qualifier: qualifier.clone(),
+                            selector: selector.clone(),
+                            length: *length,
+                        })
+                    }
+                }
+            } else {
+                // The qualifier does not match a value in the environment, but parts of it might.
+                // Reminder, a path that does not match a value in the environment is rooted in
+                // an unknown value, such as a parameter.
+                let refined_qualifier = qualifier.refine_paths(environment);
+                let refined_qualifier_matches =
+                    environment.value_map.contains_key(&refined_qualifier);
+                let refined_selector = selector.refine_paths(environment);
+                let refined_length = refined_qualifier.path_length();
+                assume!(refined_length < 1_000_000_000); // We'll run out of memory long before this happens
+                let refined_path = Rc::new(Path::QualifiedPath {
+                    qualifier: refined_qualifier,
+                    selector: refined_selector,
+                    length: refined_length + 1,
+                });
+                if refined_qualifier_matches {
+                    refined_path.refine_paths(environment)
+                } else {
+                    refined_path
+                }
+            }
+        } else {
+            self.clone()
+        }
+    }
+
+    /// Returns a copy path with the root replaced by new_root.
+    fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path> {
+        match self.as_ref() {
+            Path::QualifiedPath {
+                qualifier,
+                selector,
+                ..
+            } => {
+                let new_qualifier = if *qualifier == *old_root {
+                    new_root
+                } else {
+                    qualifier.replace_root(old_root, new_root)
+                };
+                let new_qualifier_path_length = new_qualifier.path_length();
+                assume!(new_qualifier_path_length < 1_000_000_000); // We'll run out of memory long before this happens
+                Rc::new(Path::QualifiedPath {
+                    qualifier: new_qualifier,
+                    selector: selector.clone(),
+                    length: new_qualifier_path_length + 1,
+                })
+            }
+            _ => new_root,
+        }
+    }
+}
+
+/// The selector denotes a de-referenced item, field, or element, or slice.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum PathSelector {
+    /// The length of an array.
+    ArrayLength,
+
+    /// Given a path that denotes a reference, select the thing the reference points to.
+    Deref,
+
+    /// The tag used to indicate which case of an enum is used for a particular enum value.
+    Discriminant,
+
+    /// Select the struct field with the given index.
+    Field(usize),
+
+    /// Select the collection element with the index specified by the abstract value.
+    Index(Rc<AbstractValue>),
+
+    /// These indices are generated by slice patterns. Easiest to explain
+    /// by example:
+    ///
+    /// ```
+    /// [X, _, .._, _, _] => { offset: 0, min_length: 4, from_end: false },
+    /// [_, X, .._, _, _] => { offset: 1, min_length: 4, from_end: false },
+    /// [_, _, .._, X, _] => { offset: 2, min_length: 4, from_end: true },
+    /// [_, _, .._, _, X] => { offset: 1, min_length: 4, from_end: true },
+    /// ```
+    ConstantIndex {
+        /// index or -index (in Python terms), depending on from_end
+        offset: u32,
+        /// thing being indexed must be at least this long
+        min_length: u32,
+        /// counting backwards from end?
+        from_end: bool,
+    },
+
+    /// These indices are generated by slice patterns.
+    ///
+    /// slice[from:-to] in Python terms.
+    Subslice { from: u32, to: u32 },
+
+    /// "Downcast" to a variant of an ADT. Currently, MIR only introduces
+    /// this for ADTs with more than one variant. The value is the ordinal of the variant.
+    Downcast(usize),
+
+    /// Select the struct model field with the given name.
+    /// A model field is a specification construct used during MIRAI verification
+    /// and does not have a runtime location.
+    ModelField(Rc<String>),
+}
+
+impl PathSelector {
+    /// Adds any abstract heap addresses found in embedded index values to the given set.
+    pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
+        if let PathSelector::Index(value) = self {
+            value.record_heap_addresses(result);
+        }
+    }
+}
+
+pub trait PathSelectorRefinement: Sized {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Self;
+
+    /// Returns a value that is simplified (refined) by replacing values with Variable(path) expressions
+    /// with the value at that path (if there is one). If no refinement is possible
+    /// the result is simply a clone of this value. This refinement only makes sense
+    /// following a call to refine_parameters.
+    fn refine_paths(&self, environment: &mut Environment) -> Self;
+}
+
+impl PathSelectorRefinement for Rc<PathSelector> {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Rc<PathSelector> {
+        if let PathSelector::Index(value) = self.as_ref() {
+            let refined_value = value.refine_parameters(arguments);
+            Rc::new(PathSelector::Index(refined_value))
+        } else {
+            self.clone()
+        }
+    }
+
+    /// Returns a value that is simplified (refined) by replacing values with Variable(path) expressions
+    /// with the value at that path (if there is one). If no refinement is possible
+    /// the result is simply a clone of this value. This refinement only makes sense
+    /// following a call to refine_parameters.
+    fn refine_paths(&self, environment: &mut Environment) -> Rc<PathSelector> {
+        if let PathSelector::Index(value) = self.as_ref() {
+            let refined_value = value.refine_paths(environment);
+            Rc::new(PathSelector::Index(refined_value))
+        } else {
+            self.clone()
+        }
+    }
+}

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -9,6 +9,7 @@ use rustc::hir::ItemKind;
 use rustc::hir::Node;
 use rustc::ty::subst::UnpackedKind;
 use rustc::ty::{Ty, TyCtxt, TyKind};
+use std::rc::Rc;
 
 /// Returns the location of the rust system binaries that are associated with this build of Mirai.
 /// The location is obtained by looking at the contents of the environmental variables that were
@@ -61,7 +62,7 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
 
 /// Returns a string that is a valid identifier, made up from the concatenation of
 /// the string representationss of the given list of argument types.
-pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) -> String {
+pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) -> Rc<String> {
     let mut result = "_".to_string();
     let bound_sig = ty.fn_sig(*tcx);
     let sig = bound_sig.skip_binder();
@@ -69,7 +70,7 @@ pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) ->
         result.push('_');
         append_mangled_type(&mut result, arg_ty, tcx);
     }
-    result
+    Rc::new(result)
 }
 
 /// Appends a string to str with the constraint that it must uniquely identify ty and also
@@ -198,7 +199,7 @@ fn qualified_type_name(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
 /// the summary cache, which is a key value store. The string will always be the same as
 /// long as the definition does not change its name or location, so it can be used to
 /// transfer information from one compilation to the next, making incremental analysis possible.
-pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
+pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> Rc<String> {
     let mut name = if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str().to_string()
     } else {
@@ -240,5 +241,5 @@ pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
             name.push_str(da.as_str());
         }
     }
-    name
+    Rc::new(name)
 }

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -4,14 +4,14 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-use crate::abstract_domains::AbstractDomain;
-use crate::abstract_domains::AbstractDomainTrait;
+use crate::abstract_value::AbstractValue;
+use crate::abstract_value::AbstractValueTrait;
 use crate::constant_domain::ConstantDomain;
 use crate::expression::{Expression, ExpressionType};
 use crate::smt_solver::SmtResult;
 use crate::smt_solver::SmtSolver;
 
-use crate::abstract_value::Path;
+use crate::path::Path;
 use lazy_static::lazy_static;
 use log::debug;
 use mirai_annotations::{checked_assume, checked_assume_eq};
@@ -422,7 +422,7 @@ impl Z3Solver {
     fn get_ast_for_widened(
         &mut self,
         path: &Rc<Path>,
-        operand: &Rc<AbstractDomain>,
+        operand: &Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> z3_sys::Z3_ast {
         let path_str = CString::new(format!("{:?}", path)).unwrap();
@@ -431,7 +431,7 @@ impl Z3Solver {
             let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
             let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
             if target_type.is_integer() {
-                let domain = Rc::new(AbstractDomain::from(Expression::Widen {
+                let domain = Rc::new(AbstractValue::from(Expression::Widen {
                     path: path.clone(),
                     operand: operand.clone(),
                 }));

--- a/checker/tests/run-pass/core_contract.rs
+++ b/checker/tests/run-pass/core_contract.rs
@@ -14,7 +14,7 @@ pub fn main() {
     let x: Option<i64> = Some(1);
     let _y = x.unwrap();
     let z: Option<i64> = None;
-    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None
+    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None, defined in tests/run-pass/core_contract.rs:30:21: 36:23
 }
 
 pub mod foreign_contracts {


### PR DESCRIPTION
## Description

Keeping track of the full provenance of each abstract value turns out to be extremely expensive. It is also hardly used, so the price is not worth paying. Removing the provenance provides an opportunity to merge AbstractValue and AbstractDomain, which simplifies things (but does make for a large and uninteresting pull request).

Also part of this pull request are few more places where large sharable values (such as String) are put
inside Rc wrappers.

## How Has This Been Tested?
cargo test

