### PR TITLE
Propagate function constants that are leaf vals of structured args

### DIFF
--- a/checker/tests/run-pass/func_params.rs
+++ b/checker/tests/run-pass/func_params.rs
@@ -31,9 +31,20 @@ fn foos<T: Copy>(f: fn(Option<T>, T) -> Option<T>, x: T) -> Option<T> {
     f(Some(x), x)
 }
 
+struct S {
+    pub i: i32,
+    pub f: fn(Option<i32>, i32) -> Option<i32>,
+}
+
+fn foot(s: S) -> Option<i32> {
+    (s.f)(Some(s.i), s.i)
+}
+
 pub fn main() {
     let fbar = foo(bar);
     verify!(fbar.unwrap() == 2);
     let fbas = foos(bas, 2);
     verify!(fbas.unwrap() == 2);
+    let fbart = foot(S { i: 2, f: bar });
+    verify!(fbart.unwrap() == 4);
 }


### PR DESCRIPTION
## Description

A number of library functions call function values that are passed not as direct arguments, but in fields or structured arguments. If these values are known at the call site, the call site should still use a summary that was specialized using the caller's arguments.

To fix this, the code for extracting function constants from the actual arguments has been generalized. While here, I also fixed a todo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
Expanded a test case
