### PR TITLE
Fix usize issue, add additional contracts

### DIFF
--- a/checker/tests/run-pass/core_contract.rs
+++ b/checker/tests/run-pass/core_contract.rs
@@ -10,5 +10,5 @@ pub fn main() {
     let x: Option<i64> = Some(1);
     let _y = x.unwrap();
     let z: Option<i64> = None;
-    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None, defined in standard_contracts/src/foreign_contracts.rs:266:17: 266:71
+    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None, defined in standard_contracts/src/foreign_contracts.rs:331:17: 331:71
 }

--- a/checker/tests/run-pass/core_contract.rs
+++ b/checker/tests/run-pass/core_contract.rs
@@ -10,5 +10,5 @@ pub fn main() {
     let x: Option<i64> = Some(1);
     let _y = x.unwrap();
     let z: Option<i64> = None;
-    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None, defined in standard_contracts/src/foreign_contracts.rs:254:17: 254:71
+    let _ = z.unwrap(); //~ unsatisfied precondition: self may not be None, defined in standard_contracts/src/foreign_contracts.rs:266:17: 266:71
 }

--- a/checker/tests/run-pass/isize_max.rs
+++ b/checker/tests/run-pass/isize_max.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that checks that usize::max_value() is set correctly
+// A test that checks that std::isize::MAX is set correctly
 #![allow(non_snake_case)]
 
 #[macro_use]
@@ -12,12 +12,12 @@ extern crate mirai_annotations;
 
 #[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
 fn test() {
-    verify!(usize::max_value() == 4294967295);
+    verify!(std::isize::MAX == 2147483647);
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
 fn test() {
-    verify!(usize::max_value() == 18446744073709551615);
+    verify!(std::isize::MAX == 9223372036854775807);
 }
 
 pub fn main() {

--- a/checker/tests/run-pass/isize_max_value.rs
+++ b/checker/tests/run-pass/isize_max_value.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that checks that usize::max_value() is set correctly
+// A test that checks that isize::max_value() is set correctly
 #![allow(non_snake_case)]
 
 #[macro_use]
@@ -12,12 +12,12 @@ extern crate mirai_annotations;
 
 #[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
 fn test() {
-    verify!(usize::max_value() == 4294967295);
+    verify!(isize::max_value() == 2147483647);
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
 fn test() {
-    verify!(usize::max_value() == 18446744073709551615);
+    verify!(isize::max_value() == 9223372036854775807);
 }
 
 pub fn main() {

--- a/checker/tests/run-pass/isize_min.rs
+++ b/checker/tests/run-pass/isize_min.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that checks that usize::max_value() is set correctly
+// A test that checks that std::isize::MIN is set correctly
 #![allow(non_snake_case)]
 
 #[macro_use]
@@ -12,12 +12,12 @@ extern crate mirai_annotations;
 
 #[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
 fn test() {
-    verify!(usize::max_value() == 4294967295);
+    verify!(std::isize::MIN == -2147483648);
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
 fn test() {
-    verify!(usize::max_value() == 18446744073709551615);
+    verify!(std::isize::MIN == -9223372036854775808);
 }
 
 pub fn main() {

--- a/checker/tests/run-pass/isize_min_value.rs
+++ b/checker/tests/run-pass/isize_min_value.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that checks that usize::max_value() is set correctly
+// A test that checks that isize::min_value() is set correctly
 #![allow(non_snake_case)]
 
 #[macro_use]
@@ -12,12 +12,12 @@ extern crate mirai_annotations;
 
 #[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
 fn test() {
-    verify!(usize::max_value() == 4294967295);
+    verify!(isize::min_value() == -2147483648);
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
 fn test() {
-    verify!(usize::max_value() == 18446744073709551615);
+    verify!(isize::min_value() == -9223372036854775808);
 }
 
 pub fn main() {

--- a/checker/tests/run-pass/usize_max.rs
+++ b/checker/tests/run-pass/usize_max.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that std::usize::MAX is set correctly
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+#[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
+fn test() {
+    verify!(std::usize::MAX == 4294967295);
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
+fn test() {
+    verify!(std::usize::MAX == 18446744073709551615);
+}
+
+pub fn main() {
+    test();
+}

--- a/checker/tests/run-pass/usize_max_value.rs
+++ b/checker/tests/run-pass/usize_max_value.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that std::usize::max_value() is set correctly
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+#[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
+fn test() {
+    verify!(usize::max_value() == 4294967295);
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
+fn test() {
+    verify!(usize::max_value() == 18446744073709551615);
+}
+
+pub fn main() {
+    test();
+}

--- a/checker/tests/run-pass/vec_append.rs
+++ b/checker/tests/run-pass/vec_append.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// This tests the Vector append method
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn main() {
+    let mut v1: Vec<i32> = Vec::new();
+    let mut v2: Vec<i32> = Vec::new();
+    v2.push(1);
+    v1.append(&mut v2);
+    verify!(v1.len() == 1);
+}

--- a/checker/tests/run-pass/vec_clear.rs
+++ b/checker/tests/run-pass/vec_clear.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// This tests the Vector clear method
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn main() {
+    let mut v: Vec<i32> = Vec::new();
+    v.push(1);
+    v.clear();
+    verify!(v.is_empty());
+}

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -176,10 +176,19 @@ pub mod core {
 
         pub mod implement_usize {
             pub fn max_value() -> usize {
-                4294967295
+                if cfg!(any(target_arch = "x86", tagret_arch = "mips", tagret_arch = "powerpc", tagret_arch = "arm")) {
+                    4294967295
+                } else if cfg!(any(target_arch = "x86_64", tagret_arch = "powerpc64", tagret_arch = "aarch64")) {
+                    18446744073709551615
+                } else {
+                    panic!("Unsupported architecture");
+                }
             }
             pub fn min_value() -> usize {
                 0
+            }
+            pub fn checked_add(_self: usize, value: usize) -> Option<usize> {
+                _self.checked_add(value)
             }
         }
 
@@ -189,6 +198,9 @@ pub mod core {
             }
             pub fn min_value() -> u8 {
                 0
+            }
+            pub fn checked_add(_self: u8, value: u8) -> Option<u8> {
+                _self.checked_add(value)
             }
         }
 
@@ -486,7 +498,10 @@ pub mod core {
     }
 
     pub mod usize {
+        #[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
         pub const MAX: usize = 4294967295;
+        #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
+        pub const MAX: usize = 18446744073709551615;
         pub const MIN: usize = 0;
     }
 
@@ -577,6 +592,11 @@ pub mod alloc {
                 self.len += 1;
             }
 
+            pub fn append(&mut self, other: &mut Vec<T>) {
+                precondition!(self.len <= usize::max_value() - other.len());
+                self.len += other.len;
+            }
+
             pub fn pop(&mut self) -> Option<T> {
                 if self.len == 0 {
                     None
@@ -588,6 +608,10 @@ pub mod alloc {
 
             pub fn is_empty(&self) -> bool {
                 self.len == 0
+            }
+
+            pub fn clear(&mut self) {
+                self.len = 0;
             }
         }
     }

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -176,9 +176,18 @@ pub mod core {
 
         pub mod implement_usize {
             pub fn max_value() -> usize {
-                if cfg!(any(target_arch = "x86", tagret_arch = "mips", tagret_arch = "powerpc", tagret_arch = "arm")) {
+                if cfg!(any(
+                    target_arch = "x86",
+                    tagret_arch = "mips",
+                    tagret_arch = "powerpc",
+                    tagret_arch = "arm"
+                )) {
                     4294967295
-                } else if cfg!(any(target_arch = "x86_64", tagret_arch = "powerpc64", tagret_arch = "aarch64")) {
+                } else if cfg!(any(
+                    target_arch = "x86_64",
+                    tagret_arch = "powerpc64",
+                    tagret_arch = "aarch64"
+                )) {
                     18446744073709551615
                 } else {
                     panic!("Unsupported architecture");
@@ -498,9 +507,19 @@ pub mod core {
     }
 
     pub mod usize {
-        #[cfg(any(target_arch = "x86", target_arch = "mips", target_arch = "mips", target_arch = "powerpc", target_arch = "arm"))]
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "mips",
+            target_arch = "mips",
+            target_arch = "powerpc",
+            target_arch = "arm"
+        ))]
         pub const MAX: usize = 4294967295;
-        #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64", target_arch = "aarch64"))]
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "aarch64"
+        ))]
         pub const MAX: usize = 18446744073709551615;
         pub const MIN: usize = 0;
     }

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -90,8 +90,34 @@ pub mod core {
     }
 
     pub mod isize {
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "mips",
+            target_arch = "mips",
+            target_arch = "powerpc",
+            target_arch = "arm"
+        ))]
         pub const MAX: isize = 2147483647;
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "aarch64"
+        ))]
+        pub const MAX: isize = 9223372036854775807;
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "mips",
+            target_arch = "mips",
+            target_arch = "powerpc",
+            target_arch = "arm"
+        ))]
         pub const MIN: isize = -2147483648;
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "powerpc64",
+            target_arch = "aarch64"
+        ))]
+        pub const MIN: isize = -9223372036854775808;
     }
 
     pub mod i8 {
@@ -122,10 +148,40 @@ pub mod core {
     pub mod num {
         pub mod implement_isize {
             pub fn max_value() -> isize {
-                2147483647
+                if cfg!(any(
+                    target_arch = "x86",
+                    tagret_arch = "mips",
+                    tagret_arch = "powerpc",
+                    tagret_arch = "arm"
+                )) {
+                    2147483647
+                } else if cfg!(any(
+                    target_arch = "x86_64",
+                    tagret_arch = "powerpc64",
+                    tagret_arch = "aarch64"
+                )) {
+                    9223372036854775807
+                } else {
+                    panic!("Unsupported architecture");
+                }
             }
             pub fn min_value() -> isize {
-                -2147483648
+                if cfg!(any(
+                    target_arch = "x86",
+                    tagret_arch = "mips",
+                    tagret_arch = "powerpc",
+                    tagret_arch = "arm"
+                )) {
+                    -2147483648
+                } else if cfg!(any(
+                    target_arch = "x86_64",
+                    tagret_arch = "powerpc64",
+                    tagret_arch = "aarch64"
+                )) {
+                    -9223372036854775808
+                } else {
+                    panic!("Unsupported architecture");
+                }
             }
         }
 
@@ -607,7 +663,7 @@ pub mod alloc {
             }
 
             pub fn push(&mut self, _value: T) {
-                precondition!(self.len < std::usize::MAX);
+                precondition!(self.len < usize::max_value());
                 self.len += 1;
             }
 


### PR DESCRIPTION
## Description

Set the value of `std::usize::MAX` and `usize::max_value()` based on whether the target architecture is 32 or 64 bit.

Add contracts for `Vec::append`, `Vec::clear`, `usize::checked_add`.

Fixes: #238

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

Cargo test with new contract tests.

## Checklist:

- [ ] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

