### PR TITLE
Keep track of expression size

### DIFF
--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -12,14 +12,17 @@ pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
 
+/// If Expressions get too large they become too costly to refine.
+pub const MAX_EXPRESSION_SIZE: u64 = 10_000;
+
 /// Double the observed maximum used in practice.
 pub const MAX_FIXPOINT_ITERATIONS: usize = 50;
 
 /// The point at which diverging summaries experience exponential blowup right now.
-pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
+pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 2;
 
-/// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
-pub const MAX_PATH_LENGTH: usize = 10;
+/// Prevents the outer fixed point loop from creating ever more new abstract values of type Expression::Variable.
+pub const MAX_PATH_LENGTH: usize = 30;
 
 /// Refining values with a path condition that is a really big expression leads to exponential blow up.
 pub const MAX_REFINE_DEPTH: usize = 9;

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -431,10 +431,13 @@ impl Z3Solver {
             let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
             let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
             if target_type.is_integer() {
-                let domain = Rc::new(AbstractValue::from(Expression::Widen {
-                    path: path.clone(),
-                    operand: operand.clone(),
-                }));
+                let domain = AbstractValue::make_from(
+                    Expression::Widen {
+                        path: path.clone(),
+                        operand: operand.clone(),
+                    },
+                    1,
+                );
                 let interval = domain.get_as_interval();
                 if !interval.is_bottom() {
                     if let Some(lower_bound) = interval.lower_bound() {


### PR DESCRIPTION
## Description

There are some corner cases, in practice, where expressions can blow up exponentially in size. This leads to intolerable analysis times because of the consequent cost of expression refinement and serialization. To control this behavior, expressions now keep track of their size and join operations resort to widening if they would otherwise produce an expression that exceeds a k_limit. This is conservative in nature and trades precision for false positives.

Also in the PR a tweak to increase the maximum Path length to 30 because 10 is regularly exceeded and there does not seem to be a big cost to increasing it. Another tweak is to allow one more fixed point iteration before issuing an INFO log event.

With this change MIRAI can now run on itself again and finishes in less than a minute.

## Type of change

Performance trade-off.

## How Has This Been Tested?
cargo test; validate.sh

