### PR TITLE
Allow precondition arguments to include control flow.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.3.0",
+ "mirai-annotations 1.3.1",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,13 +292,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.3.0"
+version = "1.3.1"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.3.0",
+ "mirai-annotations 1.3.1",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -361,16 +361,19 @@ macro_rules! debug_checked_postcondition_ne {
 macro_rules! precondition {
     ($condition:expr) => {
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, "unsatisfied precondition")
         }
     };
     ($condition:expr, $message:literal) => {
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, concat!("unsatisfied precondition: ", $message))
         }
     };
     ($condition:expr, $($arg:tt)*) => {
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, concat!("unsatisfied precondition: ", stringify!($($arg)*)));
         }
     };
@@ -384,6 +387,7 @@ macro_rules! precondition {
 macro_rules! checked_precondition {
     ($condition:expr) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, "unsatisfied precondition")
         } else {
             assert!($condition);
@@ -391,6 +395,7 @@ macro_rules! checked_precondition {
     );
     ($condition:expr, $message:literal) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, concat!("unsatisfied precondition: ", $message))
         } else {
             assert!($condition, $message);
@@ -398,6 +403,7 @@ macro_rules! checked_precondition {
     );
     ($condition:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, concat!("unsatisfied precondition: ", stringify!($($arg)*)));
         } else {
             assert!($condition, $($arg)*);
@@ -413,6 +419,7 @@ macro_rules! checked_precondition {
 macro_rules! checked_precondition_eq {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left == $right, concat!("unsatisfied precondition: ", stringify!($left == $right)))
         } else {
             assert_eq!($left, $right);
@@ -420,6 +427,7 @@ macro_rules! checked_precondition_eq {
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left == $right, concat!("unsatisfied precondition: ", stringify!($left == $right), ", ", $message))
         } else {
             assert_eq!($left, $right, $message);
@@ -427,6 +435,7 @@ macro_rules! checked_precondition_eq {
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left == $right, concat!("unsatisfied precondition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
         } else {
             assert_eq!($left, $right, $($arg)*);
@@ -442,6 +451,7 @@ macro_rules! checked_precondition_eq {
 macro_rules! checked_precondition_ne {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left != $right, concat!("unsatisfied precondition: ", stringify!($left != $right)))
         } else {
             assert_ne!($left, $right);
@@ -449,6 +459,7 @@ macro_rules! checked_precondition_ne {
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left != $right, concat!("unsatisfied precondition: ", stringify!($left != $right), ", ", $message))
         } else {
             assert_ne!($left, $right, $message);
@@ -456,6 +467,7 @@ macro_rules! checked_precondition_ne {
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left != $right, concat!("unsatisfied precondition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
         } else {
             assert_ne!($left, $right, $($arg)*);
@@ -471,6 +483,7 @@ macro_rules! checked_precondition_ne {
 macro_rules! debug_checked_precondition {
     ($condition:expr) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, "unsatisfied precondition")
         } else {
             debug_assert!($condition);
@@ -478,6 +491,7 @@ macro_rules! debug_checked_precondition {
     );
     ($condition:expr, $message:literal) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, concat!("unsatisfied precondition: ", $message))
         } else {
             debug_assert!($condition, $message);
@@ -485,6 +499,7 @@ macro_rules! debug_checked_precondition {
     );
     ($condition:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($condition, concat!("unsatisfied precondition: ", stringify!($($arg)*)));
         } else {
             debug_assert!($condition, $($arg)*);
@@ -500,6 +515,7 @@ macro_rules! debug_checked_precondition {
 macro_rules! debug_checked_precondition_eq {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left == $right, concat!("unsatisfied precondition: ", stringify!($left == $right)))
         } else {
             debug_assert_eq!($left, $right);
@@ -507,6 +523,7 @@ macro_rules! debug_checked_precondition_eq {
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left == $right, concat!("unsatisfied precondition: ", stringify!($left == $right), ", ", $message))
         } else {
             debug_assert_eq!($left, $right, $message);
@@ -514,6 +531,7 @@ macro_rules! debug_checked_precondition_eq {
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left == $right, concat!("unsatisfied precondition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
         } else {
             debug_assert_eq!($left, $right, $($arg)*);
@@ -529,6 +547,7 @@ macro_rules! debug_checked_precondition_eq {
 macro_rules! debug_checked_precondition_ne {
     ($left:expr, $right:expr) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left != $right, concat!("unsatisfied precondition: ", stringify!($left != $right)))
         } else {
             debug_assert_ne!($left, $right);
@@ -536,6 +555,7 @@ macro_rules! debug_checked_precondition_ne {
     );
     ($left:expr, $right:expr, $message:literal) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left != $right, concat!("unsatisfied precondition: ", stringify!($left != $right), ", ", $message))
         } else {
             debug_assert_ne!($left, $right, $message);
@@ -543,6 +563,7 @@ macro_rules! debug_checked_precondition_ne {
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
         if cfg!(mirai) {
+            mirai_annotations::mirai_precondition_start();
             mirai_annotations::mirai_precondition($left != $right, concat!("unsatisfied precondition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
         } else {
             debug_assert_ne!($left, $right, $($arg)*);
@@ -779,6 +800,10 @@ pub fn mirai_assume(_condition: bool) {}
 // Helper function for MIRAI. Should only be called via the postcondition macros.
 #[doc(hidden)]
 pub fn mirai_postcondition(_condition: bool, _assumed: bool, _message: &str) {}
+
+// Helper function for MIRAI. Should only be called via the precondition macros.
+#[doc(hidden)]
+pub fn mirai_precondition_start() {}
 
 // Helper function for MIRAI. Should only be called via the precondition macros.
 #[doc(hidden)]

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -102,6 +102,8 @@ pub enum KnownFunctionNames {
     MiraiGetModelField,
     /// mirai_annotations.mirai_postcondition
     MiraiPostcondition,
+    /// mirai_annotations.mirai_precondition_start
+    MiraiPreconditionStart,
     /// mirai_annotations.mirai_precondition
     MiraiPrecondition,
     /// mirai_annotations.mirai_result
@@ -136,6 +138,7 @@ impl ConstantDomain {
             "mirai_annotations.mirai_assume" => MiraiAssume,
             "mirai_annotations.mirai_get_model_field" => MiraiGetModelField,
             "mirai_annotations.mirai_postcondition" => MiraiPostcondition,
+            "mirai_annotations.mirai_precondition_start" => MiraiPreconditionStart,
             "mirai_annotations.mirai_precondition" => MiraiPrecondition,
             "mirai_annotations.mirai_result" => MiraiResult,
             "mirai_annotations.mirai_set_model_field" => MiraiSetModelField,

--- a/checker/tests/run-pass/precondition.rs
+++ b/checker/tests/run-pass/precondition.rs
@@ -25,3 +25,10 @@ pub fn bad_foo(arr: &mut [i32; 2], i: usize) {
     }
     arr[i] = 12;
 }
+
+pub fn good_foo(a: &[i32; 2], i: usize) {
+    precondition!({
+        let j = if i == 0 { 1 } else { 0 };
+        a[j] > 50
+    });
+}


### PR DESCRIPTION
## Description

Refine the check for preconditions to not complain if the arguments to a precondition includes control flow that appears to precede the call to the precondition method.

This is done by introducing a call to a marker method that precedes evaluation of precondition condition. This only works once, so the check now only complains about the first precondition. Since this is a style check that should be sufficient.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
Added a test case


