### PR TITLE
Add option to only analyze a single function

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -30,7 +30,7 @@ pub struct MiraiCallbacks {
     /// True if this run is done via cargo test
     test_run: bool,
     /// If a function name is given, only analyze that function
-    analyze_single_func: Option<String>,
+    pub analyze_single_func: Option<String>,
 }
 
 /// Constructors
@@ -100,11 +100,6 @@ struct DefSets {
 }
 
 impl MiraiCallbacks {
-    /// Set MIRAI to analyze just a single function
-    pub fn set_analyze_single_func(&mut self, fname: Option<String>) {
-        self.analyze_single_func = fname;
-    }
-
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.
     fn analyze_with_mirai<'a, 'tcx: 'a>(
         &mut self,

--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
 
     let result = rustc_driver::report_ices_to_stderr_if_any(move || {
         let callbacks = &mut callbacks::MiraiCallbacks::default();
-        callbacks.set_analyze_single_func(analyze_single_func);
+        callbacks.analyze_single_func = analyze_single_func;
         rustc_driver::run_compiler(
             &command_line_arguments,
             callbacks,

--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -38,10 +38,11 @@ fn main() {
     }
 
     // Configure the analysis to just run on a single function if set
-    let mut analyze_single_func: Option<String> = None;
-    if env::var("SINGLE_FUNC").is_ok() {
-        analyze_single_func = env::var("SINGLE_FUNC").ok();
-    }
+    let analyze_single_func = if env::var("SINGLE_FUNC").is_ok() {
+        env::var("SINGLE_FUNC").ok()
+    } else {
+        None
+    };
 
     // Get command line arguments from environment and massage them a bit.
     let mut command_line_arguments: Vec<_> = env::args().collect();

--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -37,6 +37,12 @@ fn main() {
         env_logger::init_from_env(e);
     }
 
+    // Configure the analysis to just run on a single function if set
+    let mut analyze_single_func: Option<String> = None;
+    if env::var("SINGLE_FUNC").is_ok() {
+        analyze_single_func = env::var("SINGLE_FUNC").ok();
+    }
+
     // Get command line arguments from environment and massage them a bit.
     let mut command_line_arguments: Vec<_> = env::args().collect();
 
@@ -54,9 +60,11 @@ fn main() {
     command_line_arguments.push(utils::find_sysroot());
 
     let result = rustc_driver::report_ices_to_stderr_if_any(move || {
+        let callbacks = &mut callbacks::MiraiCallbacks::default();
+        callbacks.set_analyze_single_func(analyze_single_func);
         rustc_driver::run_compiler(
             &command_line_arguments,
-            &mut callbacks::MiraiCallbacks::default(),
+            callbacks,
             None, // use default file loader
             None, // emit output to default destination
         )


### PR DESCRIPTION
## Description

Add an environment variable `SINGLE_FUNC` that, if set to `fname`, restricts MIRAI to skip the analysis of all functions whose names don't match `fname`.

Fixes #113 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?

Testing has been completely locally. 

Linting via `clippy` fails due to the function `analyze_bodies` now having 8 arguments (over the max of 7 arguments). 

## Checklist:

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [ ] Make sure your code lints.
- [ ] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

