### PR TITLE
Fudges to get MIRAI to build Libra without failing.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -566,7 +566,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             && !(consequent_type.is_integer() && alternate_type.is_integer())
             && !(consequent.is_top() || alternate.is_top())
         {
-            unreachable!(
+            info!(
                 "conditional with mismatched types  {:?}: {:?}     {:?}: {:?}",
                 consequent_type, consequent, alternate_type, alternate
             );
@@ -2090,13 +2090,25 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             | Expression::Reference(..)
             | Expression::Top
             | Expression::Variable { .. } => self.clone(),
-            _ => AbstractValue::make_from(
-                Expression::Widen {
-                    path: path.clone(),
-                    operand: self.clone(),
-                },
-                1,
-            ),
+            _ => {
+                if self.expression_size > 1000 {
+                    AbstractValue::make_from(
+                        Expression::Variable {
+                            path: path.clone(),
+                            var_type: self.expression.infer_type(),
+                        },
+                        1,
+                    )
+                } else {
+                    AbstractValue::make_from(
+                        Expression::Widen {
+                            path: path.clone(),
+                            operand: self.clone(),
+                        },
+                        3,
+                    )
+                }
+            }
         }
     }
 }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -123,6 +123,34 @@ impl MiraiCallbacks {
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.
     #[logfn(TRACE)]
     fn analyze_with_mirai(&mut self, compiler: &interface::Compiler, tcx: &TyCtxt<'_>) {
+        // missing case in type mangling code
+        if self.file_name.contains("/nix")
+            || self.file_name.contains("/xml-rs")
+            || self.file_name.contains("/clap")
+            || self.file_name.contains("/proptest")
+            || self.file_name.contains("/ring")
+        {
+            return;
+        }
+        // runs out of memory
+        if self.file_name.contains("/rustc-serialize")
+            || self.file_name.contains("/protobuf")
+            || self.file_name.contains("/rust-crypto")
+            || self.file_name.contains("/h2-0.1.25")
+            || self.file_name.contains("/regex")
+            || self.file_name.contains("/csv")
+        {
+            return;
+        }
+        // fails to map a MIRAI path to the corresponding Rustc type value
+        if self.file_name.contains("/futures-util-preview") || self.file_name.contains("/backtrace")
+        {
+            return;
+        }
+        // non termination
+        if self.file_name.contains("/crc32fast") {
+            return;
+        }
         let summary_store_path = String::from(self.output_directory.to_str().unwrap());
         info!(
             "storing summaries for {} at {}/.summary_store.sled",


### PR DESCRIPTION
## Description

Hopefully temporary fudges to get MIRAI to run on Libra (and its external dependencies) without failing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
and in the Libra root directory:
cargo clean; RUSTC_WRAPPER=mirai cargo build

