### PR TITLE
Add (assume|verify)_unreachable macros.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.3.1",
+ "mirai-annotations 1.4.0",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -293,13 +293,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.3.1"
+version = "1.4.0"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.3.1",
+ "mirai-annotations 1.4.0",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/README.md
+++ b/annotations/README.md
@@ -6,9 +6,9 @@ They add value by allowing [MIRAI](https://github.com/facebookexperimental/MIRAI
 * distinguish between conditions that it should assume as true and conditions that it should verify
 * check conditions at compile time that should not be checked at runtime because they are too expensive
 
-From this it follows that we have three families of macros:
+From these considerations we get these families of macros:
 * assume macros
-* postcondition macros (like verify wehre defined and like assume for callers)
+* postcondition macros (like verify where defined and like assume for callers)
 * precondition macros (like assume where defined and like verify for callers)
 * verify macros
 
@@ -28,7 +28,10 @@ Additionally, the runtime checked kinds provides eq and ne varieties, leaving us
 
 Likewise for postcondition! precondition! and verify!
 
-Additionally there is also assumed_postcondition! which is an assume at the definition site, rather than a verify.
+Additionally we also have:
+* assumed_postcondition! which is an assume at the definition site, rather than a verify.
+* assume_unreachable! which assumes that it is unreachable for reasons beyond what MIRAI can reason about.
+* verify_unreachable! which requires MIRAI to verify that it is not unreachable.
 
 This crate also provides macros for describing and constraining abstract state that only has meaning to MIRAI. These are:
 * get_model_field!

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -6,7 +6,7 @@
 // A set of macros and functions to use for annotating source files that are being checked with MIRAI
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! assume {
@@ -18,7 +18,7 @@ macro_rules! assume {
 }
 
 /// Equivalent to the standard assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! checked_assume {
@@ -39,7 +39,7 @@ macro_rules! checked_assume {
 }
 
 /// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! checked_assume_eq {
@@ -60,7 +60,7 @@ macro_rules! checked_assume_eq {
 }
 
 /// Equivalent to the standard assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! checked_assume_ne {
@@ -81,7 +81,7 @@ macro_rules! checked_assume_ne {
 }
 
 /// Equivalent to the standard debug_assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! debug_checked_assume {
@@ -102,7 +102,7 @@ macro_rules! debug_checked_assume {
 }
 
 /// Equivalent to the standard debug_assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! debug_checked_assume_eq {
@@ -123,7 +123,7 @@ macro_rules! debug_checked_assume_eq {
 }
 
 /// Equivalent to the standard debug_assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition unless it can
+/// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
 #[macro_export]
 macro_rules! debug_checked_assume_ne {
@@ -144,7 +144,7 @@ macro_rules! debug_checked_assume_ne {
 }
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -167,7 +167,7 @@ macro_rules! postcondition {
 }
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -180,7 +180,7 @@ macro_rules! assumed_postcondition {
 }
 
 /// Equivalent to the standard assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -209,7 +209,7 @@ macro_rules! checked_postcondition {
 }
 
 /// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -238,7 +238,7 @@ macro_rules! checked_postcondition_eq {
 }
 
 /// Equivalent to the standard assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -267,7 +267,7 @@ macro_rules! checked_postcondition_ne {
 }
 
 /// Equivalent to the standard debug_assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -296,7 +296,7 @@ macro_rules! debug_checked_postcondition {
 }
 
 /// Equivalent to the standard debug_assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -325,7 +325,7 @@ macro_rules! debug_checked_postcondition_eq {
 }
 
 /// Equivalent to the standard debug_assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to verify the condition at the
+/// When compiled with MIRAI, this causes MIRAI to verify the condition at the
 /// point where it appears in a function, but to also add it a postcondition that can
 /// be assumed by the caller of the function.
 #[macro_export]
@@ -354,7 +354,7 @@ macro_rules! debug_checked_postcondition_ne {
 }
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -380,7 +380,7 @@ macro_rules! precondition {
 }
 
 /// Equivalent to the standard assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -412,7 +412,7 @@ macro_rules! checked_precondition {
 }
 
 /// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -444,7 +444,7 @@ macro_rules! checked_precondition_eq {
 }
 
 /// Equivalent to the standard assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -476,7 +476,7 @@ macro_rules! checked_precondition_ne {
 }
 
 /// Equivalent to the standard debug_assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -508,7 +508,7 @@ macro_rules! debug_checked_precondition {
 }
 
 /// Equivalent to the standard debug_assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -540,7 +540,7 @@ macro_rules! debug_checked_precondition_eq {
 }
 
 /// Equivalent to the standard debug_assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to assume the condition at the
+/// When compiled with MIRAI, this causes MIRAI to assume the condition at the
 /// point where it appears in a function, but to also add it a precondition that must
 /// be verified by the caller of the function.
 #[macro_export]
@@ -572,7 +572,7 @@ macro_rules! debug_checked_precondition_ne {
 }
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! verify {
@@ -584,7 +584,7 @@ macro_rules! verify {
 }
 
 /// Equivalent to the standard assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! checked_verify {
@@ -612,7 +612,7 @@ macro_rules! checked_verify {
 }
 
 /// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! checked_verify_eq {
@@ -640,7 +640,7 @@ macro_rules! checked_verify_eq {
 }
 
 /// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! checked_verify_ne {
@@ -668,7 +668,7 @@ macro_rules! checked_verify_ne {
 }
 
 /// Equivalent to the standard debug_assert! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! debug_checked_verify {
@@ -696,7 +696,7 @@ macro_rules! debug_checked_verify {
 }
 
 /// Equivalent to the standard debug_assert_eq! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! debug_checked_verify_eq {
@@ -724,7 +724,7 @@ macro_rules! debug_checked_verify_eq {
 }
 
 /// Equivalent to the standard debug_assert_ne! when used with an unmodified Rust compiler.
-/// When compiled with MIRAI, this causes the compiler to check the condition and
+/// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.
 #[macro_export]
 macro_rules! debug_checked_verify_ne {
@@ -789,6 +789,48 @@ macro_rules! set_model_field {
     ($target:expr, $field_name:ident, $value:expr) => {
         if cfg!(mirai) {
             mirai_annotations::mirai_set_model_field($target, stringify!($field_name), $value);
+        }
+    };
+}
+
+/// Equivalent to unreachable! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes MIRAI to assume that the annotation statement cannot be reached.
+#[macro_export]
+macro_rules! assume_unreachable {
+    () => {
+        unreachable!()
+    };
+    ($message:literal) => {
+        unreachable!($message)
+    };
+    (($fmt:expr, $($arg:tt)*)) => {
+        unreachable!($fmt, $($arg)*)
+    };
+}
+
+/// Equivalent to unreachable! when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes MIRAI to verify that the annotation statement cannot be reached.
+#[macro_export]
+macro_rules! verify_unreachable {
+    () => {
+        if cfg!(mirai) {
+            panic!("statement is reachable");
+        } else {
+            unreachable!()
+        }
+    };
+    ($message:literal) => {
+        if cfg!(mirai) {
+            panic!($message);
+        } else {
+            unreachable!($message)
+        }
+    };
+    (($fmt:expr, $($arg:tt)*)) => {
+        if cfg!(mirai) {
+            panic!($fmt, $($arg)*);
+        } else {
+            unreachable!($fmt, $($arg)*)
         }
     };
 }

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -117,6 +117,8 @@ pub enum KnownFunctionNames {
     MiraiVerify,
     /// std.panicking.begin_panic
     StdBeginPanic,
+    /// std.panicking.begin_panic_fmt
+    StdBeginPanicFmt,
 }
 
 /// Constructors
@@ -146,6 +148,7 @@ impl ConstantDomain {
             "mirai_annotations.mirai_shallow_clone" => MiraiShallowClone,
             "mirai_annotations.mirai_verify" => MiraiVerify,
             "std.panicking.begin_panic" => StdBeginPanic,
+            "std.panicking.begin_panic_fmt" => StdBeginPanicFmt,
             _ => KnownFunctionNames::None,
         };
         ConstantDomain::Function {

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -1703,7 +1703,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
                     }
                 }
             }
-            KnownFunctionNames::StdBeginPanic => {
+            KnownFunctionNames::StdBeginPanic | KnownFunctionNames::StdBeginPanicFmt => {
+                assume!(!actual_args.is_empty()); // The type checker ensures this.
                 let mut path_cond = self.current_environment.entry_condition.as_bool_if_known();
                 if path_cond.is_none() {
                     // Try the SMT solver
@@ -1780,7 +1781,8 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
         // If we never get here, rather call unreachable!()
         if !entry_cond_as_bool.unwrap_or(true) {
             let span = self.current_span;
-            let message = "this is unreachable, mark it as such by using the unreachable! macro";
+            let message =
+                "this is unreachable, mark it as such by using the verify_unreachable! macro";
             let warning = self.session.struct_span_warn(span, message);
             self.emit_diagnostic(warning);
             return None;

--- a/checker/tests/run-pass/verify_unreachable.rs
+++ b/checker/tests/run-pass/verify_unreachable.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses built-in contracts for the Vec struct.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn foo1(i: i32) {
+    if i < 10 {
+        assume_unreachable!();
+    }
+}
+
+fn foo2(i: i32) {
+    if i < 10 {
+        verify_unreachable!(); //~ related location
+    }
+}
+
+pub fn main() {
+    foo1(1);
+    foo2(2); //~ statement is reachable
+    foo2(10);
+}

--- a/checker/tests/run-pass/x_equals_x.rs
+++ b/checker/tests/run-pass/x_equals_x.rs
@@ -25,7 +25,7 @@ fn foo(x: i32, y: f32) {
     if x == x {
         verify!(true);
     } else {
-        verify!(false); //~ this is unreachable, mark it as such by using the unreachable! macro
+        verify!(false); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
     }
     if y == y {
         verify!(true);


### PR DESCRIPTION
## Description

MIRAI treats `unreachable!()` as an assumption since that seems to be the predominant use of the annotation in the wild.

This leaves open the problem of how to ask MIRAI to actually verify that a statement cannot be reached. The first thing that comes to mind is write `verify!(false, "...")`, but just sounds weird and the error message one gets is not to the point. Moreover, if the annotation is actually unreachable, MIRAI suggests that you use the `unreachable!` macro instead of the `verify! `macro.

To fix this Catch 22, there are now two new macros in mirai_annotations:
* assume_unreachable!
* verify_unreachable!

It should be pretty obvious what they mean.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh

