### PR TITLE
Analyze function bodies in the context of actual function parameters.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -324,6 +324,6 @@ impl MiraiCallbacks {
             smt_solver: &mut smt_solver,
             buffered_diagnostics: &mut buffered_diagnostics,
         });
-        mir_visitor.visit_body(&name);
+        mir_visitor.visit_body(&name, &[]);
     }
 }

--- a/checker/tests/run-pass/func_params.rs
+++ b/checker/tests/run-pass/func_params.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a function parameter
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn bar(x: Option<i32>, j: i32) -> Option<i32> {
+    match x {
+        Some(i) => Some(i << 1),
+        None => Some(j),
+    }
+}
+
+fn bas(x: Option<i32>, j: i32) -> Option<i32> {
+    match x {
+        Some(i) => Some(i << 2),
+        None => Some(j),
+    }
+}
+
+fn foo(f: fn(Option<i32>, i32) -> Option<i32>) -> Option<i32> {
+    f(Some(1), 1)
+}
+
+pub fn main() {
+    let fbar = foo(bar);
+    verify!(fbar.unwrap() == 2);
+    let fbas = foo(bas);
+    verify!(fbas.unwrap() == 4);
+}


### PR DESCRIPTION
## Description

Higher order functions are difficult to summarize accurately when only the type of the function parameter is known. Doing this bottom up via delayed (uninterpreted) calls requires intricate book keeping and is likely a source of subtle performance and correctness bugs.

Now that we analyze top down, we can create a separate summary for each higher order function, actual function arguments combination. Caching the specialized summaries avoids exponential blow-up.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
export RUSTFLAGS="-Z always_encode_mir"
cargo clean
cargo build
find . -type f -name lib.rs -exec touch {} \\;
RUSTC_WRAPPER=mirai cargo build

