### PR TITLE
Make sure free variables are mapped to Z3 constants of the right length

### DIFF
--- a/checker/tests/run-pass/smt_shift_left.rs
+++ b/checker/tests/run-pass/smt_shift_left.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls Z3Solver::bv_variable with an explicit bit length different from the var type
+
+pub fn read_uleb128_as_u32(bytes: [u8; 20]) -> u32 {
+    let mut value: u32 = 0;
+    let mut shift: u32 = 0;
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        let val = byte & 0x7f;
+        value |= (val as u32) << shift; //~ possible attempt to shift left with overflow
+        if val == byte {
+            return value;
+        }
+        shift += 7;
+        if shift > 28 {
+            break;
+        }
+        cursor += 1;
+    }
+    return value;
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Tweak the Z3 expression mapper to produce operands of consistent size when one of those operands is a free variable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; ./validate.sh
