### PR TITLE
Break up z3_solver methods into smaller methods

### DIFF
--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -159,7 +159,6 @@ impl SmtSolver<Z3ExpressionType> for Z3Solver {
 }
 
 impl Z3Solver {
-    #[allow(clippy::cognitive_complexity)]
     fn get_as_z3_ast(&self, expression: &Expression) -> z3_sys::Z3_ast {
         match expression {
             Expression::Add { .. }
@@ -171,12 +170,7 @@ impl Z3Solver {
             | Expression::Sub { .. }
             | Expression::SubOverflows { .. } => self.get_as_numeric_z3_ast(expression).1,
             Expression::And { left, right } => {
-                let left_ast = self.get_as_bool_z3_ast(&(**left).expression);
-                let right_ast = self.get_as_bool_z3_ast(&(**right).expression);
-                unsafe {
-                    let tmp = vec![left_ast, right_ast];
-                    z3_sys::Z3_mk_and(self.z3_context, 2, tmp.as_ptr())
-                }
+                self.general_boolean_op(left, right, z3_sys::Z3_mk_and)
             }
             Expression::BitAnd { .. } | Expression::BitOr { .. } | Expression::BitXor { .. } => {
                 self.get_as_bv_z3_ast(expression, 128)
@@ -184,220 +178,252 @@ impl Z3Solver {
             Expression::Cast {
                 operand,
                 target_type,
-            } => {
-                if *target_type == ExpressionType::NonPrimitive
-                    || *target_type == ExpressionType::Reference
-                {
-                    self.get_as_z3_ast(&operand.expression)
-                } else if *target_type == ExpressionType::Bool {
-                    self.get_as_bool_z3_ast(&operand.expression)
-                } else {
-                    self.get_as_numeric_z3_ast(&operand.expression).1
-                }
-            }
+            } => self.general_cast(&operand, target_type),
             Expression::CompileTimeConstant(const_domain) => self.get_constant_as_ast(const_domain),
             Expression::ConditionalExpression {
                 condition,
                 consequent,
                 alternate,
-            } => {
-                let condition_ast = self.get_as_bool_z3_ast(&(**condition).expression);
-                let consequent_ast = self.get_as_z3_ast(&(**consequent).expression);
-                let alternate_ast = self.get_as_z3_ast(&(**alternate).expression);
-                unsafe {
-                    z3_sys::Z3_mk_ite(
-                        self.z3_context,
-                        condition_ast,
-                        consequent_ast,
-                        alternate_ast,
-                    )
-                }
-            }
+            } => self.general_conditional(condition, consequent, alternate),
             Expression::Equals { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        z3_sys::Z3_mk_fpa_eq(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_eq(self.z3_context, left_ast, right_ast)
-                    }
-                }
+                self.general_relational(left, right, z3_sys::Z3_mk_fpa_eq, z3_sys::Z3_mk_eq)
             }
             Expression::GreaterOrEqual { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        z3_sys::Z3_mk_fpa_geq(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_ge(self.z3_context, left_ast, right_ast)
-                    }
-                }
+                self.general_relational(left, right, z3_sys::Z3_mk_fpa_geq, z3_sys::Z3_mk_ge)
             }
             Expression::GreaterThan { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        z3_sys::Z3_mk_fpa_gt(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_gt(self.z3_context, left_ast, right_ast)
-                    }
-                }
+                self.general_relational(left, right, z3_sys::Z3_mk_fpa_gt, z3_sys::Z3_mk_gt)
             }
             Expression::LessOrEqual { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        z3_sys::Z3_mk_fpa_leq(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_le(self.z3_context, left_ast, right_ast)
-                    }
-                }
+                self.general_relational(left, right, z3_sys::Z3_mk_fpa_leq, z3_sys::Z3_mk_le)
             }
             Expression::LessThan { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        z3_sys::Z3_mk_fpa_lt(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_lt(self.z3_context, left_ast, right_ast)
-                    }
-                }
+                self.general_relational(left, right, z3_sys::Z3_mk_fpa_lt, z3_sys::Z3_mk_lt)
             }
-            Expression::Ne { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        let l = z3_sys::Z3_mk_fpa_is_nan(self.z3_context, left_ast);
-                        let r = z3_sys::Z3_mk_fpa_is_nan(self.z3_context, right_ast);
-                        let eq = z3_sys::Z3_mk_fpa_eq(self.z3_context, left_ast, right_ast);
-                        let ne = z3_sys::Z3_mk_not(self.z3_context, eq);
-                        let tmp = vec![l, r, ne];
-                        z3_sys::Z3_mk_or(self.z3_context, 3, tmp.as_ptr())
-                    } else {
-                        z3_sys::Z3_mk_not(
-                            self.z3_context,
-                            z3_sys::Z3_mk_eq(self.z3_context, left_ast, right_ast),
-                        )
-                    }
-                }
-            }
-            Expression::Neg { operand } => {
-                let (is_float, operand_ast) = self.get_as_numeric_z3_ast(&(**operand).expression);
-                unsafe {
-                    if is_float {
-                        z3_sys::Z3_mk_fpa_neg(self.z3_context, operand_ast)
-                    } else {
-                        z3_sys::Z3_mk_unary_minus(self.z3_context, operand_ast)
-                    }
-                }
-            }
-            Expression::Not { operand } => {
-                let operand_ast = self.get_as_bool_z3_ast(&(**operand).expression);
-                unsafe { z3_sys::Z3_mk_not(self.z3_context, operand_ast) }
-            }
+            Expression::Ne { left, right } => self.general_ne(left, right),
+            Expression::Neg { operand } => self.general_negation(operand),
+            Expression::Not { operand } => self.general_logical_not(operand),
             Expression::Or { left, right } => {
-                let left_ast = self.get_as_bool_z3_ast(&(**left).expression);
-                let right_ast = self.get_as_bool_z3_ast(&(**right).expression);
-                unsafe {
-                    let tmp = vec![left_ast, right_ast];
-                    z3_sys::Z3_mk_or(self.z3_context, 2, tmp.as_ptr())
-                }
+                self.general_boolean_op(left, right, z3_sys::Z3_mk_or)
             }
-            Expression::Reference(path) => {
-                let path_str = CString::new(format!("&{:?}", path)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.any_sort)
-                }
-            }
+            Expression::Reference(path) => self.general_reference(path),
             Expression::Shl { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, 128);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, 128);
-                unsafe { z3_sys::Z3_mk_bvshl(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(128, left, right, z3_sys::Z3_mk_bvshl)
             }
             Expression::Shr {
                 left,
                 right,
                 result_type,
-            } => {
-                let num_bits = u32::from(result_type.bit_length());
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe {
-                    if result_type.is_signed_integer() {
-                        z3_sys::Z3_mk_bvashr(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_bvlshr(self.z3_context, left_ast, right_ast)
-                    }
-                }
-            }
+            } => self.general_shr(left, right, result_type),
             Expression::ShlOverflows {
                 right, result_type, ..
             }
             | Expression::ShrOverflows {
                 right, result_type, ..
-            } => {
-                let (f, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume!(!f);
-                let num_bits = i32::from(result_type.bit_length());
-                unsafe {
-                    let num_bits_val = z3_sys::Z3_mk_int(self.z3_context, num_bits, self.int_sort);
-                    z3_sys::Z3_mk_ge(self.z3_context, right_ast, num_bits_val)
-                }
-            }
-            Expression::Top | Expression::Bottom => unsafe {
-                z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, self.bool_sort)
-            },
-            Expression::Variable { path, var_type } => {
-                let path_str = CString::new(format!("{:?}", path)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    let sort = self.get_sort_for(var_type);
-                    let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
-                    if var_type.is_integer() {
-                        let min_ast = self.get_constant_as_ast(&var_type.min_value());
-                        let max_ast = self.get_constant_as_ast(&var_type.max_value());
-                        let range_check = self.get_range_check(ast, min_ast, max_ast);
-
-                        // Side-effecting the solver smells bad, but it hard to come up with an expression
-                        // of type var_type that only take values that satisfies the range constraint.
-                        // Since this is kind of a lazy variable declaration, it is probably OK.
-                        z3_sys::Z3_solver_assert(self.z3_context, self.z3_solver, range_check);
-                    }
-                    ast
-                }
-            }
+            } => self.general_shift_overflows(right, result_type),
+            Expression::Top | Expression::Bottom => self.general_fresh_const(),
+            Expression::Variable { path, var_type } => self.general_variable(path, &var_type),
             Expression::Widen { path, operand } => {
                 self.get_ast_for_widened(path, operand, operand.expression.infer_type())
             }
             Expression::Join { path, .. } | Expression::UnknownModelField { path, .. } => {
-                let path_str = CString::new(format!("{:?}", path)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    let sort = self.get_sort_for(&expression.infer_type());
-                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
-                }
+                self.general_join(expression, path)
             }
             _ => unsafe {
                 debug!("uninterpreted expression: {:?}", expression);
                 let sort = self.get_sort_for(&expression.infer_type());
                 z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)
             },
+        }
+    }
+
+    fn general_boolean_op(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        operation: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            num_args: std::os::raw::c_uint,
+            args: *const z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> z3_sys::Z3_ast {
+        let left_ast = self.get_as_bool_z3_ast(&(**left).expression);
+        let right_ast = self.get_as_bool_z3_ast(&(**right).expression);
+        unsafe {
+            let tmp = vec![left_ast, right_ast];
+            operation(self.z3_context, 2, tmp.as_ptr())
+        }
+    }
+
+    fn general_cast(
+        &self,
+        operand: &Rc<AbstractValue>,
+        target_type: &ExpressionType,
+    ) -> z3_sys::Z3_ast {
+        if *target_type == ExpressionType::NonPrimitive || *target_type == ExpressionType::Reference
+        {
+            self.get_as_z3_ast(&operand.expression)
+        } else if *target_type == ExpressionType::Bool {
+            self.get_as_bool_z3_ast(&operand.expression)
+        } else {
+            self.get_as_numeric_z3_ast(&operand.expression).1
+        }
+    }
+
+    fn general_conditional(
+        &self,
+        condition: &Rc<AbstractValue>,
+        consequent: &Rc<AbstractValue>,
+        alternate: &Rc<AbstractValue>,
+    ) -> z3_sys::Z3_ast {
+        let condition_ast = self.get_as_bool_z3_ast(&(**condition).expression);
+        let consequent_ast = self.get_as_z3_ast(&(**consequent).expression);
+        let alternate_ast = self.get_as_z3_ast(&(**alternate).expression);
+        unsafe {
+            z3_sys::Z3_mk_ite(
+                self.z3_context,
+                condition_ast,
+                consequent_ast,
+                alternate_ast,
+            )
+        }
+    }
+
+    fn general_relational(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        float_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+        int_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> z3_sys::Z3_ast {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume_eq!(lf, rf);
+        unsafe {
+            if lf {
+                float_op(self.z3_context, left_ast, right_ast)
+            } else {
+                int_op(self.z3_context, left_ast, right_ast)
+            }
+        }
+    }
+
+    fn general_ne(&self, left: &Rc<AbstractValue>, right: &Rc<AbstractValue>) -> z3_sys::Z3_ast {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume_eq!(lf, rf);
+        unsafe {
+            if lf {
+                let l = z3_sys::Z3_mk_fpa_is_nan(self.z3_context, left_ast);
+                let r = z3_sys::Z3_mk_fpa_is_nan(self.z3_context, right_ast);
+                let eq = z3_sys::Z3_mk_fpa_eq(self.z3_context, left_ast, right_ast);
+                let ne = z3_sys::Z3_mk_not(self.z3_context, eq);
+                let tmp = vec![l, r, ne];
+                z3_sys::Z3_mk_or(self.z3_context, 3, tmp.as_ptr())
+            } else {
+                z3_sys::Z3_mk_not(
+                    self.z3_context,
+                    z3_sys::Z3_mk_eq(self.z3_context, left_ast, right_ast),
+                )
+            }
+        }
+    }
+
+    fn general_negation(&self, operand: &Rc<AbstractValue>) -> z3_sys::Z3_ast {
+        let (is_float, operand_ast) = self.get_as_numeric_z3_ast(&(**operand).expression);
+        unsafe {
+            if is_float {
+                z3_sys::Z3_mk_fpa_neg(self.z3_context, operand_ast)
+            } else {
+                z3_sys::Z3_mk_unary_minus(self.z3_context, operand_ast)
+            }
+        }
+    }
+
+    fn general_logical_not(&self, operand: &Rc<AbstractValue>) -> z3_sys::Z3_ast {
+        let operand_ast = self.get_as_bool_z3_ast(&(**operand).expression);
+        unsafe { z3_sys::Z3_mk_not(self.z3_context, operand_ast) }
+    }
+
+    fn general_reference(&self, path: &Rc<Path>) -> z3_sys::Z3_ast {
+        let path_str = CString::new(format!("&{:?}", path)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.any_sort)
+        }
+    }
+
+    fn general_shr(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        result_type: &ExpressionType,
+    ) -> z3_sys::Z3_ast {
+        let num_bits = u32::from(result_type.bit_length());
+        let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
+        let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
+        unsafe {
+            if result_type.is_signed_integer() {
+                z3_sys::Z3_mk_bvashr(self.z3_context, left_ast, right_ast)
+            } else {
+                z3_sys::Z3_mk_bvlshr(self.z3_context, left_ast, right_ast)
+            }
+        }
+    }
+
+    fn general_shift_overflows(
+        &self,
+        right: &Rc<AbstractValue>,
+        result_type: &ExpressionType,
+    ) -> z3_sys::Z3_ast {
+        let (f, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume!(!f);
+        let num_bits = i32::from(result_type.bit_length());
+        unsafe {
+            let num_bits_val = z3_sys::Z3_mk_int(self.z3_context, num_bits, self.int_sort);
+            z3_sys::Z3_mk_ge(self.z3_context, right_ast, num_bits_val)
+        }
+    }
+
+    fn general_fresh_const(&self) -> z3_sys::Z3_ast {
+        //todo: why a bool_sort?
+        unsafe { z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, self.bool_sort) }
+    }
+
+    fn general_variable(&self, path: &Rc<Path>, var_type: &ExpressionType) -> z3_sys::Z3_ast {
+        let path_str = CString::new(format!("{:?}", path)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            let sort = self.get_sort_for(var_type);
+            let ast = z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort);
+            if var_type.is_integer() {
+                let min_ast = self.get_constant_as_ast(&var_type.min_value());
+                let max_ast = self.get_constant_as_ast(&var_type.max_value());
+                let range_check = self.get_range_check(ast, min_ast, max_ast);
+
+                // Side-effecting the solver smells bad, but it hard to come up with an expression
+                // of type var_type that only take values that satisfies the range constraint.
+                // Since this is kind of a lazy variable declaration, it is probably OK.
+                z3_sys::Z3_solver_assert(self.z3_context, self.z3_solver, range_check);
+            }
+            ast
+        }
+    }
+
+    fn general_join(&self, expression: &Expression, path: &Rc<Path>) -> z3_sys::Z3_ast {
+        let path_str = CString::new(format!("{:?}", path)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            let sort = self.get_sort_for(&expression.infer_type());
+            z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
         }
     }
 
@@ -516,198 +542,39 @@ impl Z3Solver {
         }
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn get_as_numeric_z3_ast(&self, expression: &Expression) -> (bool, z3_sys::Z3_ast) {
         match expression {
             Expression::Add { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        (
-                            true,
-                            z3_sys::Z3_mk_fpa_add(
-                                self.z3_context,
-                                self.nearest_even,
-                                left_ast,
-                                right_ast,
-                            ),
-                        )
-                    } else {
-                        let tmp = vec![left_ast, right_ast];
-                        (false, z3_sys::Z3_mk_add(self.z3_context, 2, tmp.as_ptr()))
-                    }
-                }
+                self.numeric_binary_var_arg(left, right, z3_sys::Z3_mk_fpa_add, z3_sys::Z3_mk_add)
             }
             Expression::AddOverflows {
                 left,
                 right,
                 result_type,
-            } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume!(!(lf || rf));
-                unsafe {
-                    let tmp = vec![left_ast, right_ast];
-                    let sum = z3_sys::Z3_mk_add(self.z3_context, 2, tmp.as_ptr());
-                    let min_ast = self.get_constant_as_ast(&result_type.min_value());
-                    let min_is_gt = z3_sys::Z3_mk_gt(self.z3_context, min_ast, sum);
-                    let max_ast = self.get_constant_as_ast(&result_type.max_value());
-                    let max_is_lt = z3_sys::Z3_mk_lt(self.z3_context, max_ast, sum);
-                    let tmp = vec![min_is_gt, max_is_lt];
-                    let result_overflows = z3_sys::Z3_mk_or(self.z3_context, 2, tmp.as_ptr());
-                    let left_in_range = self.get_range_check(left_ast, min_ast, max_ast);
-                    let right_in_range = self.get_range_check(right_ast, min_ast, max_ast);
-                    let tmp = vec![left_in_range, right_in_range, result_overflows];
-                    (false, z3_sys::Z3_mk_and(self.z3_context, 3, tmp.as_ptr()))
-                }
-            }
+            } => self.numeric_binary_overflow_vararg(left, right, result_type, z3_sys::Z3_mk_add),
             Expression::Div { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        (
-                            true,
-                            z3_sys::Z3_mk_fpa_div(
-                                self.z3_context,
-                                self.nearest_even,
-                                left_ast,
-                                right_ast,
-                            ),
-                        )
-                    } else {
-                        (
-                            false,
-                            z3_sys::Z3_mk_div(self.z3_context, left_ast, right_ast),
-                        )
-                    }
-                }
+                self.numeric_binary(left, right, z3_sys::Z3_mk_fpa_div, z3_sys::Z3_mk_div)
             }
-            Expression::Join { path, .. } => {
-                let path_str = CString::new(format!("{:?}", path)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    let mut var_type = &expression.infer_type();
-                    if !(var_type.is_integer() || var_type.is_floating_point_number()) {
-                        var_type = &ExpressionType::I128
-                    };
-                    let sort = self.get_sort_for(var_type);
-                    (
-                        var_type.is_floating_point_number(),
-                        z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort),
-                    )
-                }
+            Expression::Join { path, .. } | Expression::UnknownModelField { path, .. } => {
+                self.numeric_join(&expression, path)
             }
             Expression::Mul { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        (
-                            true,
-                            z3_sys::Z3_mk_fpa_mul(
-                                self.z3_context,
-                                self.nearest_even,
-                                left_ast,
-                                right_ast,
-                            ),
-                        )
-                    } else {
-                        let tmp = vec![left_ast, right_ast];
-                        (false, z3_sys::Z3_mk_mul(self.z3_context, 2, tmp.as_ptr()))
-                    }
-                }
+                self.numeric_binary_var_arg(left, right, z3_sys::Z3_mk_fpa_mul, z3_sys::Z3_mk_mul)
             }
             Expression::MulOverflows {
                 left,
                 right,
                 result_type,
-            } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume!(!(lf || rf));
-                unsafe {
-                    let tmp = vec![left_ast, right_ast];
-                    let sum = z3_sys::Z3_mk_mul(self.z3_context, 2, tmp.as_ptr());
-                    let min_ast = self.get_constant_as_ast(&result_type.min_value());
-                    let min_is_gt = z3_sys::Z3_mk_gt(self.z3_context, min_ast, sum);
-                    let max_ast = self.get_constant_as_ast(&result_type.max_value());
-                    let max_is_lt = z3_sys::Z3_mk_lt(self.z3_context, max_ast, sum);
-                    let tmp = vec![min_is_gt, max_is_lt];
-                    let result_overflows = z3_sys::Z3_mk_or(self.z3_context, 2, tmp.as_ptr());
-                    let left_in_range = self.get_range_check(left_ast, min_ast, max_ast);
-                    let right_in_range = self.get_range_check(right_ast, min_ast, max_ast);
-                    let tmp = vec![left_in_range, right_in_range, result_overflows];
-                    (false, z3_sys::Z3_mk_and(self.z3_context, 3, tmp.as_ptr()))
-                }
-            }
-            Expression::Rem { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        (
-                            true,
-                            z3_sys::Z3_mk_fpa_rem(self.z3_context, left_ast, right_ast),
-                        )
-                    } else {
-                        (
-                            false,
-                            z3_sys::Z3_mk_rem(self.z3_context, left_ast, right_ast),
-                        )
-                    }
-                }
-            }
+            } => self.numeric_binary_overflow_vararg(left, right, result_type, z3_sys::Z3_mk_mul),
+            Expression::Rem { left, right } => self.numeric_rem(left, right),
             Expression::Sub { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume_eq!(lf, rf);
-                unsafe {
-                    if lf {
-                        (
-                            true,
-                            z3_sys::Z3_mk_fpa_sub(
-                                self.z3_context,
-                                self.nearest_even,
-                                left_ast,
-                                right_ast,
-                            ),
-                        )
-                    } else {
-                        let tmp = vec![left_ast, right_ast];
-                        (false, z3_sys::Z3_mk_sub(self.z3_context, 2, tmp.as_ptr()))
-                    }
-                }
+                self.numeric_binary_var_arg(left, right, z3_sys::Z3_mk_fpa_sub, z3_sys::Z3_mk_sub)
             }
             Expression::SubOverflows {
                 left,
                 right,
                 result_type,
-            } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume!(!(lf || rf));
-                unsafe {
-                    let tmp = vec![left_ast, right_ast];
-                    let sum = z3_sys::Z3_mk_sub(self.z3_context, 2, tmp.as_ptr());
-                    let min_ast = self.get_constant_as_ast(&result_type.min_value());
-                    let min_is_gt = z3_sys::Z3_mk_gt(self.z3_context, min_ast, sum);
-                    let max_ast = self.get_constant_as_ast(&result_type.max_value());
-                    let max_is_lt = z3_sys::Z3_mk_lt(self.z3_context, max_ast, sum);
-                    let tmp = vec![min_is_gt, max_is_lt];
-                    let result_overflows = z3_sys::Z3_mk_or(self.z3_context, 2, tmp.as_ptr());
-                    let left_in_range = self.get_range_check(left_ast, min_ast, max_ast);
-                    let right_in_range = self.get_range_check(right_ast, min_ast, max_ast);
-                    let tmp = vec![left_in_range, right_in_range, result_overflows];
-                    (false, z3_sys::Z3_mk_and(self.z3_context, 3, tmp.as_ptr()))
-                }
-            }
+            } => self.numeric_binary_overflow_vararg(left, right, result_type, z3_sys::Z3_mk_sub),
             Expression::And { .. }
             | Expression::Equals { .. }
             | Expression::GreaterOrEqual { .. }
@@ -716,148 +583,345 @@ impl Z3Solver {
             | Expression::LessThan { .. }
             | Expression::Ne { .. }
             | Expression::Not { .. }
-            | Expression::Or { .. } => {
-                let ast = self.get_as_z3_ast(expression);
-                unsafe {
-                    (
-                        false,
-                        z3_sys::Z3_mk_ite(self.z3_context, ast, self.one, self.zero),
-                    )
-                }
-            }
+            | Expression::Or { .. } => self.numeric_boolean_op(expression),
             Expression::BitAnd { .. } | Expression::BitOr { .. } | Expression::BitXor { .. } => {
-                let ast = self.get_as_bv_z3_ast(expression, 128);
-                unsafe { (false, z3_sys::Z3_mk_bv2int(self.z3_context, ast, false)) }
+                self.numeric_bitwise_binary(expression)
             }
-            Expression::Cast { target_type, .. } => {
-                let path_str = CString::new(format!("{:?}", expression)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    match target_type {
-                        ExpressionType::F32 => (
-                            true,
-                            z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f32_sort),
-                        ),
-                        ExpressionType::F64 => (
-                            true,
-                            z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f64_sort),
-                        ),
-                        _ => (
-                            false,
-                            z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
-                        ),
-                    }
-                }
+            Expression::Cast { target_type, .. } => self.numeric_cast(expression, target_type),
+            Expression::CompileTimeConstant(const_domain) => {
+                self.numeric_const(expression, const_domain)
             }
-            Expression::CompileTimeConstant(const_domain) => match const_domain {
-                ConstantDomain::False => unsafe {
-                    (false, z3_sys::Z3_mk_int(self.z3_context, 0, self.int_sort))
-                },
-                ConstantDomain::True => unsafe {
-                    (false, z3_sys::Z3_mk_int(self.z3_context, 1, self.int_sort))
-                },
-                ConstantDomain::F32(..) | ConstantDomain::F64(..) => {
-                    (true, self.get_as_z3_ast(expression))
-                }
-                _ => (false, self.get_as_z3_ast(expression)),
-            },
             Expression::ConditionalExpression {
                 condition,
                 consequent,
                 alternate,
-            } => {
-                let condition_ast = self.get_as_bool_z3_ast(&(**condition).expression);
-                let (cf, consequent_ast) = self.get_as_numeric_z3_ast(&(**consequent).expression);
-                let (af, alternate_ast) = self.get_as_numeric_z3_ast(&(**alternate).expression);
-                checked_assume_eq!(cf, af);
-                unsafe {
-                    (
-                        cf,
-                        z3_sys::Z3_mk_ite(
-                            self.z3_context,
-                            condition_ast,
-                            consequent_ast,
-                            alternate_ast,
-                        ),
-                    )
-                }
+            } => self.numeric_conditional(condition, consequent, alternate),
+            Expression::Neg { operand } => self.numeric_neg(operand),
+            Expression::Reference(path) => self.numeric_reference(path),
+            Expression::Shl { left, right } => self.numeric_shl(left, right),
+            Expression::Shr { left, right, .. } => self.numeric_shr(left, right),
+            Expression::Top | Expression::Bottom => self.numeric_fresh_const(),
+            Expression::Variable { path, var_type } => {
+                self.numeric_variable(expression, path, var_type)
             }
-            Expression::Neg { operand } => {
-                let (is_float, operand_ast) = self.get_as_numeric_z3_ast(&(**operand).expression);
-                unsafe {
-                    if is_float {
-                        (true, z3_sys::Z3_mk_fpa_neg(self.z3_context, operand_ast))
-                    } else {
-                        (
-                            false,
-                            z3_sys::Z3_mk_unary_minus(self.z3_context, operand_ast),
-                        )
-                    }
-                }
+            Expression::Widen { path, operand } => self.numeric_widen(path, operand),
+            _ => (false, self.get_as_z3_ast(expression)),
+        }
+    }
+
+    fn numeric_binary_var_arg(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        float_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            rm: z3_sys::Z3_ast,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+        int_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            num_args: ::std::os::raw::c_uint,
+            args: *const z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume_eq!(lf, rf);
+        unsafe {
+            if lf {
+                (
+                    true,
+                    float_op(self.z3_context, self.nearest_even, left_ast, right_ast),
+                )
+            } else {
+                let tmp = vec![left_ast, right_ast];
+                (false, int_op(self.z3_context, 2, tmp.as_ptr()))
             }
-            Expression::Reference(path) => unsafe {
+        }
+    }
+
+    fn numeric_binary_overflow_vararg(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        result_type: &ExpressionType,
+        int_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            num_args: ::std::os::raw::c_uint,
+            args: *const z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume!(!(lf || rf));
+        unsafe {
+            let tmp = vec![left_ast, right_ast];
+            let result = int_op(self.z3_context, 2, tmp.as_ptr());
+            let min_ast = self.get_constant_as_ast(&result_type.min_value());
+            let min_is_gt = z3_sys::Z3_mk_gt(self.z3_context, min_ast, result);
+            let max_ast = self.get_constant_as_ast(&result_type.max_value());
+            let max_is_lt = z3_sys::Z3_mk_lt(self.z3_context, max_ast, result);
+            let tmp = vec![min_is_gt, max_is_lt];
+            let result_overflows = z3_sys::Z3_mk_or(self.z3_context, 2, tmp.as_ptr());
+            let left_in_range = self.get_range_check(left_ast, min_ast, max_ast);
+            let right_in_range = self.get_range_check(right_ast, min_ast, max_ast);
+            let tmp = vec![left_in_range, right_in_range, result_overflows];
+            (false, z3_sys::Z3_mk_and(self.z3_context, 3, tmp.as_ptr()))
+        }
+    }
+
+    fn numeric_rem(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume_eq!(lf, rf);
+        unsafe {
+            if lf {
+                (
+                    true,
+                    z3_sys::Z3_mk_fpa_rem(self.z3_context, left_ast, right_ast),
+                )
+            } else {
+                (
+                    false,
+                    z3_sys::Z3_mk_rem(self.z3_context, left_ast, right_ast),
+                )
+            }
+        }
+    }
+
+    fn numeric_binary(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        float_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            rm: z3_sys::Z3_ast,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+        int_op: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume_eq!(lf, rf);
+        unsafe {
+            if lf {
+                (
+                    true,
+                    float_op(self.z3_context, self.nearest_even, left_ast, right_ast),
+                )
+            } else {
+                (false, int_op(self.z3_context, left_ast, right_ast))
+            }
+        }
+    }
+
+    fn numeric_join(&self, expression: &Expression, path: &Rc<Path>) -> (bool, z3_sys::Z3_ast) {
+        let path_str = CString::new(format!("{:?}", path)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            let mut var_type = &expression.infer_type();
+            if !(var_type.is_integer() || var_type.is_floating_point_number()) {
+                var_type = &ExpressionType::I128
+            };
+            let sort = self.get_sort_for(var_type);
+            (
+                var_type.is_floating_point_number(),
+                z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort),
+            )
+        }
+    }
+
+    fn numeric_boolean_op(&self, expression: &Expression) -> (bool, z3_sys::Z3_ast) {
+        let ast = self.get_as_z3_ast(expression);
+        unsafe {
+            (
+                false,
+                z3_sys::Z3_mk_ite(self.z3_context, ast, self.one, self.zero),
+            )
+        }
+    }
+
+    fn numeric_bitwise_binary(&self, expression: &Expression) -> (bool, z3_sys::Z3_ast) {
+        let ast = self.get_as_bv_z3_ast(expression, 128);
+        unsafe { (false, z3_sys::Z3_mk_bv2int(self.z3_context, ast, false)) }
+    }
+
+    fn numeric_cast(
+        &self,
+        expression: &Expression,
+        target_type: &ExpressionType,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let path_str = CString::new(format!("{:?}", expression)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            match target_type {
+                ExpressionType::F32 => (
+                    true,
+                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f32_sort),
+                ),
+                ExpressionType::F64 => (
+                    true,
+                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f64_sort),
+                ),
+                _ => (
+                    false,
+                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
+                ),
+            }
+        }
+    }
+
+    fn numeric_const(
+        &self,
+        expression: &Expression,
+        const_domain: &ConstantDomain,
+    ) -> (bool, z3_sys::Z3_ast) {
+        match const_domain {
+            ConstantDomain::False => unsafe {
+                (false, z3_sys::Z3_mk_int(self.z3_context, 0, self.int_sort))
+            },
+            ConstantDomain::True => unsafe {
+                (false, z3_sys::Z3_mk_int(self.z3_context, 1, self.int_sort))
+            },
+            ConstantDomain::F32(..) | ConstantDomain::F64(..) => {
+                (true, self.get_as_z3_ast(expression))
+            }
+            _ => (false, self.get_as_z3_ast(expression)),
+        }
+    }
+
+    fn numeric_conditional(
+        &self,
+        condition: &Rc<AbstractValue>,
+        consequent: &Rc<AbstractValue>,
+        alternate: &Rc<AbstractValue>,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let condition_ast = self.get_as_bool_z3_ast(&(**condition).expression);
+        let (cf, consequent_ast) = self.get_as_numeric_z3_ast(&(**consequent).expression);
+        let (af, alternate_ast) = self.get_as_numeric_z3_ast(&(**alternate).expression);
+        checked_assume_eq!(cf, af);
+        unsafe {
+            (
+                cf,
+                z3_sys::Z3_mk_ite(
+                    self.z3_context,
+                    condition_ast,
+                    consequent_ast,
+                    alternate_ast,
+                ),
+            )
+        }
+    }
+
+    fn numeric_neg(&self, operand: &Rc<AbstractValue>) -> (bool, z3_sys::Z3_ast) {
+        let (is_float, operand_ast) = self.get_as_numeric_z3_ast(&(**operand).expression);
+        unsafe {
+            if is_float {
+                (true, z3_sys::Z3_mk_fpa_neg(self.z3_context, operand_ast))
+            } else {
+                (
+                    false,
+                    z3_sys::Z3_mk_unary_minus(self.z3_context, operand_ast),
+                )
+            }
+        }
+    }
+
+    fn numeric_reference(&self, path: &Rc<Path>) -> (bool, z3_sys::Z3_ast) {
+        unsafe {
+            let path_symbol = self.get_symbol_for(path);
+            (
+                false,
+                z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
+            )
+        }
+    }
+
+    fn numeric_shl(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume!(!(lf || rf));
+        unsafe {
+            let right_power = z3_sys::Z3_mk_power(self.z3_context, self.two, right_ast);
+            let tmp = vec![left_ast, right_power];
+            (false, z3_sys::Z3_mk_mul(self.z3_context, 2, tmp.as_ptr()))
+        }
+    }
+
+    fn numeric_shr(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+    ) -> (bool, z3_sys::Z3_ast) {
+        let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
+        let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
+        checked_assume!(!(lf || rf));
+        unsafe {
+            let right_power = z3_sys::Z3_mk_power(self.z3_context, self.two, right_ast);
+            (
+                false,
+                z3_sys::Z3_mk_div(self.z3_context, left_ast, right_power),
+            )
+        }
+    }
+
+    fn numeric_fresh_const(&self) -> (bool, z3_sys::Z3_ast) {
+        unsafe {
+            (
+                false,
+                z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, self.int_sort),
+            )
+        }
+    }
+
+    fn numeric_variable(
+        &self,
+        expression: &Expression,
+        path: &Rc<Path>,
+        var_type: &ExpressionType,
+    ) -> (bool, z3_sys::Z3_ast) {
+        use self::ExpressionType::*;
+        match var_type {
+            Bool | Reference | NonPrimitive => unsafe {
                 let path_symbol = self.get_symbol_for(path);
                 (
                     false,
                     z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
                 )
             },
-            Expression::Shl { left, right } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume!(!(lf || rf));
-                unsafe {
-                    let right_power = z3_sys::Z3_mk_power(self.z3_context, self.two, right_ast);
-                    let tmp = vec![left_ast, right_power];
-                    (false, z3_sys::Z3_mk_mul(self.z3_context, 2, tmp.as_ptr()))
-                }
-            }
-            Expression::Shr { left, right, .. } => {
-                let (lf, left_ast) = self.get_as_numeric_z3_ast(&(**left).expression);
-                let (rf, right_ast) = self.get_as_numeric_z3_ast(&(**right).expression);
-                checked_assume!(!(lf || rf));
-                unsafe {
-                    let right_power = z3_sys::Z3_mk_power(self.z3_context, self.two, right_ast);
-                    (
-                        false,
-                        z3_sys::Z3_mk_div(self.z3_context, left_ast, right_power),
-                    )
-                }
-            }
-            Expression::Top | Expression::Bottom => unsafe {
-                (
-                    false,
-                    z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, self.int_sort),
-                )
-            },
-            Expression::Variable { path, var_type } => {
-                use self::ExpressionType::*;
-                match var_type {
-                    Bool | Reference | NonPrimitive => unsafe {
-                        let path_symbol = self.get_symbol_for(path);
-                        (
-                            false,
-                            z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
-                        )
-                    },
-                    F32 | F64 => (true, self.get_as_z3_ast(expression)),
-                    _ => (false, self.get_as_z3_ast(expression)),
-                }
-            }
-            Expression::Widen { path, operand } => {
-                use self::ExpressionType::*;
-                let expr_type = operand.expression.infer_type();
-                let expr_type = match expr_type {
-                    Bool | Reference | NonPrimitive => ExpressionType::I128,
-                    _ => expr_type,
-                };
-                let is_float = expr_type.is_floating_point_number();
-                let ast = self.get_ast_for_widened(path, operand, expr_type);
-                (is_float, ast)
-            }
+            F32 | F64 => (true, self.get_as_z3_ast(expression)),
             _ => (false, self.get_as_z3_ast(expression)),
         }
+    }
+
+    fn numeric_widen(
+        &self,
+        path: &Rc<Path>,
+        operand: &Rc<AbstractValue>,
+    ) -> (bool, z3_sys::Z3_ast) {
+        use self::ExpressionType::*;
+        let expr_type = operand.expression.infer_type();
+        let expr_type = match expr_type {
+            Bool | Reference | NonPrimitive => ExpressionType::I128,
+            _ => expr_type,
+        };
+        let is_float = expr_type.is_floating_point_number();
+        let ast = self.get_ast_for_widened(path, operand, expr_type);
+        (is_float, ast)
     }
 
     fn get_as_bool_z3_ast(&self, expression: &Expression) -> z3_sys::Z3_ast {
@@ -932,111 +996,53 @@ impl Z3Solver {
     fn get_as_bv_z3_ast(&self, expression: &Expression, num_bits: u32) -> z3_sys::Z3_ast {
         match expression {
             Expression::Add { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvadd(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvadd)
             }
             Expression::AddOverflows {
                 left,
                 right,
                 result_type,
-            } => {
-                let num_bits = u32::from(result_type.bit_length());
-                let is_signed = result_type.is_signed_integer();
-                let left_bv = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_bv = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe {
-                    let does_not_overflow = z3_sys::Z3_mk_bvadd_no_overflow(
-                        self.z3_context,
-                        left_bv,
-                        right_bv,
-                        is_signed,
-                    );
-                    if is_signed {
-                        let does_not_underflow =
-                            z3_sys::Z3_mk_bvadd_no_underflow(self.z3_context, left_bv, right_bv);
-                        let tmp = vec![does_not_overflow, does_not_underflow];
-                        let stays_in_range = z3_sys::Z3_mk_and(self.z3_context, 2, tmp.as_ptr());
-                        z3_sys::Z3_mk_not(self.z3_context, stays_in_range)
-                    } else {
-                        z3_sys::Z3_mk_not(self.z3_context, does_not_overflow)
-                    }
-                }
-            }
+            } => self.bv_overflows(
+                left,
+                right,
+                result_type,
+                z3_sys::Z3_mk_bvadd_no_overflow,
+                z3_sys::Z3_mk_bvadd_no_underflow,
+            ),
             Expression::Div { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvsdiv(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvsdiv)
             }
             Expression::Mul { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvmul(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvmul)
             }
             Expression::MulOverflows {
                 left,
                 right,
                 result_type,
-            } => {
-                let num_bits = u32::from(result_type.bit_length());
-                let is_signed = result_type.is_signed_integer();
-                let left_bv = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_bv = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe {
-                    let does_not_overflow = z3_sys::Z3_mk_bvmul_no_overflow(
-                        self.z3_context,
-                        left_bv,
-                        right_bv,
-                        is_signed,
-                    );
-                    if is_signed {
-                        let does_not_underflow =
-                            z3_sys::Z3_mk_bvmul_no_underflow(self.z3_context, left_bv, right_bv);
-                        let tmp = vec![does_not_overflow, does_not_underflow];
-                        let stays_in_range = z3_sys::Z3_mk_and(self.z3_context, 2, tmp.as_ptr());
-                        z3_sys::Z3_mk_not(self.z3_context, stays_in_range)
-                    } else {
-                        z3_sys::Z3_mk_not(self.z3_context, does_not_overflow)
-                    }
-                }
-            }
+            } => self.bv_overflows(
+                left,
+                right,
+                result_type,
+                z3_sys::Z3_mk_bvmul_no_overflow,
+                z3_sys::Z3_mk_bvmul_no_underflow,
+            ),
             Expression::Rem { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvsrem(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvsrem)
             }
             Expression::Sub { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvsub(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvsub)
             }
             Expression::SubOverflows {
                 left,
                 right,
                 result_type,
-            } => {
-                let num_bits = u32::from(result_type.bit_length());
-                let is_signed = result_type.is_signed_integer();
-                let left_bv = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_bv = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe {
-                    let does_not_underflow = z3_sys::Z3_mk_bvsub_no_underflow(
-                        self.z3_context,
-                        left_bv,
-                        right_bv,
-                        is_signed,
-                    );
-                    if is_signed {
-                        let does_not_overflow =
-                            z3_sys::Z3_mk_bvsub_no_overflow(self.z3_context, left_bv, right_bv);
-                        let tmp = vec![does_not_overflow, does_not_underflow];
-                        let stays_in_range = z3_sys::Z3_mk_and(self.z3_context, 2, tmp.as_ptr());
-                        z3_sys::Z3_mk_not(self.z3_context, stays_in_range)
-                    } else {
-                        z3_sys::Z3_mk_not(self.z3_context, does_not_underflow)
-                    }
-                }
-            }
+            } => self.bv_overflows(
+                left,
+                right,
+                result_type,
+                z3_sys::Z3_mk_bvsub_no_underflow,
+                z3_sys::Z3_mk_bvsub_no_overflow,
+            ),
             Expression::And { .. }
             | Expression::Equals { .. }
             | Expression::GreaterOrEqual { .. }
@@ -1045,158 +1051,233 @@ impl Z3Solver {
             | Expression::LessThan { .. }
             | Expression::Ne { .. }
             | Expression::Not { .. }
-            | Expression::Or { .. } => {
-                let ast = self.get_as_z3_ast(expression);
-                // ast results in a boolean, but we want a bit vector.
-                unsafe {
-                    //todo: use a different primitive
-                    let bv_one = z3_sys::Z3_mk_int2bv(self.z3_context, num_bits, self.one);
-                    let bv_zero = z3_sys::Z3_mk_int2bv(self.z3_context, num_bits, self.zero);
-                    z3_sys::Z3_mk_ite(self.z3_context, ast, bv_one, bv_zero)
-                }
-            }
+            | Expression::Or { .. } => self.bv_boolean_op(expression, num_bits),
             Expression::BitAnd { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvand(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvand)
             }
             Expression::BitOr { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvor(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvor)
             }
             Expression::BitXor { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvxor(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvxor)
             }
-            Expression::Cast { .. } => {
-                let path_str = CString::new(format!("{:?}", expression)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
-                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
-                }
+            Expression::Cast { .. } => self.bv_cast(expression, num_bits),
+            Expression::CompileTimeConstant(const_domain) => {
+                self.bv_constant(num_bits, const_domain)
             }
-            Expression::CompileTimeConstant(const_domain) => match const_domain {
-                ConstantDomain::Char(v) => unsafe {
-                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 16, v as *const char as *const bool)
-                },
-                ConstantDomain::False => unsafe {
-                    let v = false;
-                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
-                },
-                ConstantDomain::F32(v) => unsafe {
-                    let fv = f32::from_bits(*v);
-                    z3_sys::Z3_mk_fpa_numeral_float(self.z3_context, fv, self.f32_sort)
-                },
-                ConstantDomain::F64(v) => unsafe {
-                    let fv = f64::from_bits(*v);
-                    z3_sys::Z3_mk_fpa_numeral_double(self.z3_context, fv, self.f64_sort)
-                },
-                ConstantDomain::I128(v) => unsafe {
-                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const i128 as *const bool)
-                },
-                ConstantDomain::U128(v) => unsafe {
-                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const u128 as *const bool)
-                },
-                ConstantDomain::True => unsafe {
-                    let v = true;
-                    z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
-                },
-                _ => unsafe {
-                    let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
-                    z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)
-                },
-            },
             Expression::ConditionalExpression {
                 condition,
                 consequent,
                 alternate,
-            } => {
-                let condition_ast = self.get_as_bool_z3_ast(&(**condition).expression);
-                let consequent_ast = self.get_as_bv_z3_ast(&(**consequent).expression, num_bits);
-                let alternate_ast = self.get_as_bv_z3_ast(&(**alternate).expression, num_bits);
-                unsafe {
-                    z3_sys::Z3_mk_ite(
-                        self.z3_context,
-                        condition_ast,
-                        consequent_ast,
-                        alternate_ast,
-                    )
-                }
-            }
-            Expression::Join { path, .. } => unsafe {
-                let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
-                let path_symbol = self.get_symbol_for(path);
-                z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
-            },
-            Expression::Reference(path) => unsafe {
-                let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
-                let path_symbol = self.get_symbol_for(path);
-                z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
-            },
+            } => self.bv_conditional(num_bits, condition, consequent, alternate),
+            Expression::Join { path, .. } => self.bv_join(num_bits, path),
+            Expression::Reference(path) => self.bv_reference(num_bits, path),
             Expression::Shl { left, right } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe { z3_sys::Z3_mk_bvshl(self.z3_context, left_ast, right_ast) }
+                self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvshl)
             }
             Expression::Shr {
                 left,
                 right,
                 result_type,
-            } => {
-                let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
-                let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
-                unsafe {
-                    if result_type.is_signed_integer() {
-                        z3_sys::Z3_mk_bvashr(self.z3_context, left_ast, right_ast)
-                    } else {
-                        z3_sys::Z3_mk_bvlshr(self.z3_context, left_ast, right_ast)
-                    }
-                }
+            } => self.bv_shr_by(num_bits, left, right, result_type),
+            Expression::Top | Expression::Bottom => self.bv_fresh_const(num_bits),
+            Expression::Variable { path, var_type } => self.bv_variable(path, var_type),
+            Expression::Widen { path, operand } => self.bv_widen(path, operand),
+            _ => self.get_as_z3_ast(expression),
+        }
+    }
+
+    fn bv_binary(
+        &self,
+        num_bits: u32,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        operation: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> z3_sys::Z3_ast {
+        let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
+        let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
+        unsafe { operation(self.z3_context, left_ast, right_ast) }
+    }
+
+    fn bv_overflows(
+        &self,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        result_type: &ExpressionType,
+        no_overflow: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+            signed: z3_sys::Z3_bool,
+        ) -> z3_sys::Z3_ast,
+        no_underflow: unsafe extern "C" fn(
+            c: z3_sys::Z3_context,
+            t1: z3_sys::Z3_ast,
+            t2: z3_sys::Z3_ast,
+        ) -> z3_sys::Z3_ast,
+    ) -> z3_sys::Z3_ast {
+        let num_bits = u32::from(result_type.bit_length());
+        let is_signed = result_type.is_signed_integer();
+        let left_bv = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
+        let right_bv = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
+        unsafe {
+            let does_not_overflow = no_overflow(self.z3_context, left_bv, right_bv, is_signed);
+            if is_signed {
+                let does_not_underflow = no_underflow(self.z3_context, left_bv, right_bv);
+                let tmp = vec![does_not_overflow, does_not_underflow];
+                let stays_in_range = z3_sys::Z3_mk_and(self.z3_context, 2, tmp.as_ptr());
+                z3_sys::Z3_mk_not(self.z3_context, stays_in_range)
+            } else {
+                z3_sys::Z3_mk_not(self.z3_context, does_not_overflow)
             }
-            Expression::Top | Expression::Bottom => unsafe {
+        }
+    }
+
+    fn bv_boolean_op(&self, expression: &Expression, num_bits: u32) -> z3_sys::Z3_ast {
+        let ast = self.get_as_z3_ast(expression);
+        // ast results in a boolean, but we want a bit vector.
+        unsafe {
+            let bv_one = z3_sys::Z3_mk_int2bv(self.z3_context, num_bits, self.one);
+            let bv_zero = z3_sys::Z3_mk_int2bv(self.z3_context, num_bits, self.zero);
+            z3_sys::Z3_mk_ite(self.z3_context, ast, bv_one, bv_zero)
+        }
+    }
+
+    fn bv_cast(&self, expression: &Expression, num_bits: u32) -> z3_sys::Z3_ast {
+        let path_str = CString::new(format!("{:?}", expression)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
+            z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
+        }
+    }
+
+    fn bv_constant(&self, num_bits: u32, const_domain: &ConstantDomain) -> z3_sys::Z3_ast {
+        match const_domain {
+            ConstantDomain::Char(v) => unsafe {
+                z3_sys::Z3_mk_bv_numeral(self.z3_context, 16, v as *const char as *const bool)
+            },
+            ConstantDomain::False => unsafe {
+                let v = false;
+                z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
+            },
+            ConstantDomain::F32(v) => unsafe {
+                let fv = f32::from_bits(*v);
+                z3_sys::Z3_mk_fpa_numeral_float(self.z3_context, fv, self.f32_sort)
+            },
+            ConstantDomain::F64(v) => unsafe {
+                let fv = f64::from_bits(*v);
+                z3_sys::Z3_mk_fpa_numeral_double(self.z3_context, fv, self.f64_sort)
+            },
+            ConstantDomain::I128(v) => unsafe {
+                z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const i128 as *const bool)
+            },
+            ConstantDomain::U128(v) => unsafe {
+                z3_sys::Z3_mk_bv_numeral(self.z3_context, 128, v as *const u128 as *const bool)
+            },
+            ConstantDomain::True => unsafe {
+                let v = true;
+                z3_sys::Z3_mk_bv_numeral(self.z3_context, 1, &v as *const bool)
+            },
+            _ => unsafe {
                 let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
                 z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)
             },
-            Expression::Variable { path, var_type } => {
-                use self::ExpressionType::*;
-                let path_str = CString::new(format!("{:?}", path)).unwrap();
-                unsafe {
-                    let path_symbol =
-                        z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
-                    let sort =
-                        z3_sys::Z3_mk_bv_sort(self.z3_context, u32::from(var_type.bit_length()));
-                    match var_type {
-                        Bool | Char | I8 | I16 | I32 | I64 | I128 | Isize | U8 | U16 | U32
-                        | U64 | U128 | Usize | Reference => {
-                            z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
-                        }
-                        F32 => z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f32_sort),
-                        F64 => z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f64_sort),
-                        NonPrimitive => {
-                            z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)
-                        }
-                    }
-                }
+        }
+    }
+
+    fn bv_conditional(
+        &self,
+        num_bits: u32,
+        condition: &Rc<AbstractValue>,
+        consequent: &Rc<AbstractValue>,
+        alternate: &Rc<AbstractValue>,
+    ) -> z3_sys::Z3_ast {
+        let condition_ast = self.get_as_bool_z3_ast(&(**condition).expression);
+        let consequent_ast = self.get_as_bv_z3_ast(&(**consequent).expression, num_bits);
+        let alternate_ast = self.get_as_bv_z3_ast(&(**alternate).expression, num_bits);
+        unsafe {
+            z3_sys::Z3_mk_ite(
+                self.z3_context,
+                condition_ast,
+                consequent_ast,
+                alternate_ast,
+            )
+        }
+    }
+
+    fn bv_join(&self, num_bits: u32, path: &Rc<Path>) -> z3_sys::Z3_ast {
+        unsafe {
+            let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
+            let path_symbol = self.get_symbol_for(path);
+            z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
+        }
+    }
+
+    fn bv_reference(&self, num_bits: u32, path: &Rc<Path>) -> z3_sys::Z3_ast {
+        unsafe {
+            let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
+            let path_symbol = self.get_symbol_for(path);
+            z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
+        }
+    }
+
+    fn bv_shr_by(
+        &self,
+        num_bits: u32,
+        left: &Rc<AbstractValue>,
+        right: &Rc<AbstractValue>,
+        result_type: &ExpressionType,
+    ) -> z3_sys::Z3_ast {
+        let left_ast = self.get_as_bv_z3_ast(&(**left).expression, num_bits);
+        let right_ast = self.get_as_bv_z3_ast(&(**right).expression, num_bits);
+        unsafe {
+            if result_type.is_signed_integer() {
+                z3_sys::Z3_mk_bvashr(self.z3_context, left_ast, right_ast)
+            } else {
+                z3_sys::Z3_mk_bvlshr(self.z3_context, left_ast, right_ast)
             }
-            Expression::Widen { path, operand } => {
-                use self::ExpressionType::*;
-                let expr_type = operand.expression.infer_type();
-                let expr_type = match expr_type {
-                    Bool | Reference | NonPrimitive => ExpressionType::I128,
-                    _ => expr_type,
-                };
-                let path_symbol = self.get_symbol_for(path);
-                unsafe {
-                    let sort =
-                        z3_sys::Z3_mk_bv_sort(self.z3_context, u32::from(expr_type.bit_length()));
-                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
-                }
+        }
+    }
+
+    fn bv_fresh_const(&self, num_bits: u32) -> z3_sys::Z3_ast {
+        unsafe {
+            let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
+            z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort)
+        }
+    }
+
+    fn bv_variable(&self, path: &Rc<Path>, var_type: &ExpressionType) -> z3_sys::Z3_ast {
+        use self::ExpressionType::*;
+        let path_str = CString::new(format!("{:?}", path)).unwrap();
+        unsafe {
+            let path_symbol = z3_sys::Z3_mk_string_symbol(self.z3_context, path_str.into_raw());
+            let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, u32::from(var_type.bit_length()));
+            match var_type {
+                Bool | Char | I8 | I16 | I32 | I64 | I128 | Isize | U8 | U16 | U32 | U64 | U128
+                | Usize | Reference => z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort),
+                F32 => z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f32_sort),
+                F64 => z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f64_sort),
+                NonPrimitive => z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, sort),
             }
-            _ => self.get_as_z3_ast(expression),
+        }
+    }
+
+    fn bv_widen(&self, path: &Rc<Path>, operand: &Rc<AbstractValue>) -> z3_sys::Z3_ast {
+        use self::ExpressionType::*;
+        let expr_type = operand.expression.infer_type();
+        let expr_type = match expr_type {
+            Bool | Reference | NonPrimitive => ExpressionType::I128,
+            _ => expr_type,
+        };
+        let path_symbol = self.get_symbol_for(path);
+        unsafe {
+            let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, u32::from(expr_type.bit_length()));
+            z3_sys::Z3_mk_const(self.z3_context, path_symbol, sort)
         }
     }
 }


### PR DESCRIPTION
## Description

The visitor methods in z3_solver were a bit too big for MIRAI too swallow and probably too big for most people as well. This is just a somewhat mechanical method extraction. The not entire mechanical part is when several code blocks become a single parameterized method.

## Type of change

- [x] Code Improvement

## How Has This Been Tested?
cargo test; ./validate.sh

