### PR TITLE
Remove (now) unnecessary mutability.

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -195,7 +195,7 @@ pub trait AbstractDomainTrait: Sized {
     fn try_to_distribute_binary_op(&self, other: Self, operation: fn(Self, Self) -> Self) -> Self;
     fn get_cached_interval(&self) -> Rc<IntervalDomain>;
     fn get_as_interval(&self) -> IntervalDomain;
-    fn refine_paths(&self, environment: &mut Environment) -> Self;
+    fn refine_paths(&self, environment: &Environment) -> Self;
     fn refine_parameters(&self, arguments: &[(Rc<Path>, AbstractValue)]) -> Self;
     fn refine_with(&self, path_condition: &Self, depth: usize) -> Self;
     fn widen(&self, path: &Rc<Path>) -> Self;
@@ -1121,7 +1121,7 @@ impl AbstractDomainTrait for Rc<AbstractDomain> {
 
     /// Replaces occurrences of Expression::Variable(path) with the value at that path
     /// in the given environment (if there is such a value).
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<AbstractDomain> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<AbstractDomain> {
         match &self.expression {
             Expression::Top | Expression::Bottom | Expression::AbstractHeapAddress(..) => {
                 self.clone()

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -37,6 +37,9 @@ pub struct AbstractValue {
     // It is used to refine the value with respect to path conditions and actual arguments.
     // It is also used to construct corresponding domain elements, when needed.
     pub expression: Expression,
+    // Keeps track of how large the expression is.
+    // When an expression get's too large it needs to get widened otherwise execution time diverges.
+    pub expression_size: u64,
     /// Cached interval domain element computed on demand by get_as_interval.
     #[serde(skip)]
     interval: RefCell<Option<Rc<IntervalDomain>>>,
@@ -64,24 +67,28 @@ impl PartialEq for AbstractValue {
 /// I.e. the corresponding set of possible concrete values is empty.
 pub const BOTTOM: AbstractValue = AbstractValue {
     expression: Expression::Bottom,
+    expression_size: 1,
     interval: RefCell::new(None),
 };
 
 /// An abstract domain element that all represent the single concrete value, false.
 pub const FALSE: AbstractValue = AbstractValue {
     expression: Expression::CompileTimeConstant(ConstantDomain::False),
+    expression_size: 1,
     interval: RefCell::new(None),
 };
 
 /// An abstract domain element that all represents all possible concrete values.
 pub const TOP: AbstractValue = AbstractValue {
     expression: Expression::Top,
+    expression_size: 1,
     interval: RefCell::new(None),
 };
 
 /// An abstract domain element that all represent the single concrete value, true.
 pub const TRUE: AbstractValue = AbstractValue {
     expression: Expression::CompileTimeConstant(ConstantDomain::True),
+    expression_size: 1,
     interval: RefCell::new(None),
 };
 
@@ -90,11 +97,13 @@ impl From<bool> for AbstractValue {
         if b {
             AbstractValue {
                 expression: Expression::CompileTimeConstant(ConstantDomain::True),
+                expression_size: 1,
                 interval: RefCell::new(None),
             }
         } else {
             AbstractValue {
                 expression: Expression::CompileTimeConstant(ConstantDomain::False),
+                expression_size: 1,
                 interval: RefCell::new(None),
             }
         }
@@ -105,17 +114,61 @@ impl From<ConstantDomain> for AbstractValue {
     fn from(cv: ConstantDomain) -> AbstractValue {
         AbstractValue {
             expression: Expression::CompileTimeConstant(cv),
+            expression_size: 1,
             interval: RefCell::new(None),
         }
     }
 }
 
-impl From<Expression> for AbstractValue {
-    fn from(expr: Expression) -> AbstractValue {
-        AbstractValue {
-            expression: expr,
+impl AbstractValue {
+    /// Creates an abstract value from a binary expression and keeps track of the size.
+    fn make_binary(
+        left: Rc<AbstractValue>,
+        right: Rc<AbstractValue>,
+        operation: fn(Rc<AbstractValue>, Rc<AbstractValue>) -> Expression,
+    ) -> Rc<AbstractValue> {
+        let expression_size = left.expression_size.saturating_add(right.expression_size);
+        Self::make_from(operation(left, right), expression_size)
+    }
+
+    /// Creates an abstract value from a typed binary expression and keeps track of the size.
+    fn make_typed_binary(
+        left: Rc<AbstractValue>,
+        right: Rc<AbstractValue>,
+        result_type: ExpressionType,
+        operation: fn(Rc<AbstractValue>, Rc<AbstractValue>, ExpressionType) -> Expression,
+    ) -> Rc<AbstractValue> {
+        let expression_size = left.expression_size.saturating_add(right.expression_size);
+        Self::make_from(operation(left, right, result_type), expression_size)
+    }
+
+    /// Creates an abstract value from a typed unary expression and keeps track of the size.
+    fn make_typed_unary(
+        operand: Rc<AbstractValue>,
+        result_type: ExpressionType,
+        operation: fn(Rc<AbstractValue>, ExpressionType) -> Expression,
+    ) -> Rc<AbstractValue> {
+        let expression_size = operand.expression_size.saturating_add(1);
+        Self::make_from(operation(operand, result_type), expression_size)
+    }
+
+    /// Creates an abstract value from a unary expression and keeps track of the size.
+    fn make_unary(
+        operand: Rc<AbstractValue>,
+        operation: fn(Rc<AbstractValue>) -> Expression,
+    ) -> Rc<AbstractValue> {
+        let expression_size = operand.expression_size.saturating_add(1);
+        Self::make_from(operation(operand), expression_size)
+    }
+
+    /// Creates an abstract value from the given expression and size.
+    /// Initializes the optional domains to None.
+    pub fn make_from(expression: Expression, expression_size: u64) -> Rc<AbstractValue> {
+        Rc::new(AbstractValue {
+            expression,
+            expression_size,
             interval: RefCell::new(None),
-        }
+        })
     }
 }
 
@@ -185,8 +238,8 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 }
             }
         }
-        self.try_to_simplify_binary_op(other, ConstantDomain::add, |left, right| {
-            Rc::new(Expression::Add { left, right }.into())
+        self.try_to_simplify_binary_op(other, ConstantDomain::add, |l, r| {
+            AbstractValue::make_binary(l, r, |left, right| Expression::Add { left, right })
         })
     }
 
@@ -208,13 +261,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         if interval.is_contained_in(&target_type) {
             return Rc::new(FALSE);
         }
-        Rc::new(
-            Expression::AddOverflows {
-                left: self.clone(),
-                right: other,
-                result_type: target_type,
-            }
-            .into(),
+        AbstractValue::make_typed_binary(
+            self.clone(),
+            other,
+            target_type,
+            |left, right, result_type| Expression::AddOverflows {
+                left,
+                right,
+                result_type,
+            },
         )
     }
 
@@ -243,13 +298,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             other
         } else {
             // todo: #32 more simplifications
-            Rc::new(
-                Expression::And {
-                    left: self.clone(),
-                    right: other,
-                }
-                .into(),
-            )
+            AbstractValue::make_binary(self.clone(), other, |left, right| Expression::And {
+                left,
+                right,
+            })
         }
     }
 
@@ -282,13 +334,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        Rc::new(
-            Expression::BitAnd {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::BitAnd {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "self | other".
@@ -301,13 +350,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        Rc::new(
-            Expression::BitOr {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::BitOr {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "self ^ other".
@@ -320,13 +366,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        Rc::new(
-            Expression::BitXor {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::BitXor {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "self as target_type".
@@ -350,12 +393,13 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             Expression::Join { left, right, path } => left
                 .cast(target_type.clone())
                 .join(right.cast(target_type), &path),
-            _ => Rc::new(
-                Expression::Cast {
-                    operand: self.clone(),
+            _ => AbstractValue::make_typed_unary(
+                self.clone(),
+                target_type,
+                |operand, target_type| Expression::Cast {
+                    operand,
                     target_type,
-                }
-                .into(),
+                },
             ),
         }
     }
@@ -397,20 +441,24 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 _ => (),
             }
         }
-        Rc::new(
+        let expression_size = self
+            .expression_size
+            .saturating_add(consequent.expression_size)
+            .saturating_add(alternate.expression_size);
+        AbstractValue::make_from(
             ConditionalExpression {
                 condition: self.clone(),
                 consequent,
                 alternate,
-            }
-            .into(),
+            },
+            expression_size,
         )
     }
 
     /// Returns an element that is "self / other".
     fn divide(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
-        self.try_to_simplify_binary_op(other, ConstantDomain::div, |left, right| {
-            Rc::new(Expression::Div { left, right }.into())
+        self.try_to_simplify_binary_op(other, ConstantDomain::div, |l, r| {
+            AbstractValue::make_binary(l, r, |left, right| Expression::Div { left, right })
         })
     }
 
@@ -502,13 +550,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             }
         }
         // Return an equals expression rather than a constant expression.
-        Rc::new(
-            Expression::Equals {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::Equals {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "self >= other".
@@ -524,13 +569,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         {
             return Rc::new(result.into());
         }
-        Rc::new(
-            Expression::GreaterOrEqual {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| {
+            Expression::GreaterOrEqual { left, right }
+        })
     }
 
     /// Returns an element that is "self > other".
@@ -546,13 +587,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         {
             return Rc::new(result.into());
         }
-        Rc::new(
-            Expression::GreaterThan {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::GreaterThan {
+            left,
+            right,
+        })
     }
 
     /// Returns true if "self => other" is known at compile time to be true.
@@ -622,13 +660,14 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         if (*self) == other {
             return other;
         }
-        Rc::new(
+        let expression_size = self.expression_size.saturating_add(other.expression_size);
+        AbstractValue::make_from(
             Expression::Join {
                 path: path.clone(),
                 left: self.clone(),
                 right: other,
-            }
-            .into(),
+            },
+            expression_size,
         )
     }
 
@@ -645,13 +684,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         {
             return Rc::new(result.into());
         }
-        Rc::new(
-            Expression::LessOrEqual {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::LessOrEqual {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is self < other
@@ -667,19 +703,16 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         {
             return Rc::new(result.into());
         }
-        Rc::new(
-            Expression::LessThan {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::LessThan {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "self * other".
     fn multiply(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
-        self.try_to_simplify_binary_op(other, ConstantDomain::mul, |left, right| {
-            Rc::new(Expression::Mul { left, right }.into())
+        self.try_to_simplify_binary_op(other, ConstantDomain::mul, |l, r| {
+            AbstractValue::make_binary(l, r, |left, right| Expression::Mul { left, right })
         })
     }
 
@@ -701,13 +734,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         if interval.is_contained_in(&target_type) {
             return Rc::new(FALSE);
         }
-        Rc::new(
-            Expression::MulOverflows {
-                left: self.clone(),
-                right: other,
-                result_type: target_type,
-            }
-            .into(),
+        AbstractValue::make_typed_binary(
+            self.clone(),
+            other,
+            target_type,
+            |left, right, result_type| Expression::MulOverflows {
+                left,
+                right,
+                result_type,
+            },
         )
     }
 
@@ -719,12 +754,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        Rc::new(
-            Expression::Neg {
-                operand: self.clone(),
-            }
-            .into(),
-        )
+        AbstractValue::make_unary(self.clone(), |operand| Expression::Neg { operand })
     }
 
     /// Returns an element that is "self != other".
@@ -734,13 +764,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         {
             return Rc::new(v1.not_equals(v2).into());
         };
-        Rc::new(
-            Expression::Ne {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::Ne {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "!self".
@@ -754,24 +781,16 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         match &self.expression {
             Expression::Bottom => self.clone(),
             Expression::Not { operand } => operand.clone(),
-            _ => Rc::new(
-                Expression::Not {
-                    operand: self.clone(),
-                }
-                .into(),
-            ),
+            _ => AbstractValue::make_unary(self.clone(), |operand| Expression::Not { operand }),
         }
     }
 
     /// Returns an element that is "self.other".
     fn offset(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
-        Rc::new(
-            Expression::Offset {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::Offset {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is "self || other".
@@ -786,13 +805,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             match (&self.expression, &other.expression) {
                 (Expression::Not { ref operand }, _) if (**operand).eq(&other) => Rc::new(TRUE),
                 (_, Expression::Not { ref operand }) if (**operand).eq(&self) => Rc::new(TRUE),
-                _ => Rc::new(
-                    Expression::Or {
-                        left: self.clone(),
-                        right: other,
-                    }
-                    .into(),
-                ),
+                _ => AbstractValue::make_binary(self.clone(), other, |left, right| {
+                    Expression::Or { left, right }
+                }),
             }
         }
     }
@@ -804,8 +819,8 @@ impl AbstractValueTrait for Rc<AbstractValue> {
 
     /// Returns an element that is "self % other".
     fn remainder(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
-        self.try_to_simplify_binary_op(other, ConstantDomain::rem, |left, right| {
-            Rc::new(Expression::Rem { left, right }.into())
+        self.try_to_simplify_binary_op(other, ConstantDomain::rem, |l, r| {
+            AbstractValue::make_binary(l, r, |left, right| Expression::Rem { left, right })
         })
     }
 
@@ -819,13 +834,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        Rc::new(
-            Expression::Shl {
-                left: self.clone(),
-                right: other,
-            }
-            .into(),
-        )
+        AbstractValue::make_binary(self.clone(), other, |left, right| Expression::Shl {
+            left,
+            right,
+        })
     }
 
     /// Returns an element that is true if "self << other" shifts away all bits.
@@ -846,13 +858,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         if interval.is_contained_in_width_of(&target_type) {
             return Rc::new(FALSE);
         }
-        Rc::new(
-            Expression::ShlOverflows {
-                left: self.clone(),
-                right: other,
-                result_type: target_type,
-            }
-            .into(),
+        AbstractValue::make_typed_binary(
+            self.clone(),
+            other,
+            target_type,
+            |left, right, result_type| Expression::ShlOverflows {
+                left,
+                right,
+                result_type,
+            },
         )
     }
 
@@ -866,13 +880,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        Rc::new(
-            Expression::Shr {
-                left: self.clone(),
-                right: other,
-                result_type: expression_type,
-            }
-            .into(),
+        AbstractValue::make_typed_binary(
+            self.clone(),
+            other,
+            expression_type,
+            |left, right, result_type| Expression::Shr {
+                left,
+                right,
+                result_type,
+            },
         )
     }
 
@@ -894,20 +910,22 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         if interval.is_contained_in_width_of(&target_type) {
             return Rc::new(FALSE);
         }
-        Rc::new(
-            Expression::ShrOverflows {
-                left: self.clone(),
-                right: other,
-                result_type: target_type,
-            }
-            .into(),
+        AbstractValue::make_typed_binary(
+            self.clone(),
+            other,
+            target_type,
+            |left, right, result_type| Expression::ShrOverflows {
+                left,
+                right,
+                result_type,
+            },
         )
     }
 
     /// Returns an element that is "self - other".
     fn subtract(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
-        self.try_to_simplify_binary_op(other, ConstantDomain::sub, |left, right| {
-            Rc::new(Expression::Sub { left, right }.into())
+        self.try_to_simplify_binary_op(other, ConstantDomain::sub, |l, r| {
+            AbstractValue::make_binary(l, r, |left, right| Expression::Sub { left, right })
         })
     }
 
@@ -929,13 +947,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         if interval.is_contained_in(&target_type) {
             return Rc::new(FALSE);
         }
-        Rc::new(
-            Expression::SubOverflows {
-                left: self.clone(),
-                right: other,
-                result_type: target_type,
-            }
-            .into(),
+        AbstractValue::make_typed_binary(
+            self.clone(),
+            other,
+            target_type,
+            |left, right, result_type| Expression::SubOverflows {
+                left,
+                right,
+                result_type,
+            },
         )
     }
 
@@ -1216,7 +1236,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 .or(right.refine_paths(environment)),
             Expression::Reference(path) => {
                 let refined_path = path.refine_paths(environment);
-                Rc::new(Expression::Reference(refined_path).into())
+                AbstractValue::make_from(Expression::Reference(refined_path), 1)
             }
             Expression::Rem { left, right } => left
                 .refine_paths(environment)
@@ -1265,12 +1285,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                         default.clone()
                     } else {
                         // Keep passing the buck to the next caller.
-                        Rc::new(
+                        AbstractValue::make_from(
                             Expression::UnknownModelField {
                                 path: path.clone(),
                                 default: default.clone(),
-                            }
-                            .into(),
+                            },
+                            default.expression_size.saturating_add(1),
                         )
                     }
                 } else {
@@ -1287,12 +1307,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     } else if let Some(val) = environment.value_at(&refined_path) {
                         val.clone()
                     } else {
-                        Rc::new(
+                        AbstractValue::make_from(
                             Expression::Variable {
                                 path: refined_path,
                                 var_type: var_type.clone(),
-                            }
-                            .into(),
+                            },
+                            1,
                         )
                     }
                 }
@@ -1403,7 +1423,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     }
                     _ => {
                         let refined_path = path.refine_parameters(arguments);
-                        Rc::new(Expression::Reference(refined_path).into())
+                        AbstractValue::make_from(Expression::Reference(refined_path), 1)
                     }
                 }
             }
@@ -1446,12 +1466,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 .sub_overflows(right.refine_parameters(arguments), result_type.clone()),
             Expression::UnknownModelField { path, default } => {
                 let refined_path = path.refine_parameters(arguments);
-                Rc::new(
+                AbstractValue::make_from(
                     Expression::UnknownModelField {
                         path: refined_path,
                         default: default.clone(),
-                    }
-                    .into(),
+                    },
+                    1,
                 )
             }
             Expression::Variable { path, var_type } => {
@@ -1459,12 +1479,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 if let Path::Constant { value } = refined_path.as_ref() {
                     value.clone()
                 } else {
-                    Rc::new(
+                    AbstractValue::make_from(
                         Expression::Variable {
                             path: refined_path,
                             var_type: var_type.clone(),
-                        }
-                        .into(),
+                        },
+                        1,
                     )
                 }
             }
@@ -1669,12 +1689,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             | Expression::CompileTimeConstant(..)
             | Expression::Reference(..)
             | Expression::Variable { .. } => self.clone(),
-            _ => Rc::new(
+            _ => AbstractValue::make_from(
                 Expression::Widen {
                     path: path.clone(),
                     operand: self.clone(),
-                }
-                .into(),
+                },
+                1,
             ),
         }
     }

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -219,7 +219,7 @@ pub trait AbstractValueTrait: Sized {
     fn try_to_distribute_binary_op(&self, other: Self, operation: fn(Self, Self) -> Self) -> Self;
     fn get_cached_interval(&self) -> Rc<IntervalDomain>;
     fn get_as_interval(&self) -> IntervalDomain;
-    fn refine_paths(&self, environment: &mut Environment) -> Self;
+    fn refine_paths(&self, environment: &Environment) -> Self;
     fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Self;
     fn refine_with(&self, path_condition: &Self, depth: usize) -> Self;
     fn widen(&self, path: &Rc<Path>) -> Self;
@@ -1152,7 +1152,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
 
     /// Replaces occurrences of Expression::Variable(path) with the value at that path
     /// in the given environment (if there is such a value).
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<AbstractValue> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<AbstractValue> {
         match &self.expression {
             Expression::Top | Expression::Bottom | Expression::AbstractHeapAddress(..) => {
                 self.clone()

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -18,6 +18,7 @@ use rustc_interface::interface;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::path::PathBuf;
+use std::rc::Rc;
 use syntax::errors::DiagnosticBuilder;
 
 /// Private state used to implement the callbacks.
@@ -235,8 +236,8 @@ impl MiraiCallbacks {
         persistent_summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
         iteration_count: usize,
         def_id: DefId,
-    ) -> String {
-        let name: String;
+    ) -> Rc<String> {
+        let name: Rc<String>;
         {
             name = persistent_summary_cache.get_summary_key_for(def_id).clone();
             if iteration_count == 1 {

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -12,6 +12,7 @@ use rustc::hir::def_id::DefId;
 use rustc::ty::{Ty, TyCtxt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 /// Abstracts over constant values referenced in MIR and adds information
 /// that is useful for the abstract interpreter. More importantly, this
@@ -36,11 +37,11 @@ pub enum ConstantDomain {
         /// Indicates if the function is known to be treated specially by the Rust compiler
         known_name: KnownFunctionNames,
         /// The key to use when retrieving a summary for the function from the summary cache
-        summary_cache_key: String,
+        summary_cache_key: Rc<String>,
         /// To be appended to summary_cache_key when searching for a type specific version of
         /// a summary. This is necessary when a trait method cannot be accurately summarized
         /// in a generic way. For example std::ops::eq.
-        argument_type_key: String,
+        argument_type_key: Rc<String>,
     },
     /// Signed 16 byte integer.
     I128(i128),
@@ -49,7 +50,7 @@ pub enum ConstantDomain {
     /// 32 bit floating point, stored as a u32 to make it comparable.
     F32(u32),
     /// A string literal.
-    Str(String),
+    Str(Rc<String>),
     /// The Boolean true value.
     True,
     /// Unsigned 16 byte integer.
@@ -741,7 +742,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
         let str_value = String::from(value);
         self.str_cache
             .entry(str_value)
-            .or_insert_with(|| ConstantDomain::Str(String::from(value)))
+            .or_insert_with(|| ConstantDomain::Str(Rc::new(String::from(value))))
     }
 
     /// Returns a reference to a cached Expression::U128(value).

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -10,7 +10,7 @@ use crate::expression::Expression;
 use crate::path::{Path, PathWithHash};
 
 use log::debug;
-use mirai_annotations::{assume, checked_assume};
+use mirai_annotations::checked_assume;
 use rpds::HashTrieMap;
 use rustc::mir::BasicBlock;
 use std::fmt::{Debug, Formatter, Result};
@@ -96,20 +96,8 @@ impl Environment {
             } => {
                 if let Some((join_condition, true_path, false_path)) = self.try_to_split(qualifier)
                 {
-                    let true_path_length = true_path.path_length();
-                    assume!(true_path_length < 1_000_000_000);
-                    let true_path = Rc::new(Path::QualifiedPath {
-                        qualifier: true_path,
-                        selector: selector.clone(),
-                        length: true_path_length + 1,
-                    });
-                    let false_path_length = false_path.path_length();
-                    assume!(false_path_length < 1_000_000_000);
-                    let false_path = Rc::new(Path::QualifiedPath {
-                        qualifier: false_path,
-                        selector: selector.clone(),
-                        length: false_path_length + 1,
-                    });
+                    let true_path = Path::new_qualified(true_path, selector.clone());
+                    let false_path = Path::new_qualified(false_path, selector.clone());
                     return Some((join_condition, true_path, false_path));
                 }
                 None

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -12,14 +12,17 @@ pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 3;
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
 
+/// If Expressions get too large they become too costly to refine.
+pub const MAX_EXPRESSION_SIZE: u64 = 10_000;
+
 /// Double the observed maximum used in practice.
 pub const MAX_FIXPOINT_ITERATIONS: usize = 50;
 
 /// The point at which diverging summaries experience exponential blowup right now.
-pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 3;
+pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 2;
 
-/// Prevents the fixed point loop from creating ever more new abstract values of type Expression::Variable.
-pub const MAX_PATH_LENGTH: usize = 10;
+/// Prevents the outer fixed point loop from creating ever more new abstract values of type Expression::Variable.
+pub const MAX_PATH_LENGTH: usize = 30;
 
 /// Refining values with a path condition that is a really big expression leads to exponential blow up.
 pub const MAX_REFINE_DEPTH: usize = 9;

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -21,6 +21,7 @@
 extern crate rustc;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
+extern crate rustc_errors;
 extern crate rustc_interface;
 extern crate rustc_metadata;
 extern crate syntax;
@@ -29,7 +30,6 @@ extern crate syntax_pos;
 #[macro_use]
 extern crate log;
 
-pub mod abstract_domains;
 pub mod abstract_value;
 pub mod callbacks;
 pub mod constant_domain;
@@ -38,6 +38,7 @@ pub mod expected_errors;
 pub mod expression;
 pub mod interval_domain;
 pub mod k_limits;
+pub mod path;
 pub mod smt_solver;
 pub mod summaries;
 pub mod utils;

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -190,7 +190,7 @@ pub trait PathRefinement: Sized {
     /// or leaks it back to the caller in the qualifier of a path then
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path>;
+    fn refine_paths(&self, environment: &Environment) -> Rc<Path>;
 
     /// Returns a copy path with the root replaced by new_root.
     fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path>;
@@ -221,7 +221,7 @@ impl PathRefinement for Rc<Path> {
     /// or leaks it back to the caller in the qualifier of a path then
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<Path> {
         if let Some(val) = environment.value_at(&self) {
             // if the environment has self as a key, then self is canonical,
             // except if val is a Reference to another path.
@@ -361,7 +361,7 @@ pub trait PathSelectorRefinement: Sized {
     /// with the value at that path (if there is one). If no refinement is possible
     /// the result is simply a clone of this value. This refinement only makes sense
     /// following a call to refine_parameters.
-    fn refine_paths(&self, environment: &mut Environment) -> Self;
+    fn refine_paths(&self, environment: &Environment) -> Self;
 }
 
 impl PathSelectorRefinement for Rc<PathSelector> {
@@ -379,7 +379,7 @@ impl PathSelectorRefinement for Rc<PathSelector> {
     /// with the value at that path (if there is one). If no refinement is possible
     /// the result is simply a clone of this value. This refinement only makes sense
     /// following a call to refine_parameters.
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<PathSelector> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<PathSelector> {
         if let PathSelector::Index(value) = self.as_ref() {
             let refined_value = value.refine_paths(environment);
             Rc::new(PathSelector::Index(refined_value))

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -1,0 +1,326 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+use crate::abstract_value::AbstractValue;
+use crate::abstract_value::AbstractValueTrait;
+use crate::environment::Environment;
+use crate::expression::{Expression, ExpressionType};
+
+use mirai_annotations::assume;
+use rustc::hir::def_id::DefId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::rc::Rc;
+
+/// A path represents a left hand side expression.
+/// When the actual expression is evaluated at runtime it will resolve to a particular memory
+/// location. During analysis it is used to keep track of state changes.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum Path {
+    /// A dynamically allocated memory block.
+    AbstractHeapAddress { ordinal: usize },
+
+    /// Sometimes a constant value needs to be treated as a path during refinement.
+    /// Don't use this unless you are really sure you know what you are doing.
+    Constant { value: Rc<AbstractValue> },
+
+    /// 0 is the return value temporary
+    /// [1 ... arg_count] are the parameters
+    /// [arg_count ... ] are the local variables and compiler temporaries.
+    LocalVariable { ordinal: usize },
+
+    /// The name is a summary cache key string.
+    StaticVariable {
+        /// The crate specific key that is used to identify the function in the current crate.
+        /// This is not available for functions returned by calls to functions from other crates,
+        /// since the def id the other crates use have no meaning for the current crate.
+        #[serde(skip)]
+        def_id: Option<DefId>,
+        /// The key to use when retrieving a summary for the static variable from the summary cache.
+        summary_cache_key: Rc<String>,
+        /// The type to use when the static variable value is not yet available.
+        expression_type: ExpressionType,
+    },
+
+    /// The ordinal is an index into a method level table of MIR bodies.
+    /// This should not be serialized into a summary since it is function private local state.
+    PromotedConstant { ordinal: usize },
+
+    /// The qualifier denotes some reference, struct, or collection.
+    /// The selector denotes a de-referenced item, field, or element, or slice.
+    QualifiedPath {
+        length: usize,
+        qualifier: Rc<Path>,
+        selector: Rc<PathSelector>,
+    },
+}
+
+impl Path {
+    /// True if path qualifies root, or another qualified path rooted by root.
+    pub fn is_rooted_by(&self, root: &Rc<Path>) -> bool {
+        match self {
+            Path::QualifiedPath { qualifier, .. } => {
+                *qualifier == *root || qualifier.is_rooted_by(root)
+            }
+            _ => false,
+        }
+    }
+
+    // Returns the length of the path.
+    pub fn path_length(&self) -> usize {
+        match self {
+            Path::QualifiedPath { length, .. } => *length,
+            _ => 1,
+        }
+    }
+
+    /// Adds any abstract heap addresses found in embedded index values to the given set.
+    pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
+        if let Path::QualifiedPath {
+            qualifier,
+            selector,
+            ..
+        } = self
+        {
+            (**qualifier).record_heap_addresses(result);
+            selector.record_heap_addresses(result);
+        }
+    }
+}
+
+pub trait PathRefinement: Sized {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Rc<Path>;
+
+    /// Refine paths that reference other paths.
+    /// I.e. when a reference is passed to a function that then returns
+    /// or leaks it back to the caller in the qualifier of a path then
+    /// we want to dereference the qualifier in order to normalize the path
+    /// and not have more than one path for the same location.
+    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path>;
+
+    /// Returns a copy path with the root replaced by new_root.
+    fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path>;
+}
+
+impl PathRefinement for Rc<Path> {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Rc<Path> {
+        match self.as_ref() {
+            Path::LocalVariable { ordinal } if 0 < *ordinal && *ordinal <= arguments.len() => {
+                arguments[*ordinal - 1].0.clone()
+            }
+            Path::QualifiedPath {
+                qualifier,
+                selector,
+                ..
+            } => {
+                let refined_qualifier = qualifier.refine_parameters(arguments);
+                let refined_selector = selector.refine_parameters(arguments);
+                let refined_length = refined_qualifier.path_length();
+                assume!(refined_length < 1_000_000_000); // We'll run out of memory long before this happens
+                Rc::new(Path::QualifiedPath {
+                    qualifier: refined_qualifier,
+                    selector: refined_selector,
+                    length: refined_length + 1,
+                })
+            }
+            _ => self.clone(),
+        }
+    }
+
+    /// Refine paths that reference other paths.
+    /// I.e. when a reference is passed to a function that then returns
+    /// or leaks it back to the caller in the qualifier of a path then
+    /// we want to dereference the qualifier in order to normalize the path
+    /// and not have more than one path for the same location.
+    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path> {
+        if let Some(val) = environment.value_at(&self) {
+            // if the environment has self as a key, then self is canonical,
+            // except if val is a Reference to another path.
+            return match &val.expression {
+                Expression::Reference(dereferenced_path) => dereferenced_path.clone(),
+                _ => self.clone(),
+            };
+        };
+        if let Path::QualifiedPath {
+            qualifier,
+            selector,
+            length,
+        } = self.as_ref()
+        {
+            if let Some(val) = environment.value_at(qualifier) {
+                match &val.expression {
+                    Expression::Reference(dereferenced_path) => {
+                        // The qualifier is being dereferenced, so if the value at qualifier
+                        // is an explicit reference to another path, put the other path in the place
+                        // of qualifier since references do not own elements directly in
+                        // the environment.
+                        let path_len = dereferenced_path.path_length();
+                        assume!(path_len < 1_000_000_000); // We'll run out of memory long before this happens
+                        Rc::new(Path::QualifiedPath {
+                            qualifier: dereferenced_path.clone(),
+                            selector: selector.clone(),
+                            length: path_len + 1,
+                        })
+                    }
+                    _ => {
+                        // Although the qualifier matches an expression, that expression
+                        // is too abstract too qualify the path sufficiently that we
+                        // can refine this value.
+                        Rc::new(Path::QualifiedPath {
+                            qualifier: qualifier.clone(),
+                            selector: selector.clone(),
+                            length: *length,
+                        })
+                    }
+                }
+            } else {
+                // The qualifier does not match a value in the environment, but parts of it might.
+                // Reminder, a path that does not match a value in the environment is rooted in
+                // an unknown value, such as a parameter.
+                let refined_qualifier = qualifier.refine_paths(environment);
+                let refined_qualifier_matches =
+                    environment.value_map.contains_key(&refined_qualifier);
+                let refined_selector = selector.refine_paths(environment);
+                let refined_length = refined_qualifier.path_length();
+                assume!(refined_length < 1_000_000_000); // We'll run out of memory long before this happens
+                let refined_path = Rc::new(Path::QualifiedPath {
+                    qualifier: refined_qualifier,
+                    selector: refined_selector,
+                    length: refined_length + 1,
+                });
+                if refined_qualifier_matches {
+                    refined_path.refine_paths(environment)
+                } else {
+                    refined_path
+                }
+            }
+        } else {
+            self.clone()
+        }
+    }
+
+    /// Returns a copy path with the root replaced by new_root.
+    fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path> {
+        match self.as_ref() {
+            Path::QualifiedPath {
+                qualifier,
+                selector,
+                ..
+            } => {
+                let new_qualifier = if *qualifier == *old_root {
+                    new_root
+                } else {
+                    qualifier.replace_root(old_root, new_root)
+                };
+                let new_qualifier_path_length = new_qualifier.path_length();
+                assume!(new_qualifier_path_length < 1_000_000_000); // We'll run out of memory long before this happens
+                Rc::new(Path::QualifiedPath {
+                    qualifier: new_qualifier,
+                    selector: selector.clone(),
+                    length: new_qualifier_path_length + 1,
+                })
+            }
+            _ => new_root,
+        }
+    }
+}
+
+/// The selector denotes a de-referenced item, field, or element, or slice.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum PathSelector {
+    /// The length of an array.
+    ArrayLength,
+
+    /// Given a path that denotes a reference, select the thing the reference points to.
+    Deref,
+
+    /// The tag used to indicate which case of an enum is used for a particular enum value.
+    Discriminant,
+
+    /// Select the struct field with the given index.
+    Field(usize),
+
+    /// Select the collection element with the index specified by the abstract value.
+    Index(Rc<AbstractValue>),
+
+    /// These indices are generated by slice patterns. Easiest to explain
+    /// by example:
+    ///
+    /// ```
+    /// [X, _, .._, _, _] => { offset: 0, min_length: 4, from_end: false },
+    /// [_, X, .._, _, _] => { offset: 1, min_length: 4, from_end: false },
+    /// [_, _, .._, X, _] => { offset: 2, min_length: 4, from_end: true },
+    /// [_, _, .._, _, X] => { offset: 1, min_length: 4, from_end: true },
+    /// ```
+    ConstantIndex {
+        /// index or -index (in Python terms), depending on from_end
+        offset: u32,
+        /// thing being indexed must be at least this long
+        min_length: u32,
+        /// counting backwards from end?
+        from_end: bool,
+    },
+
+    /// These indices are generated by slice patterns.
+    ///
+    /// slice[from:-to] in Python terms.
+    Subslice { from: u32, to: u32 },
+
+    /// "Downcast" to a variant of an ADT. Currently, MIR only introduces
+    /// this for ADTs with more than one variant. The value is the ordinal of the variant.
+    Downcast(usize),
+
+    /// Select the struct model field with the given name.
+    /// A model field is a specification construct used during MIRAI verification
+    /// and does not have a runtime location.
+    ModelField(Rc<String>),
+}
+
+impl PathSelector {
+    /// Adds any abstract heap addresses found in embedded index values to the given set.
+    pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
+        if let PathSelector::Index(value) = self {
+            value.record_heap_addresses(result);
+        }
+    }
+}
+
+pub trait PathSelectorRefinement: Sized {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Self;
+
+    /// Returns a value that is simplified (refined) by replacing values with Variable(path) expressions
+    /// with the value at that path (if there is one). If no refinement is possible
+    /// the result is simply a clone of this value. This refinement only makes sense
+    /// following a call to refine_parameters.
+    fn refine_paths(&self, environment: &mut Environment) -> Self;
+}
+
+impl PathSelectorRefinement for Rc<PathSelector> {
+    /// Refine parameters inside embedded index values with the given arguments.
+    fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Rc<PathSelector> {
+        if let PathSelector::Index(value) = self.as_ref() {
+            let refined_value = value.refine_parameters(arguments);
+            Rc::new(PathSelector::Index(refined_value))
+        } else {
+            self.clone()
+        }
+    }
+
+    /// Returns a value that is simplified (refined) by replacing values with Variable(path) expressions
+    /// with the value at that path (if there is one). If no refinement is possible
+    /// the result is simply a clone of this value. This refinement only makes sense
+    /// following a call to refine_parameters.
+    fn refine_paths(&self, environment: &mut Environment) -> Rc<PathSelector> {
+        if let PathSelector::Index(value) = self.as_ref() {
+            let refined_value = value.refine_paths(environment);
+            Rc::new(PathSelector::Index(refined_value))
+        } else {
+            self.clone()
+        }
+    }
+}

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -198,11 +198,11 @@ fn extract_side_effects(
         for (path, value) in env
             .value_map
             .iter()
-            .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
+            .filter(|(p, _)| p.path == root || p.path.is_rooted_by(&root))
         {
-            path.record_heap_addresses(&mut heap_roots);
+            path.path.record_heap_addresses(&mut heap_roots);
             value.record_heap_addresses(&mut heap_roots);
-            result.push((path.clone(), value.clone()));
+            result.push((path.path.clone(), value.clone()));
         }
     }
     extract_reachable_heap_allocations(env, &mut heap_roots, &mut result);
@@ -224,11 +224,11 @@ fn extract_reachable_heap_allocations(
                 for (path, value) in env
                     .value_map
                     .iter()
-                    .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
+                    .filter(|(p, _)| p.path == root || p.path.is_rooted_by(&root))
                 {
-                    path.record_heap_addresses(&mut new_roots);
+                    path.path.record_heap_addresses(&mut new_roots);
                     value.record_heap_addresses(&mut new_roots);
-                    result.push((path.clone(), value.clone()));
+                    result.push((path.path.clone(), value.clone()));
                 }
             }
         }

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -9,6 +9,7 @@ use rustc::hir::ItemKind;
 use rustc::hir::Node;
 use rustc::ty::subst::UnpackedKind;
 use rustc::ty::{Ty, TyCtxt, TyKind};
+use std::rc::Rc;
 
 /// Returns the location of the rust system binaries that are associated with this build of Mirai.
 /// The location is obtained by looking at the contents of the environmental variables that were
@@ -61,7 +62,7 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_, '_, '_>) -> bool {
 
 /// Returns a string that is a valid identifier, made up from the concatenation of
 /// the string representationss of the given list of argument types.
-pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) -> String {
+pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) -> Rc<String> {
     let mut result = "_".to_string();
     let bound_sig = ty.fn_sig(*tcx);
     let sig = bound_sig.skip_binder();
@@ -69,7 +70,7 @@ pub fn argument_types_key_str<'tcx>(tcx: &TyCtxt<'_, '_, 'tcx>, ty: Ty<'tcx>) ->
         result.push('_');
         append_mangled_type(&mut result, arg_ty, tcx);
     }
-    result
+    Rc::new(result)
 }
 
 /// Appends a string to str with the constraint that it must uniquely identify ty and also
@@ -198,7 +199,7 @@ fn qualified_type_name(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
 /// the summary cache, which is a key value store. The string will always be the same as
 /// long as the definition does not change its name or location, so it can be used to
 /// transfer information from one compilation to the next, making incremental analysis possible.
-pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
+pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> Rc<String> {
     let mut name = if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str().to_string()
     } else {
@@ -240,5 +241,5 @@ pub fn summary_key_str(tcx: &TyCtxt<'_, '_, '_>, def_id: DefId) -> String {
             name.push_str(da.as_str());
         }
     }
-    name
+    Rc::new(name)
 }

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -157,7 +157,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                         &summary
                     };
                     if let Some(result) = &summary.result {
-                        let result = result.refine_paths(&mut self.current_environment);
+                        let result = result.refine_paths(&self.current_environment);
                         if let Expression::AbstractHeapAddress(ordinal) = result.expression {
                             let source_path = Rc::new(Path::LocalVariable { ordinal: 0 });
                             let target_path = Rc::new(Path::AbstractHeapAddress { ordinal });
@@ -166,8 +166,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                             }) {
                                 let tpath = Rc::new(path.clone())
                                     .replace_root(&source_path, target_path.clone())
-                                    .refine_paths(&mut self.current_environment);
-                                let rvalue = value.refine_paths(&mut self.current_environment);
+                                    .refine_paths(&self.current_environment);
+                                let rvalue = value.refine_paths(&self.current_environment);
                                 self.current_environment.update_value_at(tpath, rvalue);
                             }
                         }
@@ -935,7 +935,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     let qualifier = actual_args[0].0.clone();
                     let field_name = self.coerce_to_string(&actual_args[1].1);
                     let rpath = Path::new_model_field(qualifier, field_name)
-                        .refine_paths(&mut self.current_environment);
+                        .refine_paths(&self.current_environment);
 
                     let target_path = self.visit_place(place);
                     if self.current_environment.value_at(&rpath).is_some() {
@@ -986,7 +986,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     let qualifier = actual_args[0].0.clone();
                     let field_name = self.coerce_to_string(&actual_args[1].1);
                     let target_path = Path::new_model_field(qualifier, field_name)
-                        .refine_paths(&mut self.current_environment);
+                        .refine_paths(&self.current_environment);
                     let rpath = actual_args[2].0.clone();
                     self.copy_or_move_elements(
                         target_path,
@@ -1225,7 +1225,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             let refined_condition = precondition
                 .condition
                 .refine_parameters(actual_args)
-                .refine_paths(&mut self.current_environment)
+                .refine_paths(&self.current_environment)
                 .refine_with(&self.current_environment.entry_condition, 0);
             let (refined_precondition_as_bool, entry_cond_as_bool) =
                 self.check_condition_value_and_reachability(&refined_condition);
@@ -1562,11 +1562,11 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         {
             let tpath = Rc::new(path.clone())
                 .replace_root(source_path, target_path.clone())
-                .refine_paths(&mut self.current_environment);
+                .refine_paths(&self.current_environment);
             let rvalue = value
                 .clone()
                 .refine_parameters(arguments)
-                .refine_paths(&mut self.current_environment);
+                .refine_paths(&self.current_environment);
             for (arg_path, arg_val) in arguments.iter() {
                 if arg_val.eq(&rvalue) {
                     let rtype = rvalue.expression.infer_type();

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -4,14 +4,14 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-use crate::abstract_domains::AbstractDomain;
-use crate::abstract_domains::AbstractDomainTrait;
+use crate::abstract_value::AbstractValue;
+use crate::abstract_value::AbstractValueTrait;
 use crate::constant_domain::ConstantDomain;
 use crate::expression::{Expression, ExpressionType};
 use crate::smt_solver::SmtResult;
 use crate::smt_solver::SmtSolver;
 
-use crate::abstract_value::Path;
+use crate::path::Path;
 use lazy_static::lazy_static;
 use log::debug;
 use mirai_annotations::{checked_assume, checked_assume_eq};
@@ -422,7 +422,7 @@ impl Z3Solver {
     fn get_ast_for_widened(
         &mut self,
         path: &Rc<Path>,
-        operand: &Rc<AbstractDomain>,
+        operand: &Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> z3_sys::Z3_ast {
         let path_str = CString::new(format!("{:?}", path)).unwrap();
@@ -431,7 +431,7 @@ impl Z3Solver {
             let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
             let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
             if target_type.is_integer() {
-                let domain = Rc::new(AbstractDomain::from(Expression::Widen {
+                let domain = Rc::new(AbstractValue::from(Expression::Widen {
                     path: path.clone(),
                     operand: operand.clone(),
                 }));

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -431,10 +431,13 @@ impl Z3Solver {
             let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
             let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
             if target_type.is_integer() {
-                let domain = Rc::new(AbstractValue::from(Expression::Widen {
-                    path: path.clone(),
-                    operand: operand.clone(),
-                }));
+                let domain = AbstractValue::make_from(
+                    Expression::Widen {
+                        path: path.clone(),
+                        operand: operand.clone(),
+                    },
+                    1,
+                );
                 let interval = domain.get_as_interval();
                 if !interval.is_bottom() {
                     if let Some(lower_bound) = interval.lower_bound() {

--- a/checker/tests/run-pass/core_contract.rs
+++ b/checker/tests/run-pass/core_contract.rs
@@ -14,7 +14,7 @@ pub fn main() {
     let x: Option<i64> = Some(1);
     let _y = x.unwrap();
     let z: Option<i64> = None;
-    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None
+    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None, defined in tests/run-pass/core_contract.rs:30:21: 36:23
 }
 
 pub mod foreign_contracts {


### PR DESCRIPTION
## Description

Now that abstract values use RefCel to cache domain values that are created on demand, it is no longer necessary to pass around mutable references to Environment values.

## Type of change

Code Improvement

## How Has This Been Tested?
cargo test; ./validate.sh

