### PR TITLE
Do not supply --sysroot if it has been supplied on the command line.

### DIFF
--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -55,10 +55,16 @@ fn main() {
         command_line_arguments.remove(1);
     }
 
-    // Tell compiler where to find the std library and so on.
-    // The compiler relies on the standard rustc driver to tell it, so we have to do likewise.
-    command_line_arguments.push(String::from("--sysroot"));
-    command_line_arguments.push(utils::find_sysroot());
+    let sysroot: String = "--sysroot".into();
+    if !command_line_arguments
+        .iter()
+        .any(|arg| arg.starts_with(&sysroot))
+    {
+        // Tell compiler where to find the std library and so on.
+        // The compiler relies on the standard rustc driver to tell it, so we have to do likewise.
+        command_line_arguments.push(sysroot);
+        command_line_arguments.push(utils::find_sysroot());
+    }
 
     let result = rustc_driver::report_ices_to_stderr_if_any(move || {
         let callbacks = &mut callbacks::MiraiCallbacks::default();


### PR DESCRIPTION
## Description

Always adding a --sysroot command line argument in the main routine breaks compatibility with rustc in the case where --sysroot has been explicitly added, so first check that it is not present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
Ran mirai with explicit --sysroot argument, using both " " and "=" as the separator and observed that a duplicate sysroot error occurs without this change, and does not with the change. Also, if the argument is invalid, a "std lib not found" error is seen, whereas with a valid argument everything works as expected.
