### PR TITLE
Restrict the creation of very large expressions

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -176,6 +176,9 @@ impl AbstractValue {
     /// Initializes the optional domains to None.
     #[logfn_inputs(TRACE)]
     pub fn make_from(expression: Expression, expression_size: u64) -> Rc<AbstractValue> {
+        if expression_size > k_limits::MAX_EXPRESSION_SIZE {
+            return Rc::new(TOP);
+        }
         Rc::new(AbstractValue {
             expression,
             expression_size,
@@ -1325,9 +1328,6 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     /// in the given environment (if there is such a value).
     #[logfn_inputs(TRACE)]
     fn refine_paths(&self, environment: &Environment) -> Rc<AbstractValue> {
-        if self.expression_size > k_limits::MAX_EXPRESSION_SIZE {
-            return self.clone();
-        }
         match &self.expression {
             Expression::Top | Expression::Bottom | Expression::AbstractHeapAddress(..) => {
                 self.clone()

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -16,7 +16,7 @@ pub const MAX_BYTE_ARRAY_LENGTH: u128 = 10;
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;
 
 /// If Expressions get too large they become too costly to refine.
-pub const MAX_EXPRESSION_SIZE: u64 = 10_000;
+pub const MAX_EXPRESSION_SIZE: u64 = 1_000;
 
 /// Double the observed maximum used in practice.
 pub const MAX_FIXPOINT_ITERATIONS: usize = 50;
@@ -27,5 +27,5 @@ pub const MAX_OUTER_FIXPOINT_ITERATIONS: usize = 4;
 /// Prevents the outer fixed point loop from creating ever more new abstract values of type Expression::Variable.
 pub const MAX_PATH_LENGTH: usize = 30;
 
-/// Refining values with a path condition that is a really big expression leads to exponential blow up.
+/// Refining values with a path condition that is a really deep expression leads to exponential blow up.
 pub const MAX_REFINE_DEPTH: usize = 9;


### PR DESCRIPTION
## Description

Rather than simply not refining very large expressions, the expression factory functions will return TOP instead of very large expressions. This helps to avoid exponential blowup in the time taken to serializer/deserialize large expressions, which has proved to be a problem in practice for some corner cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
