### PR TITLE
Avoid polluting summary side-effects.

### DIFF
--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -423,7 +423,9 @@ impl Debug for Expression {
             Expression::UnknownModelField { path, default } => {
                 f.write_fmt(format_args!("({:?}).default(({:?})", path, default))
             }
-            Expression::Variable { path, .. } => path.fmt(f),
+            Expression::Variable { path, var_type } => {
+                f.write_fmt(format_args!("{:?}: {:?}", path, var_type))
+            }
             Expression::Widen { path, operand } => {
                 f.write_fmt(format_args!("widen({:?}) at {:?}", operand, path))
             }


### PR DESCRIPTION
## Description

When a parameter is accessed, an entry is created for it in the value map with a Variable expression that does little more than associate a location and type with the otherwise unknown value. These entries were then copied into the function summary as purported side-effects to the parameters. This expanded summaries and caused call site code to do more work. There is now a check to keep such entries out of side-effects lists.

A related issue comes up with real side effects where the value is a Variable expression. Such values add no information to the call site and can be injurious if the types they bundle are unspecialized generic parameters. By ignoring such values, when they are directly assigned to typed locals at the call site, we can use the actual (specialized) types of the caller variables.

Also fixed the type inference to return ISize as the type of an enum discriminant, rather then the enum itself.

Finally, tweaked the debug output for Variable expressions to also include the variable type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
