### PR TITLE
Create separate note for each related location.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode/
 .idea/
 target/

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -613,6 +613,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             Expression::BitXor { left, right } => left
                 .try_to_retype_as(target_type)
                 .bit_xor(right.try_to_retype_as(target_type)),
+            Expression::Cast {
+                operand,
+                target_type: tt,
+            } if *tt == ExpressionType::Reference => operand.try_to_retype_as(target_type),
             Expression::ConditionalExpression {
                 condition,
                 consequent,

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -241,17 +241,6 @@ impl MiraiCallbacks {
         analysis_info: &mut AnalysisInfo<'analysis, 'tcx>,
         def_id: DefId,
     ) {
-        // No need to analyze a body for which we already have a non default summary.
-        // We do, however, have to allow local foreign contract functions to override
-        // the standard summaries that are already in the cache.
-        if !utils::is_foreign_contract(tcx, def_id) {
-            let summary = analysis_info
-                .persistent_summary_cache
-                .get_summary_for(def_id, None);
-            if summary.is_not_default {
-                return;
-            }
-        }
         let name = MiraiCallbacks::get_and_log_name(
             &mut analysis_info.persistent_summary_cache,
             analysis_info.analyze_single_func.is_none(),
@@ -264,7 +253,19 @@ impl MiraiCallbacks {
             if *fname != name.to_string() {
                 return;
             }
-        };
+        } else {
+            // No need to analyze a body for which we already have a non default summary.
+            // We do, however, have to allow local foreign contract functions to override
+            // the standard summaries that are already in the cache.
+            if !utils::is_foreign_contract(tcx, def_id) {
+                let summary = analysis_info
+                    .persistent_summary_cache
+                    .get_summary_for(def_id, None);
+                if summary.is_not_default {
+                    return;
+                }
+            }
+        }
         let mut buffered_diagnostics: Vec<DiagnosticBuilder<'_>> = vec![];
         Self::visit_body(
             def_id,

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -645,12 +645,6 @@ impl<'a, 'tcx: 'a> PersistentSummaryCache<'tcx> {
                     self.cache.entry(def_id).or_insert_with(|| {
                         let summary =
                             Self::get_persistent_summary_for_db(db, &func_ref.summary_cache_key);
-                        if !def_id.is_local() && summary.is_none() {
-                            info!(
-                                "Summary store has no entry for {}{}",
-                                &func_ref.summary_cache_key, &func_ref.argument_type_key
-                            );
-                        };
                         summary.unwrap_or_default()
                     })
                 }

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -66,7 +66,6 @@ pub fn is_public(def_id: DefId, tcx: TyCtxt<'_>) -> bool {
             }
         }
     } else {
-        debug!("def_id is not local {}", summary_key_str(tcx, def_id));
         false
     }
 }

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -1748,8 +1748,8 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         }
         let span = self.current_span;
         let mut err = self.session.struct_span_warn(span, diagnostic.as_str());
-        if !precondition.spans.is_empty() {
-            err.span_note(precondition.spans.clone(), "related location");
+        for pc_span in precondition.spans.iter() {
+            err.span_note(pc_span.clone(), "related location");
         }
         self.emit_diagnostic(err);
     }


### PR DESCRIPTION
## Description

1. Create a separate note child for each location in the call stack that led to an inferred precondition. This is needed to prevent rustc from rearranging the source locations.
2. Fix things so that the single func analysis option works in conjunction with saved summaries from a previous run.
3. Look inside cast expressions when trying to harmonize the types of binary operations used in conditional expression conditions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh