### PR TITLE
Give a warning if an explicit assumption is provably true.

### DIFF
--- a/checker/tests/run-pass/true_assumption.rs
+++ b/checker/tests/run-pass/true_assumption.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a true assumption
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn test_assume() {
+    let i = 1;
+    assume!(i == 1); //~ assumption is provably true and can be deleted
+}
+
+pub fn test_unreachable_assume() {
+    let i = 1;
+    if i != 1 {
+        assume!(i == 1); //~ this is unreachable, mark it as such by using the unreachable! macro
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/x_equals_x.rs
+++ b/checker/tests/run-pass/x_equals_x.rs
@@ -25,7 +25,7 @@ fn foo(x: i32, y: f32) {
     if x == x {
         verify!(true);
     } else {
-        verify!(false);
+        verify!(false); //~ this is unreachable, mark it as such by using the unreachable! macro
     }
     if y == y {
         verify!(true);


### PR DESCRIPTION
## Description

Explicit assumptions that are only provided to work around a temporary bug in MIRAI should not stay in the code. Giving a warning when an explicit assumption can be proved by MIRAI help to rid the code of redundant annotations. If the annotation is actually useful as documentation, it can be turned into a verify call.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
New test case
