### PR TITLE
Black list LIBRA crates that currently run out of memory.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -166,6 +166,23 @@ impl MiraiCallbacks {
             || self.file_name.contains("/sled")
             || self.file_name.contains("types/src")
             || self.file_name.contains("/clap")
+            || self.file_name.contains("/grpcio-client")
+            || self.file_name.contains("/datatest-stable")
+            || self.file_name.contains("/crypto")
+            || self.file_name.contains("/ir_to_bytecode/syntax")
+            || self.file_name.contains("/storage_proto")
+            || self.file_name.contains("network/src")
+            || self.file_name.contains("language/compiler/ir_to_bytecode")
+            || self.file_name.contains("mempool/src")
+            || self.file_name.contains("language/stdlib")
+            || self.file_name.contains("language/compiler")
+            || self
+                .file_name
+                .contains("language/stackless_bytecode/bytecode-to-boogie")
+            || self.file_name.contains("client/src")
+            || self.file_name.contains("testsuite/cluster-test")
+            || self.file_name.contains("language/e2e_tests")
+            || self.file_name.contains("language/functional_tests")
         {
             return;
         }
@@ -178,6 +195,9 @@ impl MiraiCallbacks {
         if self.file_name.contains("/crc32fast")
             || self.file_name.contains("/http")
             || self.file_name.contains("/serde_derive")
+            || self
+                .file_name
+                .contains("admission_control/admission_control_proto")
         {
             return;
         }


### PR DESCRIPTION
## Description

In order to get MIRAI into continuous integration testing, it should not crash or hang, so we black list crates that are not currently handled well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
export RUSTFLAGS="-Z always_encode_mir"
cargo clean
cargo build
find . -type f -name lib.rs -exec touch {} \;
RUSTC_WRAPPER=mirai cargo build


