### PR TITLE
Distinguish between logical not and bitwise not.

### DIFF
--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -227,6 +227,18 @@ impl ConstantDomain {
         }
     }
 
+    /// Returns a constant that is "!self" where self is an integer.
+    #[logfn_inputs(TRACE)]
+    pub fn bit_not(&self, result_type: ExpressionType) -> Self {
+        match self {
+            ConstantDomain::I128(val) => ConstantDomain::I128(!*val),
+            ConstantDomain::U128(val) => {
+                ConstantDomain::U128(!*val).bit_and(&result_type.max_value())
+            }
+            _ => ConstantDomain::Bottom,
+        }
+    }
+
     /// Returns a constant that is "self | other".
     #[logfn_inputs(TRACE)]
     pub fn bit_or(&self, other: &Self) -> Self {
@@ -539,9 +551,9 @@ impl ConstantDomain {
         .into()
     }
 
-    /// Returns a constant that is "!self".
+    /// Returns a constant that is "!self" where self is a bool.
     #[logfn_inputs(TRACE)]
-    pub fn not(&self) -> Self {
+    pub fn logical_not(&self) -> Self {
         match &self {
             ConstantDomain::False => ConstantDomain::True,
             ConstantDomain::True => ConstantDomain::False,

--- a/checker/tests/run-pass/bitwise_not.rs
+++ b/checker/tests/run-pass/bitwise_not.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Tests reasoning over bitwise not operations
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn signed_arith(i: i8) {
+    precondition!(!i < i8::max_value());
+    let neg = !i + 1;
+    verify!(neg == -i);
+}
+
+pub fn unsigned_arith(i: u8) {
+    verify!(!i == 255 - i);
+}
+
+pub fn bits(i: u8) {
+    precondition!(i & 1 == 0);
+    verify!(!i & 1 != 0);
+    verify!(!i & 1 == 1);
+}
+
+pub fn constants() {
+    verify!(!0x11u8 == 0xeeu8);
+    verify!(!0x11u8 as u128 == 0xeeu128);
+    verify!(!0x11u128 == 0xffffffffffffffffffffffffffffffeeu128);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

MIRAI incorrectly assumed that !x is always a logical operation, whereas if x is an integer it amounts to a bitwise operation. This is now supported by inspecting the type of the operand and generating two different types of expression, depending on the type.

At the SMT solver level, it now need to understand bitwise not operations.

Fixes #228 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
New test case
