### PR TITLE
Make major version be 1 and fix verify! macros.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 0.2.1",
+ "mirai-annotations 1.2.2",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,13 +292,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "0.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 0.2.1",
+ "mirai-annotations 1.2.2",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "0.2.1"
+version = "1.2.2"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -366,7 +366,7 @@ macro_rules! checked_verify {
     );
     ($condition:expr, $message:literal) => {
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($condition, concat!("false verification condition: ", $message))
+            mirai_annotations::mirai_verify($condition, concat!("false verification condition: ", $message))
         } else {
             assert!($condition, $message);
         }
@@ -387,21 +387,21 @@ macro_rules! checked_verify {
 macro_rules! checked_verify_eq {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left == $right, concat!("false verification condition: ", stringify!($left == $right)))
+            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right)))
         } else {
             assert_eq!($left, $right);
         }
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", $message))
+            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", $message))
         } else {
             assert_eq!($left, $right, $message);
         }
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
+            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
         } else {
             assert_eq!($left, $right, $($arg)*);
         }
@@ -415,21 +415,21 @@ macro_rules! checked_verify_eq {
 macro_rules! checked_verify_ne {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left != $right, concat!("false verification condition: ", stringify!($left != $right)))
+            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right)))
         } else {
             assert_ne!($left, $right);
         }
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", $message))
+            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", $message))
         } else {
             assert_ne!($left, $right, $message);
         }
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
+            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
         } else {
             assert_ne!($left, $right, $($arg)*);
         }
@@ -450,7 +450,7 @@ macro_rules! debug_checked_verify {
     );
     ($condition:expr, $message:literal) => {
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($condition, concat!("false verification condition: ", $message))
+            mirai_annotations::mirai_verify($condition, concat!("false verification condition: ", $message))
         } else {
             debug_assert!($condition, $message);
         }
@@ -471,21 +471,21 @@ macro_rules! debug_checked_verify {
 macro_rules! debug_checked_verify_eq {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left == $right, concat!("false verification condition: ", stringify!($left == $right)))
+            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right)))
         } else {
             debug_assert_eq!($left, $right);
         }
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", $message))
+            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", $message))
         } else {
             debug_assert_eq!($left, $right, $message);
         }
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
+            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
         } else {
             debug_assert_eq!($left, $right, $($arg)*);
         }
@@ -499,21 +499,21 @@ macro_rules! debug_checked_verify_eq {
 macro_rules! debug_checked_verify_ne {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left != $right, concat!("false verification condition: ", stringify!($left != $right)))
+            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right)))
         } else {
             debug_assert_ne!($left, $right);
         }
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", $message))
+            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", $message))
         } else {
             debug_assert_ne!($left, $right, $message);
         }
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
-            mirai_annotations::mirai_precondition($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
+            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
         } else {
             debug_assert_ne!($left, $right, $($arg)*);
         }


### PR DESCRIPTION
## Description

Semver versioning really only makes sense if the major version starts with 1, so bump it up from 0.
Also fix a problem where verify! macros ended up calling mirai_precondition rather than mirai_verify, so bump the patch number up to 2.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh

