### PR TITLE
Fix a bug related to &*x expressions where x is structured.

### DIFF
--- a/checker/tests/run-pass/str_is_empty.rs
+++ b/checker/tests/run-pass/str_is_empty.rs
@@ -4,12 +4,12 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that uses built-in contracts for the Vec struct.
+// A test that verifies that s.is_empty() returns true for an empty string.
 
 #[macro_use]
 extern crate mirai_annotations;
 
 pub fn main() {
     let s = "";
-    verify!(s.is_empty()); //~ possible false verification condition 
+    verify!(s.is_empty());
 }


### PR DESCRIPTION
## Description

Unoptimized MIR has expressions of the form &*x. When x is a normal reference type, this can just be simplified to x and the reference value of x can just be copied to the result path without further ado. When is a special kind of reference, such as a string value, the length associated with the string should also be copied, which is what this PR is all about.

Fixes #219

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh

