### PR TITLE
Fix equality for widened values

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1164,6 +1164,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     /// Replaces occurrences of Expression::Variable(path) with the value at that path
     /// in the given environment (if there is such a value).
     fn refine_paths(&self, environment: &Environment) -> Rc<AbstractValue> {
+        if self.expression_size > k_limits::MAX_EXPRESSION_SIZE {
+            return self.clone();
+        }
         match &self.expression {
             Expression::Top | Expression::Bottom | Expression::AbstractHeapAddress(..) => {
                 self.clone()

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -59,7 +59,10 @@ impl Hash for AbstractValue {
 
 impl PartialEq for AbstractValue {
     fn eq(&self, other: &Self) -> bool {
-        self.expression.eq(&other.expression)
+        match (&self.expression, &other.expression) {
+            (Expression::Widen { path: p1, .. }, Expression::Widen { path: p2, .. }) => p1.eq(p2),
+            (e1, e2) => e1.eq(e2),
+        }
     }
 }
 

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -1596,6 +1596,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     break;
                 }
             }
+            let elapsed_time_in_seconds = self.start_instant.elapsed().as_secs();
+            if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+                return;
+            }
             self.current_environment.update_value_at(tpath, rvalue);
         }
     }
@@ -1868,6 +1872,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         rtype: ExpressionType,
         move_elements: bool,
     ) {
+        let elapsed_time_in_seconds = self.start_instant.elapsed().as_secs();
+        if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+            return;
+        }
         let mut value_map = self.current_environment.value_map.clone();
         // Some qualified rpaths are patterns that represent collections of values.
         // We need to expand the patterns before doing the actual moves.
@@ -1946,6 +1954,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                             rtype.clone(),
                             move_elements,
                         );
+                        let elapsed_time_in_seconds = self.start_instant.elapsed().as_secs();
+                        if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+                            return;
+                        }
                     }
                     return;
                 }
@@ -1960,6 +1972,10 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             .iter()
             .filter(|(p, _)| p.is_rooted_by(&rpath))
         {
+            let elapsed_time_in_seconds = self.start_instant.elapsed().as_secs();
+            if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+                return;
+            }
             let qualified_path = path.replace_root(&rpath, target_path.clone());
             if move_elements {
                 debug!("moving {:?} to {:?}", value, qualified_path);

--- a/checker/tests/run-pass/fixed_point.rs
+++ b/checker/tests/run-pass/fixed_point.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that regresses a fixed point divergence bug
+
+pub fn write_u32_as_uleb128(value: u32) {
+    let mut val = value;
+    loop {
+        let v: u8 = (val & 0x7f) as u8;
+        if (v as u32) != val {
+            val >>= 7;
+        } else {
+            break;
+        }
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/smt_shift_left.rs
+++ b/checker/tests/run-pass/smt_shift_left.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls Z3Solver::bv_variable with an explicit bit length different from the var type
+
+pub fn read_uleb128_as_u32(bytes: [u8; 20]) -> u32 {
+    let mut value: u32 = 0;
+    let mut shift: u32 = 0;
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        let val = byte & 0x7f;
+        value |= (val as u32) << shift; //~ possible attempt to shift left with overflow
+        if val == byte {
+            return value;
+        }
+        shift += 7;
+        if shift > 28 {
+            break;
+        }
+        cursor += 1;
+    }
+    return value;
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/smt_shift_left.rs
+++ b/checker/tests/run-pass/smt_shift_left.rs
@@ -4,7 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that calls Z3Solver::bv_variable with an explicit bit length different from the var type
+// A test that calls Z3Solver::bv_variable with an explicit bit length different from the var type.
+// Additionally this also tests that the path condition includes equalities for loop controlled
+// variables that are not explicitly included in the loop condition.
 
 pub fn read_uleb128_as_u32(bytes: [u8; 20]) -> u32 {
     let mut value: u32 = 0;
@@ -13,7 +15,7 @@ pub fn read_uleb128_as_u32(bytes: [u8; 20]) -> u32 {
     while cursor < bytes.len() {
         let byte = bytes[cursor];
         let val = byte & 0x7f;
-        value |= (val as u32) << shift; //~ possible attempt to shift left with overflow
+        value |= (val as u32) << shift;
         if val == byte {
             return value;
         }


### PR DESCRIPTION
## Description

Widened values should be equal when their paths are equal. The operand part of a widened value is there to help with the heuristic construction of interval domains and has not been widened, which causes fixed point computation divergence.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage

## How Has This Been Tested?
cargo test; ./validate.sh
New test case
