### PR TITLE
Give diagnostics if non public function is a call tree root.

### DIFF
--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -42,7 +42,13 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_>) -> bool {
             Node::Expr(rustc::hir::Expr {
                 node: rustc::hir::ExprKind::Closure(..),
                 ..
-            }) => false,
+            }) => {
+                if let Some(parent_def_id) = tcx.parent(def_id) {
+                    is_public(parent_def_id, tcx)
+                } else {
+                    false
+                }
+            }
             Node::Item(item) => {
                 if let ItemKind::Fn(..) = item.node {
                     return item.vis.node.is_pub();

--- a/checker/tests/run-pass/crate_traversal.rs
+++ b/checker/tests/run-pass/crate_traversal.rs
@@ -20,12 +20,12 @@ use std::mem;
 pub trait TestTrait {
     fn test_method() {
         let _loc = [1];
-        let loc2 = [ 0; 512 ];
+        let loc2 = [0; 512];
     }
 }
 
 pub struct TestStruct {
-    pub test_field: i64
+    pub test_field: i64,
 }
 
 impl TestStruct {
@@ -36,17 +36,17 @@ impl TestStruct {
 pub unsafe fn test1() {
     #[derive(Copy, Clone)]
     enum Void {}
-    union A { a: (), v: Void }
-    let a = A { a: () };
-    match a.v {
+    union A {
+        a: (),
+        v: Void,
     }
+    let a = A { a: () };
+    match a.v {}
 }
 
 fn test2() {
     let z = 0;
-    let _x = {
-        &z
-    };
+    let _x = { &z };
 }
 
 fn test3() {
@@ -57,7 +57,7 @@ fn test3() {
     // assignment:
     _nodrop_y = nodrop_x;
 
-    let drop_x : Option<Box<u32>> = None;
+    let drop_x: Option<Box<u32>> = None;
     let _drop_y;
 
     // Since the type of `drop_y` has drop, we generate a `replace`
@@ -106,17 +106,21 @@ fn test7() {
 }
 
 fn test8(x: &mut i32, y: &mut i32) -> i32 {
-  *x = 42;
-  *y = 7;
-  *x // Will load 42! We can optimize away the load.
+    *x = 42;
+    *y = 7;
+    *x // Will load 42! We can optimize away the load.
 }
 
 struct Test(i32);
 
 impl Test {
     // Make sure we run the pass on a method, not just on bare functions.
-    fn foo<'x>(&self, x: &'x mut i32) -> &'x mut i32 { x }
-    fn foo_shr<'x>(&self, x: &'x i32) -> &'x i32 { x }
+    fn foo<'x>(&self, x: &'x mut i32) -> &'x mut i32 {
+        x
+    }
+    fn foo_shr<'x>(&self, x: &'x i32) -> &'x i32 {
+        x
+    }
 }
 
 fn test9() {
@@ -125,12 +129,15 @@ fn test9() {
         let v = Test(0).foo(&mut x); // just making sure we do not panic when there is a tuple struct ctor
         let w = { v }; // assignment
         let w = w; // reborrow
-        // escape-to-raw (mut)
+                   // escape-to-raw (mut)
         let _w = w as *mut _;
     }
 
     // Also test closures
-    let c: fn(&i32) -> &i32 = |x: &i32| -> &i32 { let _y = x; x };
+    let c: fn(&i32) -> &i32 = |x: &i32| -> &i32 {
+        let _y = x;
+        x
+    };
     let _w = c(&x);
 
     // need to call `foo_shr` or it doesn't even get generated
@@ -148,8 +155,8 @@ fn test10() {
     };
 }
 
-fn test11(arr: &[String]){
-    let e = &arr[1];
+fn test11(arr: &[String]) {
+    let e = &arr[1]; //~ possible index out of bounds
 }
 
 fn test12() {
@@ -164,4 +171,6 @@ fn test14(a: i32, b: i32) -> Option<i32> {
     Some(a.checked_add(1)?.checked_mul(3_i32.checked_add(b)?)?)
 }
 
-fn main() {}
+fn main() {
+    test13(1);
+}

--- a/checker/tests/run-pass/verify_unreachable.rs
+++ b/checker/tests/run-pass/verify_unreachable.rs
@@ -6,6 +6,8 @@
 
 // A test that uses built-in contracts for the Vec struct.
 
+#![allow(unused)]
+
 #[macro_use]
 extern crate mirai_annotations;
 
@@ -17,12 +19,8 @@ fn foo1(i: i32) {
 
 fn foo2(i: i32) {
     if i < 10 {
-        verify_unreachable!(); //~ related location
+        verify_unreachable!(); //~ statement is reachable
     }
 }
 
-pub fn main() {
-    foo1(1);
-    foo2(2); //~ statement is reachable
-    foo2(10);
-}
+pub fn main() {}


### PR DESCRIPTION
## Description

If a function is non public but not called (and the rust compiler did not complain about dead code), it is likely called indirectly in way that is not visible via the call graph provided by rustc.

In these cases we can't rely on checking all of the callers, so any panics inside their bodies have to be reported as potential errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
