### PR TITLE
Enabling multiple post conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "contracts"
 version = "0.3.0"
-source = "git+https://gitlab.com/wrwg/contracts.git?branch=mirai#ec1d797121aa76e513e09db8962c84f889591f90"
+source = "git+https://gitlab.com/wrwg/contracts.git?branch=mirai#07cf1b8b0e67f7c1b905c9c901beb11ceeff71cc"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -124,7 +124,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -156,7 +156,7 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -277,7 +277,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memoffset"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -309,7 +309,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.5.0",
+ "mirai-annotations 1.5.1",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -322,13 +322,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.5.0"
+version = "1.5.1"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.5.0",
+ "mirai-annotations 1.5.1",
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
  "contracts 0.3.0 (git+https://gitlab.com/wrwg/contracts.git?branch=mirai)",
- "mirai-annotations 1.5.0",
+ "mirai-annotations 1.5.1",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -646,7 +646,7 @@ dependencies = [
 name = "taint-error"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.5.0",
+ "mirai-annotations 1.5.1",
 ]
 
 [[package]]
@@ -654,7 +654,7 @@ name = "tar"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -781,7 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 "checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
+"checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -796,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "af5ac4192220bd122fe6589742bf3873f7207ef5f39d82d036b424448f3434c7"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a85c1a8c329f11437034d7313dca647c79096523533a1c79e86f1d0f657c7cc"
+"checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
@@ -832,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
+"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -166,17 +166,17 @@ macro_rules! debug_checked_assume_ne {
 #[macro_export]
 macro_rules! postcondition {
     ($condition:expr) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_postcondition($condition, false, "unsatisfied postcondition")
+        #[cfg(mirai)] {
+            mirai_annotations::mirai_postcondition($condition, false, "unsatisfied postcondition");
         }
     };
     ($condition:expr, $message:literal) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", $message))
+        #[cfg(mirai)] {
+            mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", $message));
         }
     };
     ($condition:expr, $($arg:tt)*) => {
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", stringify!($($arg)*)));
         }
     };
@@ -189,7 +189,8 @@ macro_rules! postcondition {
 #[macro_export]
 macro_rules! assumed_postcondition {
     ($condition:expr) => {
-        if cfg!(mirai) {
+        #[cfg(mirai)]
+        {
             mirai_annotations::mirai_postcondition($condition, true, "")
         }
     };
@@ -202,26 +203,29 @@ macro_rules! assumed_postcondition {
 #[macro_export]
 macro_rules! checked_postcondition {
     ($condition:expr) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  "unsatisfied postcondition")
-        } else {
+        }
+        #[cfg(not(mirai))] {
             assert!($condition);
         }
     );
-    ($condition:expr, $message:literal) => (
-        if cfg!(mirai) {
+    ($condition:expr, $message:literal) => {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", $message))
-        } else {
+        }
+        #[cfg(not(mirai))] {
             assert!($condition, $message);
         }
-    );
-    ($condition:expr, $($arg:tt)*) => (
-        if cfg!(mirai) {
+    };
+    ($condition:expr, $($arg:tt)*) => {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", stringify!($($arg)*)));
-        } else {
+        }
+        #[cfg(not(mirai))] {
             assert!($condition, $($arg)*);
         }
-    );
+    };
 }
 
 /// Equivalent to the standard assert_eq! when used with an unmodified Rust compiler.
@@ -289,23 +293,26 @@ macro_rules! checked_postcondition_ne {
 #[macro_export]
 macro_rules! debug_checked_postcondition {
     ($condition:expr) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  "unsatisfied postcondition")
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert!($condition);
         }
     );
     ($condition:expr, $message:literal) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", $message))
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert!($condition, $message);
         }
     );
     ($condition:expr, $($arg:tt)*) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($condition, false,  concat!("unsatisfied postcondition: ", stringify!($($arg)*)));
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert!($condition, $($arg)*);
         }
     );
@@ -318,23 +325,26 @@ macro_rules! debug_checked_postcondition {
 #[macro_export]
 macro_rules! debug_checked_postcondition_eq {
     ($left:expr, $right:expr) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($left == $right, false,  concat!("unsatisfied postcondition: ", stringify!($left == $right)))
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert_eq!($left, $right);
         }
     );
     ($left:expr, $right:expr, $message:literal) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($left == $right, false,  concat!("unsatisfied postcondition: ", stringify!($left == $right), ", ", $message))
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert_eq!($left, $right, $message);
         }
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($left == $right, false,  concat!("unsatisfied postcondition: ", stringify!($left == $right), ", ", stringify!($($arg)*)));
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert_eq!($left, $right, $($arg)*);
         }
     );
@@ -347,23 +357,26 @@ macro_rules! debug_checked_postcondition_eq {
 #[macro_export]
 macro_rules! debug_checked_postcondition_ne {
     ($left:expr, $right:expr) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($left != $right, false,  concat!("unsatisfied postcondition: ", stringify!($left != $right)))
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert_ne!($left, $right);
         }
     );
     ($left:expr, $right:expr, $message:literal) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($left != $right, false,  concat!("unsatisfied postcondition: ", stringify!($left != $right), ", ", $message))
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert_ne!($left, $right, $message);
         }
     );
     ($left:expr, $right:expr, $($arg:tt)*) => (
-        if cfg!(mirai) {
+        #[cfg(mirai)] {
             mirai_annotations::mirai_postcondition($left != $right, false,  concat!("unsatisfied postcondition: ", stringify!($left != $right), ", ", stringify!($($arg)*)));
-        } else {
+        }
+        #[cfg(not(mirai))] {
             debug_assert_ne!($left, $right, $($arg)*);
         }
     );

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -87,6 +87,7 @@ pub struct MirVisitor<'analysis, 'compilation, 'tcx, E> {
     generic_arguments: Option<Vec<ExpressionType>>,
     heap_addresses: HashMap<mir::Location, Rc<AbstractValue>>,
     post_condition: Option<Rc<AbstractValue>>,
+    post_condition_block: Option<mir::BasicBlock>,
     preconditions: Vec<Precondition>,
     unwind_condition: Option<Rc<AbstractValue>>,
     unwind_environment: Environment,
@@ -111,6 +112,7 @@ struct SavedVisitorState<'analysis, 'tcx> {
     generic_arguments: Option<Vec<ExpressionType>>,
     heap_addresses: HashMap<mir::Location, Rc<AbstractValue>>,
     post_condition: Option<Rc<AbstractValue>>,
+    post_condition_block: Option<mir::BasicBlock>,
     preconditions: Vec<Precondition>,
     unwind_condition: Option<Rc<AbstractValue>>,
     unwind_environment: Environment,
@@ -137,6 +139,7 @@ impl<'analysis, 'tcx> SavedVisitorState<'analysis, 'tcx> {
             generic_arguments: None,
             heap_addresses: HashMap::default(),
             post_condition: None,
+            post_condition_block: None,
             preconditions: Vec::new(),
             unwind_condition: None,
             unwind_environment: Environment::default(),
@@ -216,6 +219,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
             generic_arguments: None,
             heap_addresses: HashMap::default(),
             post_condition: None,
+            post_condition_block: None,
             preconditions: Vec::new(),
             unwind_condition: None,
             unwind_environment: Environment::default(),
@@ -239,6 +243,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         self.generic_arguments = None;
         self.heap_addresses = HashMap::default();
         self.post_condition = None;
+        self.post_condition_block = None;
         self.preconditions = Vec::new();
         self.unwind_condition = None;
         self.unwind_environment = Environment::default();
@@ -287,6 +292,10 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         );
         std::mem::swap(&mut self.heap_addresses, &mut saved_state.heap_addresses);
         std::mem::swap(&mut self.post_condition, &mut saved_state.post_condition);
+        std::mem::swap(
+            &mut self.post_condition_block,
+            &mut saved_state.post_condition_block,
+        );
         std::mem::swap(&mut self.preconditions, &mut saved_state.preconditions);
         std::mem::swap(
             &mut self.unwind_condition,
@@ -2166,24 +2175,16 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
                 }
             }
             KnownFunctionNames::MiraiPostcondition => {
-                let extend_post_condition = |current: &Option<Rc<AbstractValue>>, cond| {
-                    if let Some(current_cond) = current {
-                        Some(current_cond.and(cond))
-                    } else {
-                        Some(cond)
-                    }
-                };
                 assume!(actual_args.len() == 3); // The type checker ensures this.
                 let (_, assumption) = &actual_args[1];
                 let (_, cond) = &actual_args[0];
                 if !assumption.as_bool_if_known().unwrap_or(false) {
                     let message = self.coerce_to_string(&actual_args[2].1);
                     if self.check_condition(cond, message, true).is_none() {
-                        self.post_condition =
-                            extend_post_condition(&self.post_condition, cond.clone());
+                        self.try_extend_post_condition(&cond);
                     }
                 } else {
-                    self.post_condition = extend_post_condition(&self.post_condition, cond.clone());
+                    self.try_extend_post_condition(&cond);
                 }
             }
             KnownFunctionNames::MiraiVerify => {
@@ -2282,6 +2283,32 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
                 }
             }
             _ => assume_unreachable!(),
+        }
+    }
+
+    fn try_extend_post_condition(&mut self, cond: &Rc<AbstractValue>) {
+        let this_block = self.current_location.block;
+        match (self.post_condition.clone(), self.post_condition_block) {
+            (Some(last_cond), Some(last_block)) => {
+                let dominators = self.mir.dominators();
+                if dominators.is_dominated_by(this_block, last_block) {
+                    // We can extend the last condition as all paths to this condition
+                    // lead over it
+                    self.post_condition = Some(last_cond.and(cond.clone()));
+                    self.post_condition_block = Some(this_block);
+                } else {
+                    let span = self.current_span;
+                    let warning = self.session.struct_span_warn(
+                        span,
+                        "multiple post conditions must be on the same execution path",
+                    );
+                    self.emit_diagnostic(warning);
+                }
+            }
+            (_, _) => {
+                self.post_condition = Some(cond.clone());
+                self.post_condition_block = Some(this_block);
+            }
         }
     }
 

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -2286,6 +2286,10 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         }
     }
 
+    /// Extend the current post condition by the given `cond`. If none was set before,
+    /// this will just set it for the first time. If there is already a post condition.
+    /// we check whether it is safe to extend it. It is considered safe if the block where
+    /// it was set dominates the existing one.
     fn try_extend_post_condition(&mut self, cond: &Rc<AbstractValue>) {
         let this_block = self.current_location.block;
         match (self.post_condition.clone(), self.post_condition_block) {

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -2166,23 +2166,24 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
                 }
             }
             KnownFunctionNames::MiraiPostcondition => {
-                if self.post_condition.is_some() {
-                    let span = self.current_span;
-                    let warning = self
-                        .session
-                        .struct_span_warn(span, "only one post condition is supported");
-                    self.emit_diagnostic(warning);
-                }
+                let extend_post_condition = |current: &Option<Rc<AbstractValue>>, cond| {
+                    if let Some(current_cond) = current {
+                        Some(current_cond.and(cond))
+                    } else {
+                        Some(cond)
+                    }
+                };
                 assume!(actual_args.len() == 3); // The type checker ensures this.
                 let (_, assumption) = &actual_args[1];
                 let (_, cond) = &actual_args[0];
                 if !assumption.as_bool_if_known().unwrap_or(false) {
                     let message = self.coerce_to_string(&actual_args[2].1);
                     if self.check_condition(cond, message, true).is_none() {
-                        self.post_condition = Some(cond.clone());
+                        self.post_condition =
+                            extend_post_condition(&self.post_condition, cond.clone());
                     }
                 } else {
-                    self.post_condition = Some(cond.clone());
+                    self.post_condition = extend_post_condition(&self.post_condition, cond.clone());
                 }
             }
             KnownFunctionNames::MiraiVerify => {

--- a/checker/tests/run-pass/contract_annotations.rs
+++ b/checker/tests/run-pass/contract_annotations.rs
@@ -94,8 +94,7 @@ struct S {
     x: i32,
 }
 
-#[debug_invariant(self.x > 0)] //~ only one post condition is supported
-                               //~ related location
+#[debug_invariant(self.x > 0)] //~ related location
 impl S {
     #[pre(self.x < std::i32::MAX)]
     #[post(ret == old(self.x))]

--- a/checker/tests/run-pass/post_conditions.rs
+++ b/checker/tests/run-pass/post_conditions.rs
@@ -24,14 +24,44 @@ pub fn foo(bl: Block) {
     verify!(ret < std::u64::MAX - 1);
 }
 
-pub fn bar(c: bool) -> u64 {
+pub fn non_joinable_post(c: bool) -> u64 {
     let result = result!();
     if c {
+        //~ multiple post conditions must be on the same execution path
         assumed_postcondition!(result < 5);
     } else {
         assumed_postcondition!(result > 10);
     }
     result
+}
+
+pub fn joinable_post() -> u64 {
+    let result = result!();
+    assumed_postcondition!(result > 0);
+    assumed_postcondition!(result < 10);
+    assumed_postcondition!(result % 2 == 0);
+    result
+}
+
+pub fn test_joinable_post() {
+    let x = joinable_post();
+    // TODO: the below currently fails. However, apparently this is not related
+    // to the post-condition feature but to the result! macro, as joinable_post_v2
+    // illustrates, which does the same wo/ result!
+    verify!(x > 0 && x < 12 && x % 2 == 0); //~ possible false verification condition
+}
+
+pub fn joinable_post_v2(x: u64) -> u64 {
+    let y = x;
+    assumed_postcondition!(y > 0);
+    assumed_postcondition!(y < 10);
+    assumed_postcondition!(y % 2 == 0);
+    return y;
+}
+
+pub fn test_joinable_post_v2(x: u64) {
+    let y = joinable_post_v2(x);
+    verify!(y > 0 && y < 12 && y % 2 == 0);
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/post_conditions.rs
+++ b/checker/tests/run-pass/post_conditions.rs
@@ -24,12 +24,12 @@ pub fn foo(bl: Block) {
     verify!(ret < std::u64::MAX - 1);
 }
 
-pub fn bad(c: bool) -> u64 {
+pub fn bar(c: bool) -> u64 {
     let result = result!();
     if c {
         assumed_postcondition!(result < 5);
     } else {
-        assumed_postcondition!(result > 10); //~ only one post condition is supported
+        assumed_postcondition!(result > 10);
     }
     result
 }


### PR DESCRIPTION
## Description

This enables multiple post conditions provided they appear in the same execution path. Thus this allows something like:

    fn f(...) {
      ...
      post
      ...
      post
    }

... but disallows:

    fn f(...) {
      ...
      if ... {
        ...
        post
      } else {
        ...
        post
      }

The implementation uses the MIR control graph's `is_dominated_by` relation to determine whether a postcondition can be extended on the same execution path. Thus it is relative general.

The mirai_annotations for postconditions needed to be changed to make this work. It turns out that a mirai macro expands to something like `if true { ... } else { ... }`, which is not eliminated in the MIR, and not reflected in the dominator relation either. We now use conditional compilation via `#[cfg(mirai)]` for all post condition macros. We don't use it for other macros because using conditional compilation should be avoided as it does not type check the full source. (The `if false` will be certainly easily eliminated in backends.)

New tests have been added and warnings have been removed from existing tests.

There are a few followup issues coming out of this PR:

- We need to further restrict placement of post conditions. Essentially, any return point needs to be 
   checked for whether the post condition dominates it. Fortunately, as we now store the basic block
   of the last post condition, this can be easily done ("self.post_condition_block must dominate every 
   exit point").

- It appears that `result!` is not working as expected. See comments in test `post_conditions.rs`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

New test cases.
