### PR TITLE
Remove more unnecessary &mut references.

### DIFF
--- a/checker/src/smt_solver.rs
+++ b/checker/src/smt_solver.rs
@@ -25,15 +25,15 @@ pub trait SmtSolver<SmtExpressionType> {
     fn as_debug_string(&self, expression: &SmtExpressionType) -> String;
 
     /// Adds the given expression to the current context.
-    fn assert(&mut self, expression: &SmtExpressionType);
+    fn assert(&self, expression: &SmtExpressionType);
 
     /// Destroy the current context and restore the containing context as current.
-    fn backtrack(&mut self) {
+    fn backtrack(&self) {
         precondition!(get_model_field!(&self, number_of_backtracks, 0) > 0);
     }
 
     /// Translate the MIRAI expression into a corresponding expression for the Solver.
-    fn get_as_smt_predicate(&mut self, mirai_expression: &Expression) -> SmtExpressionType;
+    fn get_as_smt_predicate(&self, mirai_expression: &Expression) -> SmtExpressionType;
 
     /// Provides a string that contains a set of variable assignments that satisfied the
     /// assertions in the solver. Can only be called after self.solve return SmtResult::Satisfiable.
@@ -45,7 +45,7 @@ pub trait SmtSolver<SmtExpressionType> {
 
     /// Create a nested context. When a matching backtrack is called, the current context (state)
     /// of the solver will be restored to what it was when this was called.
-    fn set_backtrack_position(&mut self) {
+    fn set_backtrack_position(&self) {
         precondition!(get_model_field!(&self, number_of_backtracks, 0) < 1000);
         set_model_field!(
             &self,
@@ -56,10 +56,10 @@ pub trait SmtSolver<SmtExpressionType> {
 
     /// Try to find an assignment of values to the free variables so that the assertions in the
     /// current context are all true.
-    fn solve(&mut self) -> SmtResult;
+    fn solve(&self) -> SmtResult;
 
     /// Establish if the given expression can be satisfied (or not) without changing the current context.
-    fn solve_expression(&mut self, expression: &SmtExpressionType) -> SmtResult {
+    fn solve_expression(&self, expression: &SmtExpressionType) -> SmtResult {
         self.set_backtrack_position();
         self.assert(expression);
         let result = self.solve();
@@ -77,11 +77,11 @@ impl SmtSolver<()> for SolverStub {
         String::from("not implemented")
     }
 
-    fn assert(&mut self, _: &()) {}
+    fn assert(&self, _: &()) {}
 
-    fn backtrack(&mut self) {}
+    fn backtrack(&self) {}
 
-    fn get_as_smt_predicate(&mut self, _mirai_expression: &Expression) {}
+    fn get_as_smt_predicate(&self, _mirai_expression: &Expression) {}
 
     fn get_model_as_string(&self) -> String {
         String::from("not implemented")
@@ -91,9 +91,9 @@ impl SmtSolver<()> for SolverStub {
         String::from("not implemented")
     }
 
-    fn set_backtrack_position(&mut self) {}
+    fn set_backtrack_position(&self) {}
 
-    fn solve(&mut self) -> SmtResult {
+    fn solve(&self) -> SmtResult {
         SmtResult::Undefined
     }
 }

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -101,21 +101,21 @@ impl SmtSolver<Z3ExpressionType> for Z3Solver {
         }
     }
 
-    fn assert(&mut self, expression: &Z3ExpressionType) {
+    fn assert(&self, expression: &Z3ExpressionType) {
         let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             z3_sys::Z3_solver_assert(self.z3_context, self.z3_solver, *expression);
         }
     }
 
-    fn backtrack(&mut self) {
+    fn backtrack(&self) {
         let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             z3_sys::Z3_solver_pop(self.z3_context, self.z3_solver, 1);
         }
     }
 
-    fn get_as_smt_predicate(&mut self, mirai_expression: &Expression) -> Z3ExpressionType {
+    fn get_as_smt_predicate(&self, mirai_expression: &Expression) -> Z3ExpressionType {
         let _guard = Z3_MUTEX.lock().unwrap();
         self.get_as_bool_z3_ast(mirai_expression)
     }
@@ -139,14 +139,14 @@ impl SmtSolver<Z3ExpressionType> for Z3Solver {
         }
     }
 
-    fn set_backtrack_position(&mut self) {
+    fn set_backtrack_position(&self) {
         let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             z3_sys::Z3_solver_push(self.z3_context, self.z3_solver);
         }
     }
 
-    fn solve(&mut self) -> SmtResult {
+    fn solve(&self) -> SmtResult {
         let _guard = Z3_MUTEX.lock().unwrap();
         unsafe {
             match z3_sys::Z3_solver_check(self.z3_context, self.z3_solver) {
@@ -160,7 +160,7 @@ impl SmtSolver<Z3ExpressionType> for Z3Solver {
 
 impl Z3Solver {
     #[allow(clippy::cognitive_complexity)]
-    fn get_as_z3_ast(&mut self, expression: &Expression) -> z3_sys::Z3_ast {
+    fn get_as_z3_ast(&self, expression: &Expression) -> z3_sys::Z3_ast {
         match expression {
             Expression::Add { .. }
             | Expression::AddOverflows { .. }
@@ -420,7 +420,7 @@ impl Z3Solver {
     }
 
     fn get_ast_for_widened(
-        &mut self,
+        &self,
         path: &Rc<Path>,
         operand: &Rc<AbstractValue>,
         target_type: ExpressionType,
@@ -460,7 +460,7 @@ impl Z3Solver {
         }
     }
 
-    fn get_constant_as_ast(&mut self, const_domain: &ConstantDomain) -> z3_sys::Z3_ast {
+    fn get_constant_as_ast(&self, const_domain: &ConstantDomain) -> z3_sys::Z3_ast {
         match const_domain {
             ConstantDomain::Char(v) => unsafe {
                 z3_sys::Z3_mk_int(self.z3_context, i32::from(*v as u16), self.int_sort)
@@ -503,7 +503,7 @@ impl Z3Solver {
     }
 
     fn get_range_check(
-        &mut self,
+        &self,
         operand_ast: z3_sys::Z3_ast,
         min_ast: z3_sys::Z3_ast,
         max_ast: z3_sys::Z3_ast,
@@ -517,7 +517,7 @@ impl Z3Solver {
     }
 
     #[allow(clippy::cognitive_complexity)]
-    fn get_as_numeric_z3_ast(&mut self, expression: &Expression) -> (bool, z3_sys::Z3_ast) {
+    fn get_as_numeric_z3_ast(&self, expression: &Expression) -> (bool, z3_sys::Z3_ast) {
         match expression {
             Expression::Add { left, right } => {
                 let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
@@ -860,7 +860,7 @@ impl Z3Solver {
         }
     }
 
-    fn get_as_bool_z3_ast(&mut self, expression: &Expression) -> z3_sys::Z3_ast {
+    fn get_as_bool_z3_ast(&self, expression: &Expression) -> z3_sys::Z3_ast {
         match expression {
             Expression::BitAnd { .. } | Expression::BitOr { .. } | Expression::BitXor { .. } => {
                 //todo: get operands as booleans and treat this operands as logical
@@ -929,7 +929,7 @@ impl Z3Solver {
         }
     }
 
-    fn get_as_bv_z3_ast(&mut self, expression: &Expression, num_bits: u32) -> z3_sys::Z3_ast {
+    fn get_as_bv_z3_ast(&self, expression: &Expression, num_bits: u32) -> z3_sys::Z3_ast {
         match expression {
             Expression::Add { left, right } => {
                 let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);


### PR DESCRIPTION
## Description

Some more places where this is now unnecessary because of the switch to using RefCell for cached domains.

## Type of change

- [x] Code cleanup

## How Has This Been Tested?
cargo test; ./validate.sh

