### PR TITLE
Introduce DiagLevel::PARANOID and run tests in this mode by default.

### DIFF
--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -5,6 +5,7 @@
 
 use clap::{App, AppSettings, Arg};
 use itertools::Itertools;
+use mirai_annotations::*;
 use rustc::session::config::ErrorOutputType;
 use rustc::session::early_error;
 use shellwords;
@@ -28,7 +29,7 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .long_help("Only #[test] methods and their usage are analyzed. This must be used together with the rustc --test option."))
     .arg(Arg::with_name("diag")
         .long("diag")
-        .possible_values(&["relaxed", "strict"])
+        .possible_values(&["relaxed", "strict", "paranoid"])
         .default_value("relaxed")
         .help("Level of diagnostics which will be produced.")
         .long_help("With `relaxed`, false positives will be avoided where possible. With `strict`, all errors will be reported."))
@@ -43,10 +44,23 @@ pub struct Options {
 }
 
 /// Represents diag level.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, PartialOrd)]
 pub enum DiagLevel {
+    /// When a function can't be fully analyzed, for example because it calls a function
+    /// without a body and no foreign function summary, it is simply assumed to be correct (angelic).
+    /// This is transitive: calling an angelic function causes the caller to become angelic itself.
+    /// This minimizes false positives but can lead to a lot code not being analyzed
+    /// while devirtualization isn't perfect and not all intrinsics have been modeled.
     RELAXED,
+    /// When a function calls another function without a body or summary, it assumes that the called
+    /// function is angelic and that it has no preconditions and no post condition. Analysis of the
+    /// caller continues optimistically. This can lead to false positives because of the missing
+    /// post conditions and imprecision can be amplified if the missing function occurs deep down
+    /// in a long call chain.
     STRICT,
+    /// When a function calls another function without a body or summary, a diagnostic is generated
+    /// to flag the call as a problem. Analysis of the caller then proceeds as in the STRICT case.
+    PARANOID,
 }
 
 impl Default for DiagLevel {
@@ -82,10 +96,11 @@ impl Options {
         let matches = make_options_parser().get_matches_from(mirai_args.iter());
         self.single_func = matches.value_of("single_func").map(|s| s.to_string());
         self.test_only = matches.is_present("test_only");
-        self.diag_level = if matches.value_of("diag").unwrap() == "strict" {
-            DiagLevel::STRICT
-        } else {
-            DiagLevel::RELAXED
+        self.diag_level = match matches.value_of("diag").unwrap() {
+            "relaxed" => DiagLevel::RELAXED,
+            "strict" => DiagLevel::STRICT,
+            "paranoid" => DiagLevel::PARANOID,
+            _ => assume_unreachable!(),
         };
         other_args.to_vec()
     }

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -24,7 +24,7 @@ extern crate syntax;
 extern crate tempdir;
 
 use mirai::callbacks;
-use mirai::options::Options;
+use mirai::options::{DiagLevel, Options};
 use mirai::utils;
 use regex::Regex;
 use rustc_rayon::iter::IntoParallelIterator;
@@ -154,6 +154,7 @@ fn invoke_driver(
 ) -> usize {
     // Read MIRAI options from file content.
     let mut options = Options::default();
+    options.diag_level = DiagLevel::PARANOID;
     let mut rustc_args = vec![]; // any arguments after `--` for rustc
     {
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();

--- a/checker/tests/run-pass/contract_annotations.rs
+++ b/checker/tests/run-pass/contract_annotations.rs
@@ -6,6 +6,8 @@
 
 // Tests for annotations from the contracts crate.
 
+// MIRAI_FLAGS --test_only
+
 use contracts::*;
 use mirai_annotations::*;
 
@@ -24,6 +26,7 @@ fn pre_post(x: i32) -> i32 {
     return x;
 }
 
+#[test]
 fn use_pre_post() {
     checked_verify!(pre_post(1) >= 1);
 }
@@ -56,6 +59,7 @@ impl Adder for MyAdder {
     }
 }
 
+#[test]
 fn use_trait() {
     let mut a = MyAdder { x: 1 };
     checked_verify!(a.get() == 1);
@@ -81,6 +85,7 @@ impl S {
     }
 }
 
+#[test]
 fn use_invariant() {
     let mut s = S { x: 1 };
     checked_verify!(s.get_and_decrement() == 1);

--- a/checker/tests/run-pass/crate_traversal.rs
+++ b/checker/tests/run-pass/crate_traversal.rs
@@ -6,6 +6,8 @@
 
 // statements and expressions that exercise all visitor code paths
 
+// MIRAI_FLAGS --diag=strict
+
 #![allow(const_err)]
 #![allow(unused)]
 #![feature(asm)]

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -6,6 +6,8 @@
 
 // A test that uses a widened summary.
 
+// MIRAI_FLAGS --diag=strict
+
 #[macro_use]
 extern crate mirai_annotations;
 

--- a/checker/tests/run-pass/generic_trait_override.rs
+++ b/checker/tests/run-pass/generic_trait_override.rs
@@ -4,6 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// MIRAI_FLAGS --test_only
+
 #[macro_use]
 extern crate mirai_annotations;
 
@@ -24,6 +26,7 @@ impl Tr<i32> for Foo {
     }
 }
 
+#[test]
 pub fn main() {
     let foo = Foo { bar: 1 };
     verify!(foo.actual() == 1);

--- a/checker/tests/run-pass/test_source.rs
+++ b/checker/tests/run-pass/test_source.rs
@@ -31,7 +31,7 @@ fn no_summary_analyzed_anyway() {
         }
     }
     let d: &dyn Dynamic = &S {} as &dyn Dynamic; // forget type info of S
-    verify!(d.f(1) == 3); // normal,y, this statement would disable verification for this
+    verify!(d.f(1) == 3); // normally, this statement would disable verification for this
                           // function and we would not see the message below. With --diag=strict,
                           // we do not see an error here (as d.f is uninterpreted), but we still
                           // see the below error.

--- a/checker/tests/run-pass/trait_contracts.rs
+++ b/checker/tests/run-pass/trait_contracts.rs
@@ -6,6 +6,8 @@
 
 // This tests the devirtualization needed for the contracts crate to work for MIRAI.
 
+// MIRAI_FLAGS --test_only
+
 use mirai_annotations::*;
 
 // Without using contracts crate directly, this is what #[contract_trait] will generate.
@@ -38,6 +40,7 @@ impl Adder for MyAdder {
     }
 }
 
+#[test]
 pub fn main() {
     let mut a = MyAdder(3);
     a.decrement();

--- a/checker/tests/run-pass/trait_override.rs
+++ b/checker/tests/run-pass/trait_override.rs
@@ -4,6 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// MIRAI_FLAGS --test_only
+
 #[macro_use]
 extern crate mirai_annotations;
 
@@ -24,6 +26,7 @@ impl Tr for Foo {
     }
 }
 
+#[test]
 pub fn main() {
     let foo = Foo { bar: 1 };
     verify!(foo.actual() == 1);


### PR DESCRIPTION
## Description

DiagLevel::PARANOID will issue a diagnostic if an attempt is made to call a function that has no summary. The integration tests now run with this mode as the default.

In some test cases, this requires using test mode and annotating particular methods as the only methods to analyze, so that devirtualization can succeed.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
