### PR TITLE
Use the common mangling routine for components of a type qualifier.

### DIFF
--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -230,7 +230,7 @@ fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
     };
     for component in &tcx.def_path(def_id).data {
         name.push('_');
-        name.push_str(component.data.as_interned_str().as_str().get());
+        push_component_name(&component.data, &mut name);
         if component.disambiguator != 0 {
             name.push('_');
             let da = component.disambiguator.to_string();


### PR DESCRIPTION
## Description

When a path qualified type name appears in a type suffix, it should not contain the spaces and illegal characters that as_interned_string() returns. There is already a function for that, just use it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh

