### PR TITLE
Do not make integer to integer casts into uninterpreted Z3 expressions

### DIFF
--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -722,7 +722,10 @@ impl Z3Solver {
                 operand,
                 result_type,
             } => self.numeric_bitwise_not(operand, result_type),
-            Expression::Cast { target_type, .. } => self.numeric_cast(expression, target_type),
+            Expression::Cast {
+                operand,
+                target_type,
+            } => self.numeric_cast(&operand.expression, target_type),
             Expression::CompileTimeConstant(const_domain) => {
                 self.numeric_const(expression, const_domain)
             }
@@ -943,10 +946,16 @@ impl Z3Solver {
                     true,
                     z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.f64_sort),
                 ),
-                _ => (
-                    false,
-                    z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
-                ),
+                _ => {
+                    if target_type.is_integer() {
+                        self.get_as_numeric_z3_ast(expression)
+                    } else {
+                        (
+                            false,
+                            z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.int_sort),
+                        )
+                    }
+                }
             }
         }
     }

--- a/checker/tests/run-pass/cast.rs
+++ b/checker/tests/run-pass/cast.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a cast in a verify condition.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn foo(i: u16) {
+    if i > 16 {
+        verify!((i as usize) > 16);
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Z3 treats all integers as the same type, so integer to integer casts are just no-ops.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
New test case
