### PR TITLE
Fix bug in refinement of conditional expressions

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2020,7 +2020,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     let refined_consequent =
                         refined_consequent.refine_with(&refined_condition, depth + 1);
                     let refined_alternate =
-                        refined_alternate.refine_with(&refined_condition, depth + 1);
+                        refined_alternate.refine_with(&refined_condition.logical_not(), depth + 1);
                     refined_condition.conditional_expression(refined_consequent, refined_alternate)
                 }
             }


### PR DESCRIPTION
## Description

When refining the alternate branch of a conditional expression whose condition has been refined, the logical not of the refined condition should be used, not the refined condition.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
A simple test case that hits this code path eludes me. It does come up in macro generated code, tough, but not in way that readily manifests itself. The bug did not yet manifest in any observable way, but the code is clearly wrong so it needs fixing.

