### PR TITLE
Modify Developer Guide to describe resolution for 'dyld: Library not loaded' issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The initial focus will be on taint analysis.
 You'll need to install MIRAI as described [here](https://github.com/facebookexperimental/MIRAI/blob/master/documentation/InstallationGuide.md).
 
 To run mirai, use cargo with `RUSTC_WRAPPER` set to `mirai`.
-Use `rustup override` to set your crate to use the same version of Rust as MIRAI as 
+Use `rustup override` to make Cargo use the same version of Rust as MIRAI as 
 described in the [Installation Guide](https://github.com/facebookexperimental/MIRAI/blob/master/documentation/InstallationGuide.md).
 
 The easiest way to get started is to first build your project in the normal way. When there are no compile errors,

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The initial focus will be on taint analysis.
 You'll need to install MIRAI as described [here](https://github.com/facebookexperimental/MIRAI/blob/master/documentation/InstallationGuide.md).
 
 To run mirai, use cargo with `RUSTC_WRAPPER` set to `mirai`.
+Use `rustup override` to set your crate to use the same version of Rust as MIRAI as 
+described in the [Installation Guide](https://github.com/facebookexperimental/MIRAI/blob/master/documentation/InstallationGuide.md).
 
 The easiest way to get started is to first build your project in the normal way. When there are no compile errors,
 no lint errors and no test failures, you can proceed to the next step and run MIRAI. For example:

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -36,6 +36,13 @@ You can then run mirai as if it were rustc, because it is in fact rustc, just wi
 To run mirai via cargo, as if it were rustc, first do `cargo install --force --path  ~/mirai` then set the
 `RUSTC_WRAPPER` environment variable to `mirai`.
 
+When running `cargo check` on a crate make sure to either:
+1. Set Rust to use the same nightly as MIRAI in the crate's directory (via `rustup override`).
+2. Or set `DYLD_LIBRARY_PATH=/Users/$USER/.rustup/toolchains/nightly-YYYY-MM-DD-x86_64-apple-darwin/lib/` before running `cargo check`.
+    - (Be sure to fill `YYYY-MM-DD` with the correctly nightly date.)
+
+Failure to do so may result in the error: `dyld: Library not loaded`.
+
 ## Debugging
 
 ### Clion

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -36,9 +36,10 @@ You can then run mirai as if it were rustc, because it is in fact rustc, just wi
 To run mirai via cargo, as if it were rustc, first do `cargo install --force --path  ~/mirai` then set the
 `RUSTC_WRAPPER` environment variable to `mirai`.
 
-When running `cargo check` on a crate make sure to either:
+When running `RUSTC_WRAPPER=mirai cargo check` on a crate make sure to either:
 1. Set Rust to use the same nightly as MIRAI in the crate's directory (via `rustup override`).
-2. Or set `DYLD_LIBRARY_PATH=/Users/$USER/.rustup/toolchains/nightly-YYYY-MM-DD-x86_64-apple-darwin/lib/` before running `cargo check`.
+2. Or set `DYLD_LIBRARY_PATH=/Users/$USER/.rustup/toolchains/nightly-YYYY-MM-DD-x86_64-apple-darwin/lib/` before running 
+    `RUSTC_WRAPPER=mirai cargo check`.
     - (Be sure to fill `YYYY-MM-DD` with the correctly nightly date.)
 
 Failure to do so may result in the error: `dyld: Library not loaded`.


### PR DESCRIPTION
## Description

Modified DeveloperGuide.md to describe two ways to get around the error `dyld: Library not loaded` when running `RUSTC_WRAPPER=mirai cargo check` on a crate.

Fixes: N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Documentation update

## How Has This Been Tested?

Local testing shows that both added solutions resolve the `dyld: Library not loaded` error.

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [ ] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

