### PR TITLE
Keep track of function constants in embedded references

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -666,7 +666,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             && !(consequent_type.is_integer() && alternate_type.is_integer())
             && !(consequent.is_top() || alternate.is_top())
         {
-            info!(
+            debug!(
                 "conditional with mismatched types  {:?}: {:?}     {:?}: {:?}",
                 consequent_type, consequent, alternate_type, alternate
             );


### PR DESCRIPTION
## Description

When the caller passes a function constant to a callee via a reference, include that in the function constants vector of the call info.

With this change, more functions propagate and that has unmasked a problem where the map from def id to generic arguments is incomplete a point where a function is used because function constants are cached for the entire analysis and not just for a given root function. To fix this substs_cache is moved into the analysis context.

Related to #390

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
MIRAI on MIRAI still not working
