### PR TITLE
Log TRACE level events for function calls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +171,11 @@ dependencies = [
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fs2"
@@ -189,6 +226,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +246,18 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -225,6 +279,7 @@ dependencies = [
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 0.2.1",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,6 +508,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.15.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,9 +647,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
@@ -597,9 +661,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hashbrown 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61e4900fa4e80b3d15c78a08ec8a08433246063fa7577e7b2c6426b3b21b1f79"
 "checksum historian 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f653416eb756b69642a1f1498817970fafe409998a849622c27cc5b1b7df989c"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)" = "c6785aa7dd976f5fbf3b71cfd9cd49d7f783c1ff565a858d71031c6c313aa5c6"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90b7e153f2d4bf69d46a9e640e2c96573940fca671d275bf6f7687f6bab803fc"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -626,6 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_bytes 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aaff47db6ef8771cca5d88febef2f22f47f645420e51226374049f68c6b08569"
 "checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
 "checksum sled 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a25c24d5f135b43b94e39f5722dbaf3923152e7fbc6dfa85cc800aeae09172"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -24,6 +24,7 @@ env_logger = "*"
 fs2 = "*"
 lazy_static = "*"
 log = "*"
+log-derive = "*"
 mirai-annotations = { path = "../annotations" }
 rand = "*"
 rpds = { version = "*", features = ["serde"] }

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -8,11 +8,13 @@ use crate::expression::{Expression, ExpressionType};
 use crate::summaries::PersistentSummaryCache;
 use crate::utils;
 
+use log_derive::{logfn, logfn_inputs};
 use rustc::hir::def_id::DefId;
 use rustc::ty::subst::SubstsRef;
 use rustc::ty::{Ty, TyCtxt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
 
 /// Abstracts over constant values referenced in MIR and adds information
@@ -90,6 +92,7 @@ pub enum KnownFunctionNames {
 /// Constructors
 impl ConstantDomain {
     /// Returns a constant value that is a reference to a function
+    #[logfn(TRACE)]
     pub fn for_function<'a, 'tcx>(
         function_id: usize,
         def_id: DefId,
@@ -123,6 +126,7 @@ impl ConstantDomain {
 }
 
 impl From<bool> for ConstantDomain {
+    #[logfn_inputs(TRACE)]
     fn from(b: bool) -> ConstantDomain {
         if b {
             ConstantDomain::True
@@ -135,6 +139,7 @@ impl From<bool> for ConstantDomain {
 /// Transfer functions
 impl ConstantDomain {
     /// Returns a constant that is "self + other".
+    #[logfn_inputs(TRACE)]
     pub fn add(&self, other: &Self) -> Self {
         match (self, other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -154,6 +159,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is true if "self + other" is not in range of target_type.
+    #[logfn_inputs(TRACE)]
     pub fn add_overflows(&self, other: &Self, target_type: &ExpressionType) -> Self {
         match (&self, &other) {
             (ConstantDomain::I128(val1), ConstantDomain::I128(val2)) => match target_type {
@@ -181,6 +187,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self & other".
+    #[logfn_inputs(TRACE)]
     pub fn bit_and(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::I128(val1), ConstantDomain::I128(val2)) => {
@@ -196,6 +203,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self | other".
+    #[logfn_inputs(TRACE)]
     pub fn bit_or(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::I128(val1), ConstantDomain::I128(val2)) => {
@@ -211,6 +219,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self ^ other".
+    #[logfn_inputs(TRACE)]
     pub fn bit_xor(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::I128(val1), ConstantDomain::I128(val2)) => {
@@ -229,6 +238,7 @@ impl ConstantDomain {
 
     /// Returns a constant that is "self as target_type"
     #[allow(clippy::cast_lossless)]
+    #[logfn_inputs(TRACE)]
     pub fn cast(&self, target_type: &ExpressionType) -> Self {
         match self {
             ConstantDomain::Bottom => self.clone(),
@@ -307,6 +317,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self / other".
+    #[logfn_inputs(TRACE)]
     pub fn div(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -338,6 +349,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self == other".
+    #[logfn_inputs(TRACE)]
     pub fn equals(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -352,6 +364,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self >= other".
+    #[logfn_inputs(TRACE)]
     pub fn greater_or_equal(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -366,6 +379,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self > other".
+    #[logfn_inputs(TRACE)]
     pub fn greater_than(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -380,6 +394,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self <= other".
+    #[logfn_inputs(TRACE)]
     pub fn less_or_equal(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -394,6 +409,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self < other".
+    #[logfn_inputs(TRACE)]
     pub fn less_than(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -408,6 +424,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self * other".
+    #[logfn_inputs(TRACE)]
     pub fn mul(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -429,6 +446,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is true if "self * other" is not in range of target_type.
+    #[logfn_inputs(TRACE)]
     pub fn mul_overflows(&self, other: &Self, target_type: &ExpressionType) -> Self {
         match (&self, &other) {
             (ConstantDomain::I128(val1), ConstantDomain::I128(val2)) => {
@@ -464,6 +482,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "-self".
+    #[logfn_inputs(TRACE)]
     pub fn neg(&self) -> Self {
         match self {
             ConstantDomain::F32(val) => {
@@ -481,6 +500,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self != other".
+    #[logfn_inputs(TRACE)]
     pub fn not_equals(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -495,6 +515,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "!self".
+    #[logfn_inputs(TRACE)]
     pub fn not(&self) -> Self {
         match &self {
             ConstantDomain::False => ConstantDomain::True,
@@ -504,6 +525,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self % other".
+    #[logfn_inputs(TRACE)]
     pub fn rem(&self, other: &Self) -> Self {
         match (&self, &other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -533,6 +555,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self << other".
+    #[logfn_inputs(TRACE)]
     pub fn shl(&self, other: &Self) -> Self {
         let other_as_u32 = match &other {
             ConstantDomain::I128(val2) => Some(*val2 as u32),
@@ -551,6 +574,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is true if "self << other" is not in range of target_type.
+    #[logfn_inputs(TRACE)]
     pub fn shl_overflows(&self, other: &Self, target_type: &ExpressionType) -> Self {
         let other_as_u32 = match &other {
             ConstantDomain::I128(val2) => Some(*val2 as u32),
@@ -583,6 +607,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self >> other".
+    #[logfn_inputs(TRACE)]
     pub fn shr(&self, other: &Self) -> Self {
         let other_as_u32 = match &other {
             ConstantDomain::I128(val2) => Some(*val2 as u32),
@@ -601,6 +626,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is true if "self >> other" shifts away all bits.
+    #[logfn_inputs(TRACE)]
     pub fn shr_overflows(&self, other: &Self, target_type: &ExpressionType) -> Self {
         let other_as_u32 = match &other {
             ConstantDomain::I128(val2) => Some(*val2 as u32),
@@ -633,6 +659,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is "self - other".
+    #[logfn_inputs(TRACE)]
     pub fn sub(&self, other: &Self) -> Self {
         match (self, other) {
             (ConstantDomain::F32(val1), ConstantDomain::F32(val2)) => {
@@ -654,6 +681,7 @@ impl ConstantDomain {
     }
 
     /// Returns a constant that is true if "self - other" is not in range of target_type.
+    #[logfn_inputs(TRACE)]
     pub fn sub_overflows(&self, other: &Self, target_type: &ExpressionType) -> Self {
         match (&self, &other) {
             (ConstantDomain::I128(val1), ConstantDomain::I128(val2)) => match target_type {
@@ -693,7 +721,14 @@ pub struct ConstantValueCache<'tcx> {
     heap_address_counter: usize,
 }
 
+impl<'tcx> Debug for ConstantValueCache<'tcx> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        "ConstantValueCache".fmt(f)
+    }
+}
+
 impl<'tcx> ConstantValueCache<'tcx> {
+    #[logfn_inputs(TRACE)]
     pub fn new() -> ConstantValueCache<'tcx> {
         ConstantValueCache {
             char_cache: HashMap::default(),
@@ -708,6 +743,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
     }
 
     /// Returns a Expression::AbstractHeapAddress with a unique counter value.
+    #[logfn_inputs(TRACE)]
     pub fn get_new_heap_address(&mut self) -> Expression {
         let heap_address_counter = self.heap_address_counter;
         self.heap_address_counter = self.heap_address_counter.wrapping_add(1);
@@ -715,6 +751,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
     }
 
     /// Returns a reference to a cached Expression::Char(value).
+    #[logfn_inputs(TRACE)]
     pub fn get_char_for(&mut self, value: char) -> &ConstantDomain {
         self.char_cache
             .entry(value)
@@ -722,6 +759,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
     }
 
     /// Returns a reference to a cached Expression::F32(value).
+    #[logfn_inputs(TRACE)]
     pub fn get_f32_for(&mut self, value: u32) -> &ConstantDomain {
         self.f32_cache
             .entry(value)
@@ -729,6 +767,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
     }
 
     /// Returns a reference to a cached Expression::F64(value).
+    #[logfn_inputs(TRACE)]
     pub fn get_f64_for(&mut self, value: u64) -> &ConstantDomain {
         self.f64_cache
             .entry(value)
@@ -736,12 +775,15 @@ impl<'tcx> ConstantValueCache<'tcx> {
     }
 
     /// Returns a reference to a cached Expression::I128(value).
+    #[logfn_inputs(TRACE)]
     pub fn get_i128_for(&mut self, value: i128) -> &ConstantDomain {
         self.i128_cache
             .entry(value)
             .or_insert_with(|| ConstantDomain::I128(value))
     }
 
+    /// Returns a reference to a cached Expression::Str(value).
+    #[logfn_inputs(TRACE)]
     pub fn get_string_for(&mut self, value: &str) -> &ConstantDomain {
         let str_value = String::from(value);
         self.str_cache
@@ -750,6 +792,7 @@ impl<'tcx> ConstantValueCache<'tcx> {
     }
 
     /// Returns a reference to a cached Expression::U128(value).
+    #[logfn_inputs(TRACE)]
     pub fn get_u128_for(&mut self, value: u128) -> &ConstantDomain {
         self.u128_cache
             .entry(value)
@@ -776,12 +819,14 @@ impl<'tcx> ConstantValueCache<'tcx> {
     /// Do this for every function body to ensure that its analysis is not dependent on what
     /// happened elsewhere. Also remember to relocate heap addresses from summaries of other
     /// functions when transferring callee state to the caller's state.
+    #[logfn_inputs(TRACE)]
     pub fn reset_heap_counter(&mut self) {
         self.heap_address_counter = 0;
     }
 }
 
 impl<'tcx> Default for ConstantValueCache<'tcx> {
+    #[logfn_inputs(TRACE)]
     fn default() -> Self {
         Self::new()
     }

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -11,6 +11,7 @@ use crate::k_limits;
 use crate::path::{Path, PathEnum};
 
 use log::debug;
+use log_derive::{logfn, logfn_inputs};
 use mirai_annotations::checked_assume;
 use rpds::HashTrieMap;
 use rustc::mir::BasicBlock;
@@ -29,6 +30,7 @@ pub struct Environment {
 
 /// Default
 impl Environment {
+    #[logfn_inputs(TRACE)]
     pub fn default() -> Environment {
         Environment {
             entry_condition: Rc::new(abstract_value::TRUE),
@@ -50,11 +52,13 @@ type JoinOrWiden =
 /// Methods
 impl Environment {
     /// Returns a reference to the value associated with the given path, if there is one.
+    #[logfn_inputs(TRACE)]
     pub fn value_at(&self, path: &Rc<Path>) -> Option<&Rc<AbstractValue>> {
         self.value_map.get(path)
     }
 
     /// Updates the path to value map so that the given path now points to the given value.
+    #[logfn_inputs(TRACE)]
     pub fn update_value_at(&mut self, path: Rc<Path>, value: Rc<AbstractValue>) {
         debug!("updating value of {:?} to {:?}", path, value);
         if value.is_bottom() {
@@ -87,6 +91,7 @@ impl Environment {
     /// concretized into two paths where the abstract value is replaced by the consequent
     /// and alternate, respectively. These paths can then be weakly updated to reflect the
     /// lack of precise knowledge at compile time.
+    #[logfn_inputs(TRACE)]
     fn try_to_split(&mut self, path: &Rc<Path>) -> Option<(Rc<AbstractValue>, Rc<Path>, Rc<Path>)> {
         match &path.value {
             PathEnum::LocalVariable { .. } => self.try_to_split_local(path),
@@ -108,6 +113,7 @@ impl Environment {
     }
 
     /// Helper for try_to_split.
+    #[logfn_inputs(TRACE)]
     fn try_to_split_local(
         &mut self,
         path: &Rc<Path>,
@@ -141,6 +147,7 @@ impl Environment {
 
     /// Returns an environment with a path for every entry in self and other and an associated
     /// value that is the join of self.value_at(path) and other.value_at(path)
+    #[logfn_inputs(TRACE)]
     pub fn join(&self, other: &Environment, join_condition: &Rc<AbstractValue>) -> Environment {
         self.join_or_widen(other, join_condition, |x, y, c, p| {
             if Some(true) == c.as_bool_if_known() {
@@ -166,6 +173,7 @@ impl Environment {
 
     /// Returns an environment with a path for every entry in self and other and an associated
     /// value that is the widen of self.value_at(path) and other.value_at(path)
+    #[logfn_inputs(TRACE)]
     pub fn widen(&self, other: &Environment, join_condition: &Rc<AbstractValue>) -> Environment {
         self.clone()
             .join_or_widen(other, join_condition, |x, y, _c, p| {
@@ -179,6 +187,7 @@ impl Environment {
 
     /// Returns an environment with a path for every entry in self and other and an associated
     /// value that is the join or widen of self.value_at(path) and other.value_at(path).
+    #[logfn(TRACE)]
     fn join_or_widen(
         &self,
         other: &Environment,
@@ -233,6 +242,7 @@ impl Environment {
     }
 
     /// Returns true if for every path, self.value_at(path).subset(other.value_at(path))
+    #[logfn_inputs(TRACE)]
     pub fn subset(&self, other: &Environment) -> bool {
         let value_map1 = &self.value_map;
         let value_map2 = &other.value_map;

--- a/checker/src/expected_errors.rs
+++ b/checker/src/expected_errors.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use log_derive::logfn_inputs;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -11,6 +12,7 @@ use std::str::FromStr;
 use syntax::errors::Diagnostic;
 
 /// A collection of error strings that are expected for a test case.
+#[derive(Debug)]
 pub struct ExpectedErrors {
     messages: Vec<String>,
 }
@@ -18,12 +20,14 @@ pub struct ExpectedErrors {
 impl ExpectedErrors {
     /// Reads the file at the given path and scans it for instances of "//~ message".
     /// Each message becomes an element of ExpectedErrors.messages.
+    #[logfn_inputs(TRACE)]
     pub fn new(path: &str) -> ExpectedErrors {
         let exp = load_errors(&PathBuf::from_str(&path).unwrap());
         ExpectedErrors { messages: exp }
     }
 
     /// Checks if the given set of diagnostics matches the expected diagnostics.
+    #[logfn_inputs(TRACE)]
     pub fn check_messages(&mut self, diagnostics: Vec<Diagnostic>) {
         diagnostics.iter().for_each(|diag| {
             self.remove_message(&diag.message());
@@ -37,6 +41,7 @@ impl ExpectedErrors {
     }
 
     /// Removes the first element of self.messages and checks if it matches msg.
+    #[logfn_inputs(TRACE)]
     fn remove_message(&mut self, msg: &str) {
         if self.messages.remove_item(&String::from(msg)).is_none() {
             panic!("Unexpected error: {} Expected: {:?}", msg, self.messages);
@@ -46,6 +51,7 @@ impl ExpectedErrors {
 
 /// Scans the contents of test file for patterns of the form "//~ message"
 /// and returns a vector of the matching messages.
+#[logfn_inputs(TRACE)]
 fn load_errors(testfile: &Path) -> Vec<String> {
     let rdr = BufReader::new(File::open(testfile).unwrap());
     let tag = "//~";
@@ -56,6 +62,7 @@ fn load_errors(testfile: &Path) -> Vec<String> {
 }
 
 /// Returns the message part of the pattern "//~ message" if there is a match, otherwise None.
+#[logfn_inputs(TRACE)]
 fn parse_expected(line: &str, tag: &str) -> Option<String> {
     let start = line.find(tag)? + tag.len();
     Some(String::from(line[start..].trim()))

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -7,6 +7,7 @@ use crate::abstract_value::AbstractValue;
 use crate::constant_domain::ConstantDomain;
 use crate::path::Path;
 
+use log_derive::logfn_inputs;
 use rustc::ty::TyKind;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -310,6 +311,7 @@ pub enum Expression {
 impl Expression {
     /// Returns the type of value the expression should result in, if well formed.
     /// (both operands are of the same type for binary operators, conditional branches match).
+    #[logfn_inputs(TRACE)]
     pub fn infer_type(&self) -> ExpressionType {
         use self::ExpressionType::*;
         match self {
@@ -356,6 +358,7 @@ impl Expression {
     }
 
     /// Determines if the given expression is the compile time constant 1u128.
+    #[logfn_inputs(TRACE)]
     pub fn is_one(&self) -> bool {
         if let Expression::CompileTimeConstant(c) = self {
             if let ConstantDomain::U128(c) = c {
@@ -366,6 +369,7 @@ impl Expression {
     }
 
     /// Determines if the given expression is the compile time constant 0u128.
+    #[logfn_inputs(TRACE)]
     pub fn is_zero(&self) -> bool {
         if let Expression::CompileTimeConstant(c) = self {
             if let ConstantDomain::U128(c) = c {
@@ -376,6 +380,7 @@ impl Expression {
     }
 
     /// Adds any abstract heap addresses found in the associated expression to the given set.
+    #[logfn_inputs(TRACE)]
     pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
         match &self {
             Expression::AbstractHeapAddress(ordinal) => {
@@ -453,6 +458,7 @@ pub enum ExpressionType {
 }
 
 impl From<&ConstantDomain> for ExpressionType {
+    #[logfn_inputs(TRACE)]
     fn from(cv: &ConstantDomain) -> ExpressionType {
         use self::ExpressionType::*;
         match cv {
@@ -472,6 +478,7 @@ impl From<&ConstantDomain> for ExpressionType {
 }
 
 impl<'a> From<&TyKind<'a>> for ExpressionType {
+    #[logfn_inputs(TRACE)]
     fn from(ty_kind: &TyKind<'a>) -> ExpressionType {
         match ty_kind {
             TyKind::Bool => ExpressionType::Bool,
@@ -508,6 +515,7 @@ impl<'a> From<&TyKind<'a>> for ExpressionType {
 
 impl ExpressionType {
     /// Returns true if this type is one of the floating point number types.
+    #[logfn_inputs(TRACE)]
     pub fn is_floating_point_number(&self) -> bool {
         use self::ExpressionType::*;
         match self {
@@ -517,6 +525,7 @@ impl ExpressionType {
     }
 
     /// Returns true if this type is one of the integer types.
+    #[logfn_inputs(TRACE)]
     pub fn is_integer(&self) -> bool {
         use self::ExpressionType::*;
         match self {
@@ -527,6 +536,7 @@ impl ExpressionType {
 
     /// Returns true if this type is not a primitive type. References are not regarded as
     /// primitives for this purpose.
+    #[logfn_inputs(TRACE)]
     pub fn is_primitive(&self) -> bool {
         use self::ExpressionType::*;
         match self {
@@ -536,6 +546,7 @@ impl ExpressionType {
     }
 
     /// Returns true if this type is one of the signed integer types.
+    #[logfn_inputs(TRACE)]
     pub fn is_signed_integer(&self) -> bool {
         use self::ExpressionType::*;
         match self {
@@ -545,6 +556,7 @@ impl ExpressionType {
     }
 
     /// Returns true if this type is one of the unsigned integer types.
+    #[logfn_inputs(TRACE)]
     pub fn is_unsigned_integer(&self) -> bool {
         use self::ExpressionType::*;
         match self {
@@ -555,6 +567,7 @@ impl ExpressionType {
 
     /// Returns the number of bits used to represent the given type, if primitive.
     /// For non primitive types the result is just 0.
+    #[logfn_inputs(TRACE)]
     pub fn bit_length(&self) -> u8 {
         use self::ExpressionType::*;
         match self {
@@ -582,6 +595,7 @@ impl ExpressionType {
     /// Returns the maximum value for this type, as a ConstantDomain element.
     /// If the type is not a primitive value, the result is Bottom.
     #[allow(clippy::cast_lossless)]
+    #[logfn_inputs(TRACE)]
     pub fn max_value(&self) -> ConstantDomain {
         use self::ExpressionType::*;
         match self {
@@ -608,6 +622,7 @@ impl ExpressionType {
     /// Returns the minimum value for this type, as a ConstantDomain element.
     /// If the type is not a primitive value, the result is Bottom.
     #[allow(clippy::cast_lossless)]
+    #[logfn_inputs(TRACE)]
     pub fn min_value(&self) -> ConstantDomain {
         use self::ExpressionType::*;
         match self {

--- a/checker/src/interval_domain.rs
+++ b/checker/src/interval_domain.rs
@@ -6,6 +6,7 @@
 
 use crate::expression::ExpressionType::{self, *};
 
+use log_derive::logfn_inputs;
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::convert::TryFrom;
@@ -32,6 +33,7 @@ pub const TOP: IntervalDomain = IntervalDomain {
 };
 
 impl From<i128> for IntervalDomain {
+    #[logfn_inputs(TRACE)]
     fn from(i: i128) -> IntervalDomain {
         IntervalDomain {
             lower_bound: i,
@@ -41,6 +43,7 @@ impl From<i128> for IntervalDomain {
 }
 
 impl From<u128> for IntervalDomain {
+    #[logfn_inputs(TRACE)]
     fn from(u: u128) -> IntervalDomain {
         if let Result::Ok(i) = i128::try_from(u) {
             i.into()
@@ -55,6 +58,7 @@ impl From<u128> for IntervalDomain {
 
 impl IntervalDomain {
     //[x...y] + [a...b] = [x+a...y+b]
+    #[logfn_inputs(TRACE)]
     pub fn add(&self, other: &Self) -> Self {
         if self.is_bottom() || other.is_bottom() {
             return BOTTOM.clone();
@@ -70,6 +74,7 @@ impl IntervalDomain {
 
     // [x...y] >= [a...b] = x >= b
     // !([x...y] >= [a...b]) = [a...b] > [x...y] = a > y
+    #[logfn_inputs(TRACE)]
     pub fn greater_or_equal(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
@@ -84,6 +89,7 @@ impl IntervalDomain {
 
     // [x...y] > [a...b] = x > b
     // !([x...y] > [a...b]) = [a...b] >= [x...y] = a >= y
+    #[logfn_inputs(TRACE)]
     pub fn greater_than(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
@@ -101,6 +107,7 @@ impl IntervalDomain {
     // not implemented. The expectation is that bottom values will not often be encountered.
     // We don't need this domain to implement transfer functions for all operations that might
     // result in integer values since other domains will be preferred in those cases.
+    #[logfn_inputs(TRACE)]
     pub fn is_bottom(&self) -> bool {
         self.upper_bound < self.lower_bound
     }
@@ -109,6 +116,7 @@ impl IntervalDomain {
     // A false result just means that we don't know, it never means that we know it does not.
     // Note that i128::MIN and i128::MAX are reserved to indicate missing (unbounded) lower and upper
     // bounds, respectively.
+    #[logfn_inputs(TRACE)]
     pub fn is_contained_in(&self, target_type: &ExpressionType) -> bool {
         if self.is_bottom() || self.is_top() {
             return false;
@@ -147,6 +155,7 @@ impl IntervalDomain {
 
     // Returns true if this interval is known to be contained in the interval [0 ... bit size of target_type).
     // A false result just means that we don't know, it never means that we know it does not.
+    #[logfn_inputs(TRACE)]
     pub fn is_contained_in_width_of(&self, target_type: &ExpressionType) -> bool {
         if self.is_bottom() || self.is_top() {
             return false;
@@ -165,12 +174,14 @@ impl IntervalDomain {
     }
 
     // All concrete integer values belong to this interval, so we know nothing.
+    #[logfn_inputs(TRACE)]
     pub fn is_top(&self) -> bool {
         self.lower_bound == std::i128::MIN && self.upper_bound == std::i128::MAX
     }
 
     // [x...y] <= [a...b] = y <= a
     // !([x...y] <= [a...b]) = [a...b] < [x...y] = b < x
+    #[logfn_inputs(TRACE)]
     pub fn less_equal(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
@@ -185,6 +196,7 @@ impl IntervalDomain {
 
     // [x...y] < [a...b] = y < a
     // !([x...y] < [a...b]) = [a...b] <= [x...y] = b <= x
+    #[logfn_inputs(TRACE)]
     pub fn less_than(&self, other: &Self) -> Option<bool> {
         if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
             None
@@ -197,6 +209,7 @@ impl IntervalDomain {
         }
     }
 
+    #[logfn_inputs(TRACE)]
     pub fn lower_bound(&self) -> Option<i128> {
         if self.lower_bound == TOP.lower_bound {
             None
@@ -205,6 +218,7 @@ impl IntervalDomain {
         }
     }
 
+    #[logfn_inputs(TRACE)]
     pub fn upper_bound(&self) -> Option<i128> {
         if self.upper_bound == TOP.upper_bound {
             None
@@ -213,6 +227,7 @@ impl IntervalDomain {
         }
     }
 
+    #[logfn_inputs(TRACE)]
     pub fn remove_lower_bound(&self) -> Self {
         IntervalDomain {
             lower_bound: TOP.lower_bound,
@@ -220,6 +235,7 @@ impl IntervalDomain {
         }
     }
 
+    #[logfn_inputs(TRACE)]
     pub fn remove_upper_bound(&self) -> Self {
         IntervalDomain {
             lower_bound: self.lower_bound,
@@ -228,6 +244,7 @@ impl IntervalDomain {
     }
 
     // [x...y] * [a...b] = [x*a...y*b]
+    #[logfn_inputs(TRACE)]
     pub fn mul(&self, other: &Self) -> Self {
         if self.is_bottom() || other.is_bottom() {
             return BOTTOM.clone();
@@ -242,6 +259,7 @@ impl IntervalDomain {
     }
 
     // -[x...y] = [-y...-x]
+    #[logfn_inputs(TRACE)]
     pub fn neg(&self) -> Self {
         if self.is_bottom() {
             return BOTTOM.clone();
@@ -256,6 +274,7 @@ impl IntervalDomain {
     }
 
     // [x...y] - [a...b] = [x-b...y-a]
+    #[logfn_inputs(TRACE)]
     pub fn sub(&self, other: &Self) -> Self {
         if self.is_bottom() || other.is_bottom() {
             return BOTTOM.clone();
@@ -270,6 +289,7 @@ impl IntervalDomain {
     }
 
     // [x...y] widen [a...b] = [min(x,a)...max(y,b)],
+    #[logfn_inputs(TRACE)]
     pub fn widen(&self, other: &Self) -> Self {
         if self.is_bottom() || other.is_bottom() {
             return BOTTOM.clone();

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use log::debug;
+use log_derive::{logfn, logfn_inputs};
 use rustc::hir::def_id::DefId;
 use rustc::hir::ItemKind;
 use rustc::hir::Node;
@@ -18,6 +19,7 @@ use std::rc::Rc;
 /// If the rust compiler was compiled and installed in some other way, for example from a source
 /// enlistment, then the RUST_SYSROOT variable must be set in the environment from which Mirai
 /// is compiled.
+#[logfn_inputs(TRACE)]
 pub fn find_sysroot() -> String {
     let home = option_env!("RUSTUP_HOME");
     let toolchain = option_env!("RUSTUP_TOOLCHAIN");
@@ -33,6 +35,7 @@ pub fn find_sysroot() -> String {
 }
 
 /// Returns true if the function identified by def_id is a public function.
+#[logfn(TRACE)]
 pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_>) -> bool {
     if let Some(node) = tcx.hir().get_if_local(def_id) {
         match node {
@@ -58,6 +61,7 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_>) -> bool {
 
 /// Returns a string that is a valid identifier, made up from the concatenation of
 /// the string representations of the given list of generic argument types.
+#[logfn(TRACE)]
 pub fn argument_types_key_str<'tcx>(
     tcx: &TyCtxt<'tcx>,
     generic_args: SubstsRef<'tcx>,
@@ -73,6 +77,7 @@ pub fn argument_types_key_str<'tcx>(
 /// Appends a string to str with the constraint that it must uniquely identify ty and also
 /// be a valid identifier (so that core library contracts can be written for type specialized
 /// generic trait methods).
+#[logfn(TRACE)]
 fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'tcx>) {
     use syntax::ast;
     use TyKind::*;
@@ -170,6 +175,7 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'tcx>)
 
 /// Pretty much the same as summary_key_str but with _ used rather than . so that
 /// the result can be appended to a valid identifier.
+#[logfn(TRACE)]
 fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
     let mut name = if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str().to_string()
@@ -196,6 +202,7 @@ fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
 /// the summary cache, which is a key value store. The string will always be the same as
 /// long as the definition does not change its name or location, so it can be used to
 /// transfer information from one compilation to the next, making incremental analysis possible.
+#[logfn(TRACE)]
 pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
     let mut name = if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str().to_string()


### PR DESCRIPTION
## Description

Switch to using log_derive to derive logging of function calls. Change the level of such logging from De bug to Trace.

Fixes #64 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
Ran MIRAI with log level set to Trace.
