### PR TITLE
Cache abstract values created from paths rooted in parameters

### DIFF
--- a/checker/src/abstract_domains.rs
+++ b/checker/src/abstract_domains.rs
@@ -195,7 +195,7 @@ pub trait AbstractDomainTrait: Sized {
     fn try_to_distribute_binary_op(&self, other: Self, operation: fn(Self, Self) -> Self) -> Self;
     fn get_cached_interval(&self) -> Rc<IntervalDomain>;
     fn get_as_interval(&self) -> IntervalDomain;
-    fn refine_paths(&self, environment: &mut Environment) -> Self;
+    fn refine_paths(&self, environment: &Environment) -> Self;
     fn refine_parameters(&self, arguments: &[(Rc<Path>, AbstractValue)]) -> Self;
     fn refine_with(&self, path_condition: &Self, depth: usize) -> Self;
     fn widen(&self, path: &Rc<Path>) -> Self;
@@ -1121,7 +1121,7 @@ impl AbstractDomainTrait for Rc<AbstractDomain> {
 
     /// Replaces occurrences of Expression::Variable(path) with the value at that path
     /// in the given environment (if there is such a value).
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<AbstractDomain> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<AbstractDomain> {
         match &self.expression {
             Expression::Top | Expression::Bottom | Expression::AbstractHeapAddress(..) => {
                 self.clone()

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -219,7 +219,7 @@ pub trait AbstractValueTrait: Sized {
     fn try_to_distribute_binary_op(&self, other: Self, operation: fn(Self, Self) -> Self) -> Self;
     fn get_cached_interval(&self) -> Rc<IntervalDomain>;
     fn get_as_interval(&self) -> IntervalDomain;
-    fn refine_paths(&self, environment: &mut Environment) -> Self;
+    fn refine_paths(&self, environment: &Environment) -> Self;
     fn refine_parameters(&self, arguments: &[(Rc<Path>, Rc<AbstractValue>)]) -> Self;
     fn refine_with(&self, path_condition: &Self, depth: usize) -> Self;
     fn widen(&self, path: &Rc<Path>) -> Self;
@@ -1152,7 +1152,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
 
     /// Replaces occurrences of Expression::Variable(path) with the value at that path
     /// in the given environment (if there is such a value).
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<AbstractValue> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<AbstractValue> {
         match &self.expression {
             Expression::Top | Expression::Bottom | Expression::AbstractHeapAddress(..) => {
                 self.clone()

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -190,7 +190,7 @@ pub trait PathRefinement: Sized {
     /// or leaks it back to the caller in the qualifier of a path then
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path>;
+    fn refine_paths(&self, environment: &Environment) -> Rc<Path>;
 
     /// Returns a copy path with the root replaced by new_root.
     fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path>;
@@ -221,7 +221,7 @@ impl PathRefinement for Rc<Path> {
     /// or leaks it back to the caller in the qualifier of a path then
     /// we want to dereference the qualifier in order to normalize the path
     /// and not have more than one path for the same location.
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<Path> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<Path> {
         if let Some(val) = environment.value_at(&self) {
             // if the environment has self as a key, then self is canonical,
             // except if val is a Reference to another path.
@@ -361,7 +361,7 @@ pub trait PathSelectorRefinement: Sized {
     /// with the value at that path (if there is one). If no refinement is possible
     /// the result is simply a clone of this value. This refinement only makes sense
     /// following a call to refine_parameters.
-    fn refine_paths(&self, environment: &mut Environment) -> Self;
+    fn refine_paths(&self, environment: &Environment) -> Self;
 }
 
 impl PathSelectorRefinement for Rc<PathSelector> {
@@ -379,7 +379,7 @@ impl PathSelectorRefinement for Rc<PathSelector> {
     /// with the value at that path (if there is one). If no refinement is possible
     /// the result is simply a clone of this value. This refinement only makes sense
     /// following a call to refine_parameters.
-    fn refine_paths(&self, environment: &mut Environment) -> Rc<PathSelector> {
+    fn refine_paths(&self, environment: &Environment) -> Rc<PathSelector> {
         if let PathSelector::Index(value) = self.as_ref() {
             let refined_value = value.refine_paths(environment);
             Rc::new(PathSelector::Index(refined_value))

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -173,26 +173,32 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                         }
                         result
                     } else {
-                        AbstractValue::make_from(
+                        let result = AbstractValue::make_from(
                             Expression::Variable {
                                 path: path.clone(),
                                 var_type: expression_type.clone(),
                             },
                             1,
-                        )
+                        );
+                        self.current_environment
+                            .update_value_at(path, result.clone());
+                        result
                     }
                 } else if path.path_length() < k_limits::MAX_PATH_LENGTH {
-                    if result_type == ExpressionType::Reference {
-                        AbstractValue::make_from(Expression::Reference(path), 1)
+                    let result = if result_type == ExpressionType::Reference {
+                        AbstractValue::make_from(Expression::Reference(path.clone()), 1)
                     } else {
                         AbstractValue::make_from(
                             Expression::Variable {
-                                path,
+                                path: path.clone(),
                                 var_type: result_type.clone(),
                             },
                             1,
                         )
-                    }
+                    };
+                    self.current_environment
+                        .update_value_at(path, result.clone());
+                    result
                 } else {
                     Rc::new(abstract_value::TOP)
                 }

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -157,7 +157,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                         &summary
                     };
                     if let Some(result) = &summary.result {
-                        let result = result.refine_paths(&mut self.current_environment);
+                        let result = result.refine_paths(&self.current_environment);
                         if let Expression::AbstractHeapAddress(ordinal) = result.expression {
                             let source_path = Rc::new(Path::LocalVariable { ordinal: 0 });
                             let target_path = Rc::new(Path::AbstractHeapAddress { ordinal });
@@ -166,8 +166,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                             }) {
                                 let tpath = Rc::new(path.clone())
                                     .replace_root(&source_path, target_path.clone())
-                                    .refine_paths(&mut self.current_environment);
-                                let rvalue = value.refine_paths(&mut self.current_environment);
+                                    .refine_paths(&self.current_environment);
+                                let rvalue = value.refine_paths(&self.current_environment);
                                 self.current_environment.update_value_at(tpath, rvalue);
                             }
                         }
@@ -935,7 +935,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     let qualifier = actual_args[0].0.clone();
                     let field_name = self.coerce_to_string(&actual_args[1].1);
                     let rpath = Path::new_model_field(qualifier, field_name)
-                        .refine_paths(&mut self.current_environment);
+                        .refine_paths(&self.current_environment);
 
                     let target_path = self.visit_place(place);
                     if self.current_environment.value_at(&rpath).is_some() {
@@ -986,7 +986,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     let qualifier = actual_args[0].0.clone();
                     let field_name = self.coerce_to_string(&actual_args[1].1);
                     let target_path = Path::new_model_field(qualifier, field_name)
-                        .refine_paths(&mut self.current_environment);
+                        .refine_paths(&self.current_environment);
                     let rpath = actual_args[2].0.clone();
                     self.copy_or_move_elements(
                         target_path,
@@ -1225,7 +1225,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             let refined_condition = precondition
                 .condition
                 .refine_parameters(actual_args)
-                .refine_paths(&mut self.current_environment)
+                .refine_paths(&self.current_environment)
                 .refine_with(&self.current_environment.entry_condition, 0);
             let (refined_precondition_as_bool, entry_cond_as_bool) =
                 self.check_condition_value_and_reachability(&refined_condition);
@@ -1562,11 +1562,11 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         {
             let tpath = Rc::new(path.clone())
                 .replace_root(source_path, target_path.clone())
-                .refine_paths(&mut self.current_environment);
+                .refine_paths(&self.current_environment);
             let rvalue = value
                 .clone()
                 .refine_parameters(arguments)
-                .refine_paths(&mut self.current_environment);
+                .refine_paths(&self.current_environment);
             for (arg_path, arg_val) in arguments.iter() {
                 if arg_val.eq(&rvalue) {
                     let rtype = rvalue.expression.infer_type();


### PR DESCRIPTION
## Description

Once an abstract (Variable) value is created to represent the value (or a part of the value) of a parameter, enter it into the environment so that subsequent references use the same value.

This makes the last fixed point divergence in MIRAI on MIRAI go away.

## Type of change

Code improvement.
Bug fix.

## How Has This Been Tested?
cargo test; ./validate.sh

