### PR TITLE
Wrap TyCtxt::type_of to avoid crashes for cases it does not handle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: osx
 language: rust
 rust:
-- nightly-2019-07-08
+- nightly-2019-08-12
 
 before_install:
 - if [ ${TRAVIS_OS_NAME} == "osx" ]; then curl -L https://github.com/mozilla/grcov/releases/download/v0.4.3/grcov-osx-x86_64.tar.bz2 | tar jxf -; fi

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -129,15 +129,6 @@ impl MiraiCallbacks {
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.
     #[logfn(TRACE)]
     fn analyze_with_mirai(&mut self, compiler: &interface::Compiler, tcx: &TyCtxt<'_>) {
-        // missing case in type mangling code
-        if self.file_name.contains("/nix")
-            || self.file_name.contains("/xml-rs")
-            || self.file_name.contains("/clap")
-            || self.file_name.contains("/proptest")
-            || self.file_name.contains("/ring")
-        {
-            return;
-        }
         // runs out of memory
         if self.file_name.contains("/rustc-serialize")
             || self.file_name.contains("/protobuf")

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -283,16 +283,18 @@ pub fn summarize(
     let mut side_effects = extract_side_effects(exit_environment, argument_count);
     let mut unwind_side_effects = extract_side_effects(unwind_environment, argument_count);
 
-    if result.is_none() && return_type.is_some() {
-        let return_value = AbstractValue::make_from(
-            Expression::Variable {
-                path: return_path.clone(),
-                var_type: return_type.unwrap().clone(),
-            },
-            1,
-        );
-        side_effects.push((return_path, return_value.clone()));
-        result = Some(return_value);
+    if result.is_none() {
+        if let Some(return_type) = return_type {
+            let return_value = AbstractValue::make_from(
+                Expression::Variable {
+                    path: return_path.clone(),
+                    var_type: return_type.clone(),
+                },
+                1,
+            );
+            side_effects.push((return_path, return_value.clone()));
+            result = Some(return_value);
+        }
     }
 
     preconditions.sort();
@@ -637,7 +639,7 @@ impl<'a, 'tcx: 'a> PersistentSummaryCache<'a, 'tcx> {
             self.cache.entry(def_id).or_insert_with(|| {
                 let summary = Self::get_persistent_summary_for_db(db, &persistent_key);
                 if !def_id.is_local() && summary.is_none() {
-                    warn!(
+                    info!(
                         "Summary store has no entry for {}{}",
                         persistent_key, arg_types_key
                     );

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -7,7 +7,7 @@ use log::debug;
 use log_derive::{logfn, logfn_inputs};
 use rustc::hir::def_id::DefId;
 use rustc::hir::map::DefPathData;
-use rustc::hir::{ItemKind, Node};
+use rustc::hir::{ItemKind, Node, TraitItemKind};
 use rustc::ty::subst::{SubstsRef, UnpackedKind};
 use rustc::ty::{DefIdTree, Ty, TyCtxt, TyKind};
 use std::rc::Rc;
@@ -219,15 +219,7 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'tcx>)
 /// the result can be appended to a valid identifier.
 #[logfn(TRACE)]
 fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
-    let mut name = if def_id.is_local() {
-        tcx.crate_name.as_interned_str().as_str().to_string()
-    } else {
-        let cdata = tcx.crate_data_as_rc_any(def_id.krate);
-        let cdata = cdata
-            .downcast_ref::<rustc_metadata::cstore::CrateMetadata>()
-            .unwrap();
-        cdata.name.as_str().to_string()
-    };
+    let mut name = crate_name(tcx, def_id);
     for component in &tcx.def_path(def_id).data {
         name.push('_');
         push_component_name(&component.data, &mut name);
@@ -240,13 +232,10 @@ fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
     name
 }
 
-/// Constructs a string that uniquely identifies a definition to serve as a key to
-/// the summary cache, which is a key value store. The string will always be the same as
-/// long as the definition does not change its name or location, so it can be used to
-/// transfer information from one compilation to the next, making incremental analysis possible.
+/// Constructs a name for the crate that contains the given def_id.
 #[logfn(TRACE)]
-pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
-    let mut name = if def_id.is_local() {
+fn crate_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
+    if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str().to_string()
     } else {
         // This is both ugly and probably brittle, but I can't find any other
@@ -263,7 +252,16 @@ pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
             .downcast_ref::<rustc_metadata::cstore::CrateMetadata>()
             .unwrap();
         cdata.name.as_str().to_string()
-    };
+    }
+}
+
+/// Constructs a string that uniquely identifies a definition to serve as a key to
+/// the summary cache, which is a key value store. The string will always be the same as
+/// long as the definition does not change its name or location, so it can be used to
+/// transfer information from one compilation to the next, making incremental analysis possible.
+#[logfn(TRACE)]
+pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
+    let mut name = crate_name(tcx, def_id);
     for component in &tcx.def_path(def_id).data {
         if name.ends_with("foreign_contracts") {
             // By stripping off this special prefix, we allow this crate (or module) to define
@@ -283,9 +281,10 @@ pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
             name.push('_');
             if saw_implement {
                 if let Some(parent_def_id) = tcx.parent(def_id) {
-                    let ty = tcx.type_of(parent_def_id);
-                    append_mangled_type(&mut name, ty, tcx);
-                    continue;
+                    if let Some(ty) = type_of(*tcx, parent_def_id) {
+                        append_mangled_type(&mut name, ty, tcx);
+                        continue;
+                    }
                 }
             }
             let da = component.disambiguator.to_string();
@@ -293,6 +292,37 @@ pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
         }
     }
     Rc::new(name)
+}
+
+/// Guards a call to tcx.type_of to avoid cases where it fails.
+fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Option<&rustc::ty::TyS<'_>> {
+    let hir_id = match tcx.hir().as_local_hir_id(def_id) {
+        Some(hir_id) => hir_id,
+        None => {
+            return Some(tcx.type_of(def_id));
+        }
+    };
+    match tcx.hir().get(hir_id) {
+        Node::TraitItem(item) => {
+            if let TraitItemKind::Type(_, None) = item.node {
+                return None;
+            }
+        }
+        Node::Item(item) => match item.node {
+            ItemKind::Trait(..)
+            | ItemKind::TraitAlias(..)
+            | ItemKind::Mod(..)
+            | ItemKind::ForeignMod(..)
+            | ItemKind::GlobalAsm(..)
+            | ItemKind::ExternCrate(..)
+            | ItemKind::Use(..) => {
+                return None;
+            }
+            _ => (),
+        },
+        _ => (),
+    }
+    Some(tcx.type_of(def_id))
 }
 
 fn push_component_name(component_data: &DefPathData, target: &mut String) {

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -1737,11 +1737,9 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     //
                     // We **do** have to push a precondition since this is the probable intent.
                     let condition = self.current_environment.entry_condition.logical_not();
-                    let mut maybe_message = String::from("possible error: ");
-                    maybe_message.push_str(msg.as_str());
                     let precondition = Precondition {
                         condition,
-                        message: Rc::new(maybe_message),
+                        message: msg,
                         provenance: None,
                         spans: vec![self.current_span],
                     };

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -614,8 +614,8 @@ impl Z3Solver {
             ConstantDomain::False => unsafe { z3_sys::Z3_mk_false(self.z3_context) },
             ConstantDomain::I128(v) => unsafe {
                 let v64 = i64::try_from(*v);
-                if v64.is_ok() {
-                    z3_sys::Z3_mk_int64(self.z3_context, v64.unwrap(), self.int_sort)
+                if let Ok(v64) = v64 {
+                    z3_sys::Z3_mk_int64(self.z3_context, v64, self.int_sort)
                 } else {
                     let num_str = format!("{}", *v);
                     let c_string = CString::new(num_str).unwrap();
@@ -632,8 +632,8 @@ impl Z3Solver {
             },
             ConstantDomain::U128(v) => unsafe {
                 let v64 = u64::try_from(*v);
-                if v64.is_ok() {
-                    z3_sys::Z3_mk_unsigned_int64(self.z3_context, v64.unwrap(), self.int_sort)
+                if let Ok(v64) = v64 {
+                    z3_sys::Z3_mk_unsigned_int64(self.z3_context, v64, self.int_sort)
                 } else {
                     let num_str = format!("{}", *v);
                     let c_string = CString::new(num_str).unwrap();

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -93,7 +93,7 @@ fn run_directory(directory_path: PathBuf, annotations_path: String) -> usize {
             output_dir_path_buf.into_os_string().into_string().unwrap(),
         ));
     }
-    if cfg!(target_os = "linux") {
+    if !cfg!(target_os = "linux") {
         files_and_temp_dirs
             .into_iter()
             .fold(0, |acc, (file_name, temp_dir_path)| {

--- a/checker/tests/run-pass/array_access_with_unwind.rs
+++ b/checker/tests/run-pass/array_access_with_unwind.rs
@@ -7,7 +7,7 @@
 // A test that needs to do cleanup if an array access is out of bounds.
 
 pub fn foo(arr: &mut [i32], i: usize) -> String {
-    arr[i] = 123; //~ possible array index out of bounds
+    arr[i] = 123; //~ possible index out of bounds
     let result = String::from("foo");
     let _e = arr[i]; // no warning here because we can't get here unless line 10 succeeded
     result

--- a/checker/tests/run-pass/array_index.rs
+++ b/checker/tests/run-pass/array_index.rs
@@ -11,7 +11,7 @@
 extern crate mirai_annotations;
 
 pub fn foo(arr: &mut [i32], i: usize) {
-    arr[i] = 123; //~ possible array index out of bounds
+    arr[i] = 123; //~ possible index out of bounds
                   // If we get here i is known to be within bounds, so no warning below.
     bar(arr, i);
 }

--- a/checker/tests/run-pass/array_literal_out_of_bounds.rs
+++ b/checker/tests/run-pass/array_literal_out_of_bounds.rs
@@ -8,7 +8,7 @@
 
 pub fn main() {
     let x = [1, 2];
-    let _y = x[2]; //~ array index out of bounds
+    let _y = x[2]; //~ index out of bounds
 }
 
 pub fn foo(c: bool) {
@@ -20,5 +20,5 @@ pub fn foo(c: bool) {
 pub fn bar(c: bool) {
     let x = [1, 2];
     let i = if c { 1 } else { 2 };
-    let _y = x[i]; //~ possible array index out of bounds
+    let _y = x[i]; //~ possible index out of bounds
 }

--- a/checker/tests/run-pass/assert_as_precondition.rs
+++ b/checker/tests/run-pass/assert_as_precondition.rs
@@ -8,7 +8,7 @@
 
 pub fn main() {
     let mut a = [1, 2];
-    foo(&mut a, 3); //~ possible error: assertion failed: i < 2
+    foo(&mut a, 3); //~ assertion failed: i < 2
 }
 
 fn foo(arr: &mut [i32; 2], i: usize) {

--- a/checker/tests/run-pass/inferred_precondition.rs
+++ b/checker/tests/run-pass/inferred_precondition.rs
@@ -8,7 +8,7 @@
 
 pub fn main() {
     let mut a = [1, 2];
-    foo(&mut a, 3); //~ array index out of bounds
+    foo(&mut a, 3); //~ index out of bounds
 }
 
 fn foo(arr: &mut [i32], i: usize) {

--- a/checker/tests/run-pass/possible_possible.rs
+++ b/checker/tests/run-pass/possible_possible.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that we don't repeat possible.
+
+pub fn foo(i: i32) {
+    bar(i); //~ possible foo_bar
+}
+
+pub fn bar(i: i32) {
+    assert!(i > -123, "foo_bar"); //~ related location
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/subslice_pattern_copy.rs
+++ b/checker/tests/run-pass/subslice_pattern_copy.rs
@@ -6,26 +6,16 @@
 
 // A test that visits the ProjectionElem::Subslice case of Visitor::visit_projection_elem
 
-#![feature(box_syntax)]
 #![feature(slice_patterns)]
 
 #[macro_use]
 extern crate mirai_annotations;
 
 pub fn main() {
-    subslice_pattern(true);
-    subslice_pattern(false);
 }
 
-pub fn subslice_pattern(from_start: bool) {
+pub fn subslice_pattern() {
     let a = [[10], [20], [30]];
-    if from_start {
-        let [x.., _] = a;
-        verify!(x[0][0] == 10);
-        verify!(x[1][0] == 20);
-    } else {
-        let[_, y..] = a;
-        verify!(y[0][0] == 20);
-        verify!(y[1][0] == 30);
-    }
+    let [x @ .., _] = a;
+    verify!(x[0][0] == 10);
 }

--- a/checker/tests/run-pass/subslice_pattern_move.rs
+++ b/checker/tests/run-pass/subslice_pattern_move.rs
@@ -22,13 +22,13 @@ struct Foo {
 }
 
 pub fn subslice_pattern(from_start: bool) {
-    let a = [Foo {f: 10}, Foo {f: 20}, Foo {f: 30}];
+    let a = [Foo { f: 10 }, Foo { f: 20 }, Foo { f: 30 }];
     if from_start {
-        let [x.., _] = a;
+        let [x @ .., _] = a;
         verify!(x[0].f == 10);
         verify!(x[1].f == 20);
     } else {
-        let[_, y..] = a;
+        let [_, y @ ..] = a;
         verify!(y[0].f == 20);
         verify!(y[1].f == 30);
     }

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -93,7 +93,6 @@ pub mod core {
         pub struct Result {}
 
         pub struct Void {}
-
     }
 
     pub mod isize {


### PR DESCRIPTION
## Description

The type_of call used to make name mangling a bit more user friendly caused crashes because not every parent of a body inside a disambiguated implementation block has a type for a parent.
Since the call that would return an option for such cases is not public, create a wrapper that duplicates the logic for the error cases.

While at it, also factor out some duplicated located nearby.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh; building libra

