### PR TITLE
Simplify the path condition following an if-else

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -805,6 +805,17 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             match (&self.expression, &other.expression) {
                 (Expression::Not { ref operand }, _) if (**operand).eq(&other) => Rc::new(TRUE),
                 (_, Expression::Not { ref operand }) if (**operand).eq(&self) => Rc::new(TRUE),
+                //(x && y) || (x && !y) = x
+                (
+                    Expression::And {
+                        left: x1,
+                        right: y1,
+                    },
+                    Expression::And {
+                        left: x2,
+                        right: y2,
+                    },
+                ) if x1 == x2 && y1.logical_not().eq(y2) => x1.clone(),
                 _ => AbstractValue::make_binary(self.clone(), other, |left, right| {
                     Expression::Or { left, right }
                 }),


### PR DESCRIPTION
## Description

The path condition following an if-else statement is of the form (x && y) || (x && !y), which simplifies to just x. When this pattern appears frequently enough, it is a form of exponential blow-up, so simplification really matters in this case.

With this change, MIRAI on MIRAI now completes in 21.64s without any time-outs. That is less time than it takes the Rustc compiler to do an optimized build.

Full disclosure: The outer fixed point loop is still restricted to just 2 iterations, which means that recursion is not properly analyzed. There is still much work to be done on that front and when that is fixed, the analysis time will no doubt be significantly more.

## Type of change

- [x] Performance bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
cargo test; ./validate.sh

