### PR TITLE
Make unanalyzable functions "Angelic"

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -130,14 +130,6 @@ impl MiraiCallbacks {
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.
     #[logfn(TRACE)]
     fn analyze_with_mirai(&mut self, compiler: &interface::Compiler, tcx: TyCtxt<'_>) {
-        if self.file_name.contains("/compiler")
-            || self.file_name.contains("/ir-to-bytecode")
-            || self.file_name.contains("/libradb")
-            || self.file_name.contains("/noise")
-            || self.file_name.contains("/stdlib")
-        {
-            return;
-        }
         let output_dir = String::from(self.output_directory.to_str().expect("valid string"));
         let summary_store_path = if std::env::var("MIRAI_SHARE_PERSISTENT_STORE").is_ok() {
             output_dir

--- a/checker/tests/run-pass/array_access_with_unwind.rs
+++ b/checker/tests/run-pass/array_access_with_unwind.rs
@@ -6,9 +6,28 @@
 
 // A test that needs to do cleanup if an array access is out of bounds.
 
+#![allow(non_snake_case)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub mod foreign_contracts {
+    pub mod core {
+        pub mod convert {
+            pub mod From {
+                pub fn from() -> String {
+                    result!()
+                }
+            }
+        }
+    }
+}
+
 pub fn foo(arr: &mut [i32], i: usize) -> String {
     arr[i] = 123; //~ possible index out of bounds
-    let result = String::from("foo");
-    let _e = arr[i]; // no warning here because we can't get here unless line 10 succeeded
+    let result = String::from("foo"); // allocate something that needs explicit cleanup
+    let _e = arr[i]; // no warning here because we can't get here unless line 27 succeeded
     result
 }
+
+pub fn main() {}

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -744,6 +744,10 @@ pub mod std {
 }
 
 pub mod alloc {
+    pub mod alloc {
+        pub fn box_free() {}
+    }
+
     pub mod slice {
         use crate::foreign_contracts::alloc::vec::Vec;
 


### PR DESCRIPTION
## Description

A function that contains calls to other functions for which no body can be obtained and for which no summary has been provided via the standard summary store or the foreign_contracts mechanism cannot be accurately analyzed, leading to many false positives. Right now, the sheer number of messages that are meaningless and hard to make go away are a barrier to adoption.

Consequently "unanalyzable" functions are now marked as "angelic" (which is to say, we simply assume that they are correctly implemented). Any function that calls an angelic function itself becomes angelic, because the lack of post conditions from the angelic call makes the analysis of the caller inaccurate and noisy.

Needless to say, MIRAI now finds very few issues. With time this will improve as more functions without bodies are eliminated either by the top down analysis phase, or by explicit models.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
export RUSTFLAGS="-Z always_encode_mir"
cargo clean
cargo build
find . -type f -name lib.rs -exec touch {} ;
RUSTC_WRAPPER=mirai cargo build

