### PR TITLE
Keep track of generic arguments

### DIFF
--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -54,8 +54,8 @@ impl Debug for ConstantDomain {
             ConstantDomain::Char(ch) => f.write_fmt(format_args!("'{}'", ch)),
             ConstantDomain::False => f.write_str("false"),
             ConstantDomain::Function(func_ref) => f.write_fmt(format_args!(
-                "fn {}{}",
-                func_ref.summary_cache_key, func_ref.argument_type_key
+                "fn {}{}<{:?}>",
+                func_ref.summary_cache_key, func_ref.argument_type_key, func_ref.generic_arguments
             )),
             ConstantDomain::I128(val) => val.fmt(f),
             ConstantDomain::F64(val) => (f64::from_bits(*val)).fmt(f),
@@ -171,8 +171,8 @@ impl ConstantDomain {
             "core.future.from_generator" | "std.future.from_generator" => StdFutureFromGenerator,
             "core.ops.deref.Deref.deref"
             | "std.ops.deref.Deref.deref"
-            | "core.ops.deref.Deref.deref_mut"
-            | "std.ops.deref.Deref.deref_mut" => StdOpsDeref,
+            | "core.ops.deref.DerefMut.deref_mut"
+            | "std.ops.deref.DerefMut.deref_mut" => StdOpsDeref,
             "core.panicking.panic" | "std.panicking.begin_panic" => StdBeginPanic,
             "core.panicking.panic_fmt" | "std.panicking.begin_panic_fmt" => StdBeginPanicFmt,
             "core.intrinsics._1.transmute" | "std.intrinsics._1.transmute" => {


### PR DESCRIPTION
## Description

A generic parameter expression by itself infers to ExpressionType::NonPrimitive, which is often the wrong thing and can lead to conditional expressions with inconsistent types for the consequent and alternate expressions. This, in turn, can lead to proof conditions for Z3 that it rejects (angrily by terminating the process), which is a pretty bad thing.

Keeping track of the generic type arguments that were supplied to the call site of a function that is analyzed on demand allows the inference to be more precise and consistent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
Ran MIRAI on LIBRA and observed that no inconsistent types for conditional expressions are reported in the log output.

