### PR TITLE
Reduce use of references to type context

### DIFF
--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -32,6 +32,6 @@ rand = "*"
 rpds = { version = "*", features = ["serde"] }
 serde = {version = "*", features = ["derive", "alloc", "rc"] }
 tar = "*"
-sled = "*"
+sled = "^0.28.0"
 tempdir = "*"
 z3-sys = "*"

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -137,8 +137,8 @@ impl ConstantDomain {
         function_id: usize,
         def_id: DefId,
         generic_args: SubstsRef<'tcx>,
-        tcx: &'a TyCtxt<'tcx>,
-        summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        tcx: TyCtxt<'tcx>,
+        summary_cache: &mut PersistentSummaryCache<'tcx>,
     ) -> ConstantDomain {
         use KnownFunctionNames::*;
         let summary_cache_key = summary_cache.get_summary_key_for(def_id).to_owned();
@@ -864,13 +864,13 @@ impl<'tcx> ConstantValueCache<'tcx> {
 
     /// Given the MIR DefId of a function return the unique (cached) ConstantDomain that corresponds
     /// to the function identified by that DefId.
-    pub fn get_function_constant_for<'a>(
+    pub fn get_function_constant_for(
         &mut self,
         def_id: DefId,
         ty: Ty<'tcx>,
         generic_args: SubstsRef<'tcx>,
-        tcx: &'a TyCtxt<'tcx>,
-        summary_cache: &mut PersistentSummaryCache<'a, 'tcx>,
+        tcx: TyCtxt<'tcx>,
+        summary_cache: &mut PersistentSummaryCache<'tcx>,
     ) -> &ConstantDomain {
         let function_id = self.function_cache.len();
         self.function_cache.entry((def_id, ty)).or_insert_with(|| {

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -415,7 +415,7 @@ fn extract_reachable_heap_allocations(
 /// A persistent map from summary key to Summary, along with a transient cache from DefId to
 /// Summary. The latter is cleared after every outer fixed point loop iteration.
 /// Also tracks which definitions depend on (use) any particular Summary.
-pub struct PersistentSummaryCache<'a, 'tcx> {
+pub struct PersistentSummaryCache<'tcx> {
     db: Db,
     cache: HashMap<DefId, Summary>,
     typed_cache: HashMap<usize, Summary>,
@@ -423,24 +423,24 @@ pub struct PersistentSummaryCache<'a, 'tcx> {
     typed_reference_cache: HashMap<Rc<FunctionReference>, Summary>,
     dependencies: HashMap<DefId, Vec<DefId>>,
     key_cache: HashMap<DefId, Rc<String>>,
-    type_context: &'a TyCtxt<'tcx>,
+    type_context: TyCtxt<'tcx>,
     pub lock_file: File,
 }
 
-impl<'a, 'tcx> Debug for PersistentSummaryCache<'a, 'tcx> {
+impl<'tcx> Debug for PersistentSummaryCache<'tcx> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         "PersistentSummaryCache".fmt(f)
     }
 }
 
-impl<'a, 'tcx: 'a> PersistentSummaryCache<'a, 'tcx> {
+impl<'a, 'tcx: 'a> PersistentSummaryCache<'tcx> {
     /// Creates a new persistent summary cache, using (or creating) a Sled data base at the given
     /// directory path.
     #[logfn(TRACE)]
     pub fn new(
-        type_context: &'a TyCtxt<'tcx>,
+        type_context: TyCtxt<'tcx>,
         summary_store_directory_str: String,
-    ) -> PersistentSummaryCache<'a, 'tcx> {
+    ) -> PersistentSummaryCache<'tcx> {
         use fs2::FileExt;
         use rand::{thread_rng, Rng};
         use std::path::Path;

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -37,7 +37,7 @@ pub fn find_sysroot() -> String {
 
 /// Returns true if the function identified by def_id is a public function.
 #[logfn(TRACE)]
-pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_>) -> bool {
+pub fn is_public(def_id: DefId, tcx: TyCtxt<'_>) -> bool {
     if let Some(node) = tcx.hir().get_if_local(def_id) {
         match node {
             Node::Expr(rustc::hir::Expr {
@@ -74,7 +74,7 @@ pub fn is_public(def_id: DefId, tcx: &TyCtxt<'_>) -> bool {
 /// the string representations of the given list of generic argument types.
 #[logfn(TRACE)]
 pub fn argument_types_key_str<'tcx>(
-    tcx: &TyCtxt<'tcx>,
+    tcx: TyCtxt<'tcx>,
     generic_args: SubstsRef<'tcx>,
 ) -> Rc<String> {
     let mut result = "_".to_string();
@@ -89,7 +89,7 @@ pub fn argument_types_key_str<'tcx>(
 /// be a valid identifier (so that core library contracts can be written for type specialized
 /// generic trait methods).
 #[logfn(TRACE)]
-fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'tcx>) {
+fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) {
     use syntax::ast;
     use TyKind::*;
     match ty.kind {
@@ -223,7 +223,7 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'tcx>)
             });
         }
         Param(param_ty) => {
-            let pty: Ty<'tcx> = param_ty.to_ty(*tcx);
+            let pty: Ty<'tcx> = param_ty.to_ty(tcx);
             if ty.eq(pty) {
                 str.push_str(&format!("{:?}", ty));
             } else {
@@ -247,7 +247,7 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: &TyCtxt<'tcx>)
 /// Pretty much the same as summary_key_str but with _ used rather than . so that
 /// the result can be appended to a valid identifier.
 #[logfn(TRACE)]
-fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
+fn qualified_type_name(tcx: TyCtxt<'_>, def_id: DefId) -> String {
     let mut name = crate_name(tcx, def_id);
     for component in &tcx.def_path(def_id).data {
         name.push('_');
@@ -263,7 +263,7 @@ fn qualified_type_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
 
 /// Constructs a name for the crate that contains the given def_id.
 #[logfn(TRACE)]
-fn crate_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
+fn crate_name(tcx: TyCtxt<'_>, def_id: DefId) -> String {
     if def_id.is_local() {
         tcx.crate_name.as_interned_str().as_str()
     } else {
@@ -281,7 +281,7 @@ fn crate_name(tcx: &TyCtxt<'_>, def_id: DefId) -> String {
 /// long as the definition does not change its name or location, so it can be used to
 /// transfer information from one compilation to the next, making incremental analysis possible.
 #[logfn(TRACE)]
-pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
+pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
     let mut name = crate_name(tcx, def_id);
     for component in &tcx.def_path(def_id).data {
         if name.ends_with("foreign_contracts") {
@@ -302,7 +302,7 @@ pub fn summary_key_str(tcx: &TyCtxt<'_>, def_id: DefId) -> Rc<String> {
             name.push('_');
             if saw_implement {
                 if let Some(parent_def_id) = tcx.parent(def_id) {
-                    if let Some(ty) = type_of(*tcx, parent_def_id) {
+                    if let Some(ty) = type_of(tcx, parent_def_id) {
                         append_mangled_type(&mut name, ty, tcx);
                         continue;
                     }

--- a/validate.sh
+++ b/validate.sh
@@ -11,7 +11,7 @@ cargo clean -p mirai
 # Run format checks
 cargo fmt --all
 # Run lint checks
-#cargo audit
+cargo audit
 cargo clippy -- -D warnings
 # Build
 cd checker; cargo rustc --lib -- -D rust-2018-idioms


### PR DESCRIPTION
## Description

Clippy frowns on passing 8 byte structs by reference, so don't do that. This requires the code to be more careful with lifetime annotations, so try to clarify those.

Also avoid updating sled until the latest version is more stable and uncomment cargo audit check.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh