### PR TITLE
Fix copying a deref of a ref.

### DIFF
--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -2417,7 +2417,7 @@ impl<'a, 'b: 'a, 'tcx: 'b, E> MirVisitor<'a, 'b, 'tcx, E> {
             value_map = value_map.insert(qualified_path, value.clone());
             no_children = false;
         }
-        if rtype != ExpressionType::NonPrimitive || (no_children && move_elements) {
+        if rtype != ExpressionType::NonPrimitive || no_children {
             // Just copy/move (rpath, value) itself.
             let value = self.lookup_path_and_refine_result(rpath.clone(), rtype);
             if move_elements {

--- a/checker/tests/run-pass/array_copy.rs
+++ b/checker/tests/run-pass/array_copy.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that checks that arrays passed as parameters are copied
+// A test that checks that fixed size arrays passed as parameters are copied when de-referenced
 #[macro_use]
 extern crate mirai_annotations;
 

--- a/checker/tests/run-pass/deref_param.rs
+++ b/checker/tests/run-pass/deref_param.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that a function can return a copy of its parameter.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn foo<P>(f: &P) -> P
+where
+    P: Copy,
+{
+    *f
+}
+
+pub fn main() {
+    let y = 1;
+    let x = foo(&y);
+    verify!(x == y);
+}


### PR DESCRIPTION
## Description

Path refinement of a variable constructed from a deref path that was done as result of constructing a reference to such a variable, ended up omitting the deref, which breaks copying semantics.
This was masked by another bug, that surfaced when looking at the result of a function that returns the deref or a ref parameter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test; ./validate.sh
new test case
