### PR TITLE
Only share the persistent store between crates if flag is present

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -23,6 +23,7 @@ use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::rc::Rc;
 use syntax::errors::DiagnosticBuilder;
+use tempdir::TempDir;
 
 /// Private state used to implement the callbacks.
 pub struct MiraiCallbacks {
@@ -172,7 +173,13 @@ impl MiraiCallbacks {
         {
             return;
         }
-        let summary_store_path = String::from(self.output_directory.to_str().unwrap());
+        let output_dir = String::from(self.output_directory.to_str().unwrap());
+        let summary_store_path = if std::env::var("MIRAI_SHARE_PERSIST_STORE").is_ok() {
+            output_dir
+        } else {
+            let temp_dir = TempDir::new("mirai_temp_dir").expect("failed to create a temp dir");
+            String::from(temp_dir.into_path().to_str().unwrap())
+        };
         info!(
             "storing summaries for {} at {}/.summary_store.sled",
             self.file_name, summary_store_path

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -498,13 +498,15 @@ impl<'a, 'tcx: 'a> PersistentSummaryCache<'a, 'tcx> {
 
         let directory_path = Path::new(summary_store_directory_str);
         let store_path = directory_path.join(".summary_store.sled");
-        if !store_path.exists() && env::var("MIRAI_START_FRESH").is_err() {
+        if !store_path.exists() || env::var("MIRAI_SHARE_PERSIST_STORE").is_err() {
             let tar_path = directory_path.join(".summary_store.tar");
             if let Ok(mut f) = File::create(tar_path.clone()) {
-                info!("creating a non default new summary store");
-                {
-                    let bytes = include_bytes!("../../binaries/summary_store.tar");
-                    f.write_all(bytes).unwrap();
+                if env::var("MIRAI_START_FRESH").is_err() {
+                    info!("creating a non default new summary store");
+                    {
+                        let bytes = include_bytes!("../../binaries/summary_store.tar");
+                        f.write_all(bytes).unwrap();
+                    }
                 }
             }
             let mut ar = Archive::new(File::open(tar_path).unwrap());


### PR DESCRIPTION
## Description

The persistent summary store is not yet ready for prime time and is currently a frequent source of versioning errors and unbounded summary growth errors.

As of this PR the MIRAI_SHARE_PERSIST_STORE environment variable must be specified before the summary store can be shared between different invocations of MIRAI.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

Ran MIRAI on itself with MIRAI_SHARE_PERSIST_STORE not set and observed that the store is not shared. Then ran it with the variable set and observed that the store is shared.
