### PR TITLE
Update documentation

### DIFF
--- a/documentation/InstallationGuide.md
+++ b/documentation/InstallationGuide.md
@@ -58,7 +58,7 @@ where /r c:\ mirai.exe
 If you just want to use MIRAI you can simply do:
 ```
 # Remember to rustup set override nightly-YYYY-MM-DD in this directory (or a parent)
-cargo install --git https://github.com/facebookexperimental/MIRAI
+cargo install --git https://github.com/facebookexperimental/MIRAI mirai --force
 ```
 
 ## Contributing to MIRAI


### PR DESCRIPTION
## Description

The cargo installation step in the documentation now has to take into account that building the project now produces more than one binary.

Fixes #361 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
Ran the new command on my Mac laptop and it worked.
