### PR TITLE
If the abstract value TOP is dereferenced, just return TOP.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -660,7 +660,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     #[logfn_inputs(TRACE)]
     fn dereference(&self, target_type: ExpressionType) -> Rc<AbstractValue> {
         match &self.expression {
-            Expression::AbstractHeapAddress(..) => self.clone(),
+            Expression::AbstractHeapAddress(..) | Expression::Bottom | Expression::Top => {
+                self.clone()
+            }
             Expression::Cast {
                 operand,
                 target_type: cast_type,


### PR DESCRIPTION
## Description

The TOP and BOTTOM abstract values can show up pretty much anywhere, so transfer functions such as deref should handle them rather than panic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh running MIRAI on LIBRA