### PR TITLE
Keep track of deref operations

### DIFF
--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::abstract_value::AbstractValue;
+use crate::abstract_value::{AbstractValue, AbstractValueTrait};
 use crate::constant_domain::ConstantDomain;
 use crate::path::Path;
 
@@ -452,8 +452,16 @@ impl Expression {
             Expression::BitXor { left, .. } => left.expression.infer_type(),
             Expression::Cast { target_type, .. } => target_type.clone(),
             Expression::CompileTimeConstant(c) => c.into(),
-            Expression::ConditionalExpression { consequent, .. } => {
-                consequent.expression.infer_type()
+            Expression::ConditionalExpression {
+                consequent,
+                alternate,
+                ..
+            } => {
+                if consequent.is_top() {
+                    alternate.expression.infer_type()
+                } else {
+                    consequent.expression.infer_type()
+                }
             }
             Expression::Div { left, .. } => left.expression.infer_type(),
             Expression::Equals { .. } => Bool,
@@ -473,7 +481,7 @@ impl Expression {
             Expression::Rem { left, .. } => left.expression.infer_type(),
             Expression::Shl { left, .. } => left.expression.infer_type(),
             Expression::ShlOverflows { .. } => Bool,
-            Expression::Shr { left, .. } => left.expression.infer_type(),
+            Expression::Shr { result_type, .. } => result_type.clone(),
             Expression::ShrOverflows { .. } => Bool,
             Expression::Sub { left, .. } => left.expression.infer_type(),
             Expression::SubOverflows { .. } => Bool,

--- a/checker/tests/run-pass/move_return.rs
+++ b/checker/tests/run-pass/move_return.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that calls std::intrinsics::unreachable conditionally.
+// A test that checks that non primitive values can move through a generic copy.
 
 #[macro_use]
 extern crate mirai_annotations;


### PR DESCRIPTION
## Description

The motivation for this rather large change is that it is currently possible to construct expressions where the types of the operands are not compatible with each other. This happens chiefly because of refinement of summaries and typically reproduce in complicated circumstances.

During refinement, paths are constructed by composing other paths and the resulting paths may be non canonical (for example &*&p). Since paths are keys to the local environment, they need to get canonicalized. 

Prior to this PR, a visitor::visit_place contained a hack where it stripped a deref (*) from a path when the value denoted by the qualifier did not obviously result in a reference type. This worked pretty well despite being largely bogus. Unsurprisingly it does not work in tricky cases.

Fixing the hack opened up a can of worms, all of which had to be dealt with before getting the test suite to pass again. Along the way I've introduced some runtime checks for type incompatibilities, which brought many other issues to light as well. Not all of those are fixed yet, but since the tests (and many large crates) now work again. I'm putting this PR up for merging to minimize the amount of code that get's vetted in one go.

As it is, this PR is extremely hard to review and likely contains problems. Those will just have to come out in the wash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh and running over a large number of crates from crates.io.

