### PR TITLE
Provide a way to discharge preconditions that rely on private state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.4.0",
+ "mirai-annotations 1.5.0",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -297,17 +297,17 @@ dependencies = [
 [[package]]
 name = "mirai-annotations"
 version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mirai-annotations"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.5.0"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.4.0",
+ "mirai-annotations 1.5.0",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/README.md
+++ b/annotations/README.md
@@ -30,6 +30,7 @@ Likewise for postcondition! precondition! and verify!
 
 Additionally we also have:
 * assumed_postcondition! which is an assume at the definition site, rather than a verify.
+* assume_preconditions! which assumes that the caller has satisfied all (inferred) preconditions of the next call.
 * assume_unreachable! which assumes that it is unreachable for reasons beyond what MIRAI can reason about.
 * verify_unreachable! which requires MIRAI to verify that it is not unreachable.
 

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -17,6 +17,22 @@ macro_rules! assume {
     };
 }
 
+/// Equivalent to a no op when used with an unmodified Rust compiler.
+/// When compiled with MIRAI, this causes MIRAI to assume that the preconditions of the next
+/// function call have been met.
+/// This is to be used when the precondition has been inferred and involves private state that
+/// cannot be constrained by a normal assumption.
+/// Note that it is bad style for an API to rely on preconditions that cannot be checked by the
+/// caller, so this is only here for supporting legacy APIs.
+#[macro_export]
+macro_rules! assume_preconditions {
+    () => {
+        if cfg!(mirai) {
+            mirai_annotations::mirai_assume_preconditions()
+        }
+    };
+}
+
 /// Equivalent to the standard assert! when used with an unmodified Rust compiler.
 /// When compiled with MIRAI, this causes MIRAI to assume the condition unless it can
 /// prove it to be false.
@@ -838,6 +854,10 @@ macro_rules! verify_unreachable {
 // Helper function for MIRAI. Should only be called via the assume macros.
 #[doc(hidden)]
 pub fn mirai_assume(_condition: bool) {}
+
+// Helper function for MIRAI. Should only be called via the assume_precondition macro.
+#[doc(hidden)]
+pub fn mirai_assume_preconditions() {}
 
 // Helper function for MIRAI. Should only be called via the postcondition macros.
 #[doc(hidden)]

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -79,6 +79,8 @@ pub enum KnownFunctionNames {
     CoreStrLen,
     /// mirai_annotations.mirai_assume
     MiraiAssume,
+    /// mirai_annotations.mirai_assume_preconditions
+    MiraiAssumePreconditions,
     /// mirai_annotations.mirai_get_model_field
     MiraiGetModelField,
     /// mirai_annotations.mirai_postcondition
@@ -145,6 +147,7 @@ impl ConstantDomain {
             "core.slice.implement.len" => CoreSliceLen,
             "core.str.implement_str.len" => CoreStrLen,
             "mirai_annotations.mirai_assume" => MiraiAssume,
+            "mirai_annotations.mirai_assume_preconditions" => MiraiAssumePreconditions,
             "mirai_annotations.mirai_get_model_field" => MiraiGetModelField,
             "mirai_annotations.mirai_postcondition" => MiraiPostcondition,
             "mirai_annotations.mirai_precondition_start" => MiraiPreconditionStart,

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -45,11 +45,11 @@ fn run_pass() {
 }
 
 fn find_annotations_path() -> String {
-    let mut deps_path = PathBuf::from_str("../target/debug/deps").unwrap();
+    let mut deps_path = PathBuf::from_str("../target/debug").unwrap();
     if !deps_path.exists() {
-        deps_path = PathBuf::from_str("target/debug/deps").unwrap();
+        deps_path = PathBuf::from_str("target/debug").unwrap();
     }
-    for entry in fs::read_dir(deps_path).expect("failed to read target/debug/deps dir") {
+    for entry in fs::read_dir(deps_path).expect("failed to read target/debug dir") {
         let entry = entry.unwrap();
         if !entry.file_type().unwrap().is_file() {
             continue;

--- a/checker/tests/run-pass/assume_preconditions.rs
+++ b/checker/tests/run-pass/assume_preconditions.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that assume_preconditions! works
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn main() {
+    assume_preconditions!();
+    foo(1);
+}
+
+fn foo(i: i32) {
+    precondition!(i != 1);
+}

--- a/validate.sh
+++ b/validate.sh
@@ -35,6 +35,7 @@ cargo uninstall mirai || true
 cargo install --path ./checker
 
 # Run cargo test
+cargo build
 cargo test
 
 # Run mirai on itself


### PR DESCRIPTION
## Description

Inferred preconditions may rely on private state for various reasons. For example, a function may rely on an invariant that is maintained by the abstraction, but which cannot be inferred by MIRAI in its current state. Less wonderfully, a function may also rely on internal state because it expects calls to follow a protocol but does not expose any way to inspect the protocol state. When this happens and the caller code is complicated enough for MIRAI to lose track of the protocol state, there is no way to discharge the precondition by means of an assumption.

To work around all this, it can be useful to just prefix a call to such an API function with the macro assume_preconditions!.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
Added a test case.
