### PR TITLE
Add a few more simplification patterns for or expressions

### DIFF
--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -355,6 +355,26 @@ impl Expression {
         }
     }
 
+    /// Determines if the given expression is the compile time constant 1u128.
+    pub fn is_one(&self) -> bool {
+        if let Expression::CompileTimeConstant(c) = self {
+            if let ConstantDomain::U128(c) = c {
+                return *c == 1u128;
+            }
+        }
+        false
+    }
+
+    /// Determines if the given expression is the compile time constant 0u128.
+    pub fn is_zero(&self) -> bool {
+        if let Expression::CompileTimeConstant(c) = self {
+            if let ConstantDomain::U128(c) = c {
+                return *c == 0u128;
+            }
+        }
+        false
+    }
+
     /// Adds any abstract heap addresses found in the associated expression to the given set.
     pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
         match &self {


### PR DESCRIPTION
## Description

Add simplification rules to factory function for logical or expressions. This makes summaries a little bit more concise, which is a baby step towards reducing exponential divergence in functions that use iterators.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code improvement

## How Has This Been Tested?
cargo test; ./validate.sh
