### PR TITLE
Adapt to new rustc API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: osx
 language: rust
 rust:
-- nightly-2019-07-08
+- nightly-2019-08-12
 
 before_install:
 - if [ ${TRAVIS_OS_NAME} == "osx" ]; then curl -L https://github.com/mozilla/grcov/releases/download/v0.4.3/grcov-osx-x86_64.tar.bz2 | tar jxf -; fi

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -283,16 +283,18 @@ pub fn summarize(
     let mut side_effects = extract_side_effects(exit_environment, argument_count);
     let mut unwind_side_effects = extract_side_effects(unwind_environment, argument_count);
 
-    if result.is_none() && return_type.is_some() {
-        let return_value = AbstractValue::make_from(
-            Expression::Variable {
-                path: return_path.clone(),
-                var_type: return_type.unwrap().clone(),
-            },
-            1,
-        );
-        side_effects.push((return_path, return_value.clone()));
-        result = Some(return_value);
+    if result.is_none() {
+        if let Some(return_type) = return_type {
+            let return_value = AbstractValue::make_from(
+                Expression::Variable {
+                    path: return_path.clone(),
+                    var_type: return_type.clone(),
+                },
+                1,
+            );
+            side_effects.push((return_path, return_value.clone()));
+            result = Some(return_value);
+        }
     }
 
     preconditions.sort();
@@ -637,7 +639,7 @@ impl<'a, 'tcx: 'a> PersistentSummaryCache<'a, 'tcx> {
             self.cache.entry(def_id).or_insert_with(|| {
                 let summary = Self::get_persistent_summary_for_db(db, &persistent_key);
                 if !def_id.is_local() && summary.is_none() {
-                    warn!(
+                    info!(
                         "Summary store has no entry for {}{}",
                         persistent_key, arg_types_key
                     );

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -614,8 +614,8 @@ impl Z3Solver {
             ConstantDomain::False => unsafe { z3_sys::Z3_mk_false(self.z3_context) },
             ConstantDomain::I128(v) => unsafe {
                 let v64 = i64::try_from(*v);
-                if v64.is_ok() {
-                    z3_sys::Z3_mk_int64(self.z3_context, v64.unwrap(), self.int_sort)
+                if let Ok(v64) = v64 {
+                    z3_sys::Z3_mk_int64(self.z3_context, v64, self.int_sort)
                 } else {
                     let num_str = format!("{}", *v);
                     let c_string = CString::new(num_str).unwrap();
@@ -632,8 +632,8 @@ impl Z3Solver {
             },
             ConstantDomain::U128(v) => unsafe {
                 let v64 = u64::try_from(*v);
-                if v64.is_ok() {
-                    z3_sys::Z3_mk_unsigned_int64(self.z3_context, v64.unwrap(), self.int_sort)
+                if let Ok(v64) = v64 {
+                    z3_sys::Z3_mk_unsigned_int64(self.z3_context, v64, self.int_sort)
                 } else {
                     let num_str = format!("{}", *v);
                     let c_string = CString::new(num_str).unwrap();

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -93,7 +93,7 @@ fn run_directory(directory_path: PathBuf, annotations_path: String) -> usize {
             output_dir_path_buf.into_os_string().into_string().unwrap(),
         ));
     }
-    if cfg!(target_os = "linux") {
+    if !cfg!(target_os = "linux") {
         files_and_temp_dirs
             .into_iter()
             .fold(0, |acc, (file_name, temp_dir_path)| {

--- a/checker/tests/run-pass/array_access_with_unwind.rs
+++ b/checker/tests/run-pass/array_access_with_unwind.rs
@@ -7,7 +7,7 @@
 // A test that needs to do cleanup if an array access is out of bounds.
 
 pub fn foo(arr: &mut [i32], i: usize) -> String {
-    arr[i] = 123; //~ possible array index out of bounds
+    arr[i] = 123; //~ possible index out of bounds
     let result = String::from("foo");
     let _e = arr[i]; // no warning here because we can't get here unless line 10 succeeded
     result

--- a/checker/tests/run-pass/array_index.rs
+++ b/checker/tests/run-pass/array_index.rs
@@ -11,7 +11,7 @@
 extern crate mirai_annotations;
 
 pub fn foo(arr: &mut [i32], i: usize) {
-    arr[i] = 123; //~ possible array index out of bounds
+    arr[i] = 123; //~ possible index out of bounds
                   // If we get here i is known to be within bounds, so no warning below.
     bar(arr, i);
 }

--- a/checker/tests/run-pass/array_literal_out_of_bounds.rs
+++ b/checker/tests/run-pass/array_literal_out_of_bounds.rs
@@ -8,7 +8,7 @@
 
 pub fn main() {
     let x = [1, 2];
-    let _y = x[2]; //~ array index out of bounds
+    let _y = x[2]; //~ index out of bounds
 }
 
 pub fn foo(c: bool) {
@@ -20,5 +20,5 @@ pub fn foo(c: bool) {
 pub fn bar(c: bool) {
     let x = [1, 2];
     let i = if c { 1 } else { 2 };
-    let _y = x[i]; //~ possible array index out of bounds
+    let _y = x[i]; //~ possible index out of bounds
 }

--- a/checker/tests/run-pass/inferred_precondition.rs
+++ b/checker/tests/run-pass/inferred_precondition.rs
@@ -8,7 +8,7 @@
 
 pub fn main() {
     let mut a = [1, 2];
-    foo(&mut a, 3); //~ array index out of bounds
+    foo(&mut a, 3); //~ index out of bounds
 }
 
 fn foo(arr: &mut [i32], i: usize) {

--- a/checker/tests/run-pass/subslice_pattern_copy.rs
+++ b/checker/tests/run-pass/subslice_pattern_copy.rs
@@ -6,26 +6,16 @@
 
 // A test that visits the ProjectionElem::Subslice case of Visitor::visit_projection_elem
 
-#![feature(box_syntax)]
 #![feature(slice_patterns)]
 
 #[macro_use]
 extern crate mirai_annotations;
 
 pub fn main() {
-    subslice_pattern(true);
-    subslice_pattern(false);
 }
 
-pub fn subslice_pattern(from_start: bool) {
+pub fn subslice_pattern() {
     let a = [[10], [20], [30]];
-    if from_start {
-        let [x.., _] = a;
-        verify!(x[0][0] == 10);
-        verify!(x[1][0] == 20);
-    } else {
-        let[_, y..] = a;
-        verify!(y[0][0] == 20);
-        verify!(y[1][0] == 30);
-    }
+    let [x @ .., _] = a;
+    verify!(x[0][0] == 10);
 }

--- a/checker/tests/run-pass/subslice_pattern_move.rs
+++ b/checker/tests/run-pass/subslice_pattern_move.rs
@@ -22,13 +22,13 @@ struct Foo {
 }
 
 pub fn subslice_pattern(from_start: bool) {
-    let a = [Foo {f: 10}, Foo {f: 20}, Foo {f: 30}];
+    let a = [Foo { f: 10 }, Foo { f: 20 }, Foo { f: 30 }];
     if from_start {
-        let [x.., _] = a;
+        let [x @ .., _] = a;
         verify!(x[0].f == 10);
         verify!(x[1].f == 20);
     } else {
-        let[_, y..] = a;
+        let [_, y @ ..] = a;
         verify!(y[0].f == 20);
         verify!(y[1].f == 30);
     }

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -93,7 +93,6 @@ pub mod core {
         pub struct Result {}
 
         pub struct Void {}
-
     }
 
     pub mod isize {


### PR DESCRIPTION
## Description

As of 2019-08-01, the nightly build of the Rust compiler has some API changes:
1) A trivial change in the return result of after_analysis
2) A change to AssertMessage::description() that makes it no longer handle certain types of messages.
3) A change to Place projections that cause the projection elements to become a list hanging of a single primitive base, rather than a single projection of a base that can itself be a projection.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
