### PR TITLE
Add a simplification rule to factor for OR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: osx
 language: rust
 rust:
-- nightly-2019-06-28
+- nightly-2019-07-03
 
 before_install:
 - if [ ${TRAVIS_OS_NAME} == "osx" ]; then curl -L https://github.com/mozilla/grcov/releases/download/v0.4.3/grcov-osx-x86_64.tar.bz2 | tar jxf -; fi

--- a/checker/tests/run-pass/def_id_not_unique.rs
+++ b/checker/tests/run-pass/def_id_not_unique.rs
@@ -10,7 +10,6 @@
 
 // This example is highly contrived, but inspired by a larger way more subtle code fragment.
 
-#![feature(type_alias_enum_variants)]
 #![allow(non_snake_case)]
 
 #[macro_use]

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -478,6 +478,10 @@ pub mod core {
             pub fn is_empty<T>(collection: &[T]) -> bool {
                 collection.len() == 0
             }
+
+            pub fn len<T>(collection: &[T]) -> usize {
+                collection.len()
+            }
         }
     }
 

--- a/standard_contracts/src/lib.rs
+++ b/standard_contracts/src/lib.rs
@@ -3,7 +3,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 //
-#![feature(type_alias_enum_variants)]
 
 #[macro_use]
 extern crate mirai_annotations;


### PR DESCRIPTION
## Description

Expressions of the form "x || (x && y)" arise during fix point loops and can easily blow up path condition expression sizes. Simplifying them to just x seems like a good thing to do.

Also update to the latest nightly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
