### PR TITLE
Add simplifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,7 +334,7 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -540,8 +545,11 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "static_assertions"
@@ -705,6 +713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum log-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "af5ac4192220bd122fe6589742bf3873f7207ef5f39d82d036b424448f3434c7"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a85c1a8c329f11437034d7313dca647c79096523533a1c79e86f1d0f657c7cc"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
@@ -735,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum sled 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7c3453de0f6a77abdd17cc9f68d6650214abd088b052b13302f86fa9a5b286e"
-"checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
+"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"

--- a/checker/tests/run-pass/simplify.rs
+++ b/checker/tests/run-pass/simplify.rs
@@ -9,11 +9,93 @@
 #[macro_use]
 extern crate mirai_annotations;
 
-pub fn main() {
-    foo(true);
-}
-
-fn foo(b: bool) {
+pub fn f1(b: bool) {
     verify!(b || !b);
     verify!(!b || b);
 }
+
+pub fn f2(x: bool, y: bool) {
+    let z = (x || y) && x;
+    verify!(z == x);
+    let z = (x || y) && y;
+    verify!(z == y);
+}
+
+pub fn f3(x: bool, y: bool) {
+    let z = (x || y) && (!x);
+    verify!(z == y);
+}
+
+pub fn f4(x: bool, y: bool) {
+    let z = (x || y) && (!y);
+    verify!(z == x);
+}
+
+pub fn f5(x: bool, y: bool) {
+    let z = (x && y) || x;
+    verify!(z == x);
+}
+
+pub fn f6(x: bool, y: bool) {
+    let z = (x && y) || y;
+    verify!(z == y);
+}
+
+pub fn f7(x: bool, y: bool) {
+    let z = (x && !y) || y;
+    verify!(z == (y || x));
+}
+
+pub fn f8(x: bool, y: bool, a: i32, b: i32) {
+    let z = if x || y {
+        if x {
+            a
+        } else {
+            b
+        }
+    } else {
+        b
+    };
+    verify!(z == if x { a } else { b });
+}
+
+pub fn f9(x: bool, y: bool, a: i32, b: i32) {
+    let z = if x || y {
+        if y {
+            a
+        } else {
+            b
+        }
+    } else {
+        b
+    };
+    verify!(z == if y { a } else { b });
+}
+
+pub fn f10(x: bool, y: bool, a: i32, b: i32) {
+    let z = if x || y {
+        if x {
+            a
+        } else {
+            b
+        }
+    } else {
+        a
+    };
+    verify!(z == if y { b } else { a });
+}
+
+pub fn f11(x: bool, y: bool, a: i32, b: i32) {
+    let z = if x || y {
+        if y {
+            a
+        } else {
+            b
+        }
+    } else {
+        a
+    };
+    verify!(z == if x { b } else { a });
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

The joining logic of the abstract interpreter, together with summary specialization result in many expressions that can be trivially simplified via pattern matching. This helps to reduce memory usage and prevent expressions from being prematurely widened, which speeds things up and helps precise reasoning when using Z3 to discharge proof obligations.

The simplification rules are necessarily ad-hoc and interact with each other in unpredictable ways, so expect lots of tweaking here.

Also, although the rules are mostly trivial, it is also easy to get them wrong, so please pay close attention to the comments that summarize the rules to see if a logic mistake has crept in.

I'm doing these additions now because they came up during debugging, when it really helps to have simple expressions.

I'll need them in future PRs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
New test cases
