### PR TITLE
Use first actual argument type to devirtualize calls

### DIFF
--- a/checker/tests/run-pass/virtual_call.rs
+++ b/checker/tests/run-pass/virtual_call.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses built-in contracts for the Vec struct.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn main() {
+    let x = 1;
+    let f = || x << 1;
+    let g = f();
+    verify!(g == 2);
+}


### PR DESCRIPTION
## Description

Calls to trait methods need to be re-bound to the actual implementation of the method that is appropriate for the actual self argument.

This involves querying the rust compiler type system, which is a bit involved at the moment, so this is only a small part of the overall task.

What is provided in the PR is a somewhat inefficient way of devirtualizing calls to closures made via core.ops.function.Fn(Mut|Once).call.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
running MIRAI over LIBRA
