### PR TITLE
Correct value of u64::MAX

### DIFF
--- a/checker/tests/run-pass/u64_max.rs
+++ b/checker/tests/run-pass/u64_max.rs
@@ -11,5 +11,5 @@
 extern crate mirai_annotations;
 
 pub fn main() {
-    verify!(std::u64::MAX == 9223372036854775807);
+    verify!(std::u64::MAX == 18446744073709551615);
 }

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -346,7 +346,7 @@ pub mod core {
     }
 
     pub mod u64 {
-        pub const MAX: u64 = 9223372036854775807;
+        pub const MAX: u64 = 18446744073709551615;
     }
 
     pub mod mem {


### PR DESCRIPTION
## Description

`u64::MAX` was incorrectly set to `9223372036854775807` which is actually `i64::MAX`.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

Local testing.

## Checklist:

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

