### PR TITLE
Adds standard contract for max usize

### DIFF
--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -30,7 +30,7 @@ pub mod core {
 
         pub fn max__u64(v1: u64, v2: u64) -> u64 {
             if v1 >= v2 {
-                return  v1;
+                return v1;
             }
             return v2;
         }

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -27,6 +27,13 @@ pub mod core {
                 result!()
             }
         }
+
+        pub fn max__u64(v1: u64, v2: u64) -> u64 {
+            if v1 >= v2 {
+                return  v1;
+            }
+            return v2;
+        }
     }
 
     pub mod default {

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -34,6 +34,13 @@ pub mod core {
             }
             return v2;
         }
+
+        pub fn max__usize(v1: usize, v2: usize) -> usize {
+            if v1 >= v2 {
+                return v1;
+            }
+            return v2;
+        }
     }
 
     pub mod default {


### PR DESCRIPTION
## Description

Adds missing standard contract for `core::cmp::max__usize`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
`./rebuild_std.sh`
