### PR TITLE
Enabling analysis of tests, plus turning angelic treatment off.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "archery"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +80,20 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +104,7 @@ dependencies = [
 [[package]]
 name = "contracts"
 version = "0.3.0"
-source = "git+https://gitlab.com/wrwg/contracts.git?branch=mirai#c8d083074e022eb23887714718297f014d5762c8"
+source = "git+https://gitlab.com/karroffel/contracts.git#c8d083074e022eb23887714718297f014d5762c8"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,6 +182,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +260,14 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,16 +328,20 @@ name = "mirai"
 version = "1.0.5"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "contracts 0.3.0 (git+https://gitlab.com/wrwg/contracts.git?branch=mirai)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "contracts 0.3.0 (git+https://gitlab.com/karroffel/contracts.git)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.5.1",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shellwords 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sled 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -561,10 +600,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellwords"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
- "contracts 0.3.0 (git+https://gitlab.com/wrwg/contracts.git?branch=mirai)",
+ "contracts 0.3.0 (git+https://gitlab.com/karroffel/contracts.git)",
  "mirai-annotations 1.5.1",
 ]
 
@@ -598,6 +646,11 @@ dependencies = [
 [[package]]
 name = "static_assertions"
 version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -668,12 +721,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
@@ -683,6 +749,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -751,6 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum archery 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d308d8fa3f687f7a7588fccc4812ed6914be09518232f00454693a7417273ad2"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
@@ -760,8 +832,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum contracts 0.3.0 (git+https://gitlab.com/wrwg/contracts.git?branch=mirai)" = "<none>"
+"checksum contracts 0.3.0 (git+https://gitlab.com/karroffel/contracts.git)" = "<none>"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
@@ -769,6 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 "checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 "checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -778,6 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
@@ -816,18 +891,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 "checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
+"checksum shellwords 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "685f0e9b0efe23d26e60a780d8dcd3ac95e90975814de9bc6f48e5d609b5d0f5"
 "checksum sled 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7c3453de0f6a77abdd17cc9f68d6650214abd088b052b13302f86fa9a5b286e"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,29 @@ At this stage your code will be better documented and more readable. Perhaps you
 Set the verbosity level of output from MIRAI by setting the environment variable `MIRAI_LOG` to one of
 `info`, `warn`, `debug`, or `trace`.
 
-To go beyond this, super lint + better documentation phase, you'll need to be aware of a lot more things.
+You can also use the environment variable `MIRAI_FLAGS` to provide options to MIRAI. The value is a string which
+can contain any of the following flags:
+
+- `--test_only`: instructs MIRAI to analyze only test methods in your crate. You must also provide the `--tests`
+  option to the `cargo build` command to include those tests actually into your build.
+- `--diag=relaxed|strict`: configures level of diagnostics. With `relaxed` (the default) MIRAI
+   will not report errors which are potential 'false positives'. With `strict` it will
+   report such errors. 
+- `--single_func <name>`: the name of a specific function you want to analyze. 
+- `--`: any arguments after this marker are passed on to rustc.
+
+A more comprehensive command line interface for MIRAI is planned, but currently not implemented.
+
+## Using MIRAI together with the contracts crate
+
+Preliminary support for MIRAI is available in the [contracts crate](https://gitlab.com/karroffel/contracts). There
+is currently no official release containing this support on crates.io, so you must directly refer to the gitlab
+repo using a dependency like below in your Cargo.toml:
+```toml
+contracts = { git = "https://gitlab.com/karroffel/contracts.git", branch = "master", features = [ "mirai_assertions" ]}
+```
+
+See the shopping cart example for usage.
 
 ## Developing MIRAI
 See the [developer guide](https://github.com/facebookexperimental/MIRAI/blob/master/documentation//DeveloperGuide.md)

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -22,22 +22,26 @@ doctest = false # and no doc tests
 
 [dependencies]
 bincode = { version = "*", features = ["i128"] }
+clap = "*"
 env_logger = "*"
 fs2 = "*"
 lazy_static = "*"
 log = "*"
 log-derive = "*"
 mirai-annotations = { path = "../annotations" }
+itertools = "*"
 rand = "*"
 rpds = { version = "*", features = ["serde"] }
 serde = {version = "*", features = ["derive", "alloc", "rc"] }
 tar = "*"
 sled = "*"
+shellwords = "*"
 tempdir = "*"
 z3-sys = "*"
+regex = "*"
 
 [dev-dependencies]
-walkdir = "2"
+walkdir = "*"
 
 # Dependencies for tests which aren't already included by the checker.
 # Note if you add one here it also needs to be added to the command line
@@ -46,4 +50,4 @@ walkdir = "2"
 # or similar, and to integration_tests.rs (search for extern_deps there).
 # We set the dep to a specific revision so we don't get paths as above not longer working after update of the repo
 # and the Cargo.lock.
-contracts = { git = "https://gitlab.com/wrwg/contracts.git", branch = "mirai", features = [ "mirai_assertions" ]}
+contracts = { git = "https://gitlab.com/karroffel/contracts.git", branch = "master", features = [ "mirai_assertions" ]}

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -36,6 +36,7 @@ pub mod expression;
 pub mod interval_domain;
 pub mod k_limits;
 pub mod known_names;
+pub mod options;
 pub mod path;
 pub mod smt_solver;
 pub mod summaries;

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use clap::{App, AppSettings, Arg};
+use itertools::Itertools;
+use rustc::session::config::ErrorOutputType;
+use rustc::session::early_error;
+use shellwords;
+
+/// Creates the clap::App metadata for argument parsing.
+fn make_options_parser<'a>() -> App<'a, 'a> {
+    // We could put this into lazy_static! with a Mutex around, but we really do not expect
+    // to construct this more then once per regular program run.
+    App::new("MIRAI")
+    .setting(AppSettings::NoBinaryName)
+    .version("v1.0.5")
+    .arg(Arg::with_name("single_func")
+        .long("single_func")
+        .takes_value(true)
+        .help("Focus analysis on the named function.")
+        .long_help("Name is the simple name of a top-level crate function or a MIRAI summary key."))
+    .arg(Arg::with_name("test_only")
+        .long("test_only")
+        .takes_value(false)
+        .help("Focus analysis on #[test] methods.")
+        .long_help("Only #[test] methods and their usage are analyzed. This must be used together with the rustc --test option."))
+    .arg(Arg::with_name("diag")
+        .long("diag")
+        .possible_values(&["relaxed", "strict"])
+        .default_value("relaxed")
+        .help("Level of diagnostics which will be produced.")
+        .long_help("With `relaxed`, false positives will be avoided where possible. With `strict`, all errors will be reported."))
+}
+
+/// Represents options passed to MIRAI.
+#[derive(Debug, Default)]
+pub struct Options {
+    pub single_func: Option<String>,
+    pub test_only: bool,
+    pub diag_level: DiagLevel,
+}
+
+/// Represents diag level.
+#[derive(Debug, PartialEq)]
+pub enum DiagLevel {
+    RELAXED,
+    STRICT,
+}
+
+impl Default for DiagLevel {
+    fn default() -> Self {
+        DiagLevel::RELAXED
+    }
+}
+
+impl Options {
+    /// Parse options from an argument string. The argument string will be split using unix
+    /// shell escaping rules. Any content beyond the leftmost `--` token will be returned
+    /// (excluding this token).
+    pub fn parse_from_str(&mut self, s: &str) -> Vec<String> {
+        self.parse(&shellwords::split(s).unwrap_or_else(|e| {
+            early_error(
+                ErrorOutputType::default(),
+                &format!("Cannot parse argument string: {:?}", e),
+            )
+        }))
+    }
+
+    /// Parses options from a list of strings. Any content beyond the leftmost `--` token
+    /// will be returned (excluding this token).
+    pub fn parse(&mut self, args: &[String]) -> Vec<String> {
+        let mut mirai_args_end = args.len();
+        let mut other_args_start = args.len();
+        if let Some((p, _)) = args.iter().find_position(|s| s.as_str() == "--") {
+            mirai_args_end = p;
+            other_args_start = p + 1;
+        }
+        let mirai_args = &args[0..mirai_args_end];
+        let other_args = &args[other_args_start..args.len()];
+        let matches = make_options_parser().get_matches_from(mirai_args.iter());
+        self.single_func = matches.value_of("single_func").map(|s| s.to_string());
+        self.test_only = matches.is_present("test_only");
+        self.diag_level = if matches.value_of("diag").unwrap() == "strict" {
+            DiagLevel::STRICT
+        } else {
+            DiagLevel::RELAXED
+        };
+        other_args.to_vec()
+    }
+}

--- a/checker/tests/run-pass/test_source.rs
+++ b/checker/tests/run-pass/test_source.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+#[macro_use]
+extern crate mirai_annotations;
+
+// MIRAI_FLAGS --test_only --diag=strict
+
+#[test]
+fn some_test() {
+    verify!(1 == 1);
+}
+
+#[test]
+fn another_test() {
+    verify!(2 == 1); //~provably false verification condition
+}
+
+#[test]
+fn no_summary_analyzed_anyway() {
+    trait Dynamic {
+        fn f(&self, x: u64) -> u64;
+    }
+    struct S;
+    impl Dynamic for S {
+        fn f(&self, x: u64) -> u64 {
+            return x + 1;
+        }
+    }
+    let d: &dyn Dynamic = &S {} as &dyn Dynamic; // forget type info of S
+    verify!(d.f(1) == 3); // normaly, this statement would disable verification for this
+                          // function and we would not see the message below. With --flaky,
+                          // we do not see an error here (as d.f is uninterpreted), but we still
+                          // see the below error.
+    verify!(3 == 4); //~provably false verification condition
+}
+
+pub fn not_a_test() {
+    // Should not complain because it is not a test function.
+    verify!(2 == 1);
+}

--- a/examples/shopping_cart/Cargo.toml
+++ b/examples/shopping_cart/Cargo.toml
@@ -10,4 +10,4 @@ name = "shopping_cart"
 [dependencies]
 mirai-annotations = { path = "../../annotations" }
 # TODO(wrwg): replace with crates.io reference once landed
-contracts = { git = "https://gitlab.com/wrwg/contracts.git", branch = "mirai", features = [ "mirai_assertions" ]}
+contracts = { git = "https://gitlab.com/karroffel/contracts.git", branch = "master", features = [ "mirai_assertions" ]}


### PR DESCRIPTION
## Description

This adds general MIRAI flag handling, and adds new flags `--test_only` and `--flaky` which allow for analyzing test functions as well as turning off the transient propagation of angelic treatment in the presence of functions without a body. This flags are intended to be used together, but are technically independent.

`--test_only` will cause MIRAI to look for a test runner and only analyze those methods which are called by the test runner (i.e. those which have the `#[test]` attribute), plus methods in their
call graph. The implementation of this isn't as trivial as expected since the rust test runner uses a native method and builds data structures for the set of test methods, while the original `#[test]` is removed from the source by macro expansion. We use heuristics which result in a first implementation which may need further refinement.

One must use the `--test` (rustc) or `--tests` (cargo) option in addition to `--test_only` to get the tests analyzed.

`--flaky` will simply cause the analyzer to report with info log that it can't analyze a method reliably, but continue instead of bailing out. The flag is named such it can serve as a general disabler for false positive suppression in the future.

A new test has been added and the test infrastructure extended to be able to deal with those options (a marker in the source indicates for integration tests what to do).

This also relates to #52 as it adds a way to inject MIRAI_FLAGS into test sources for integration tests. We want to do something similar for RUSTC_FLAGS, which should be an easy extension of the existing logic.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

New test, ./validate.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/facebookexperimental/mirai/365)
<!-- Reviewable:end -->
