### PR TITLE
Update black list for LIBRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Use `rustup override set nightly-YYYY-MM-DD` to make Cargo use the same version 
 instruction to determine which version to use. If you forget to do that or use the wrong version,
 you'll see an error message complaining about a dynamic load library not being found. 
 
-The easiest way to get started is to first build your project in the normal way.
+The easiest way to get started is to first build your project in the normal way (with one exception:
+ set `RUSTFLAGS="-Z always_encode_mir"` to force the rust compiler to include MIR into its compiled output).
 Refer [this link](https://doc.rust-lang.org/1.30.0/book/2018-edition/ch01-00-getting-started.html) for details
 on compiling a cargo project.
 When there are no compile errors,

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -392,7 +392,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         if cfg!(DEBUG) {
             let mut stdout = std::io::stdout();
             rustc_mir::util::write_mir_pretty(self.tcx, Some(self.def_id), &mut stdout).unwrap();
-            debug!("{:?}", stdout.flush());
+            info!("{:?}", stdout.flush());
         }
         self.active_calls.push(self.def_id);
         let (mut block_indices, contains_loop) = self.get_sorted_block_indices();

--- a/documentation/Linux.md
+++ b/documentation/Linux.md
@@ -7,6 +7,13 @@ In order to use MIRAI, you need to install Rust, install Z3, and install MIRAI i
 You should install rustup and then use it to get hold of the latest Rust compiler.
 See [here](https://doc.rust-lang.org/book/ch01-01-installation.html) for instructions.
 
+In addition, explicitly install the rustc-dev component since that is needed to compile MIRAI:
+```
+rustup component add rustc-dev
+```
+
+Remember to do this every time you update the Rust compiler to a newer nightly build.
+
 ## Installing Z3
 
 On Fedora install it with


### PR DESCRIPTION
## Description

Update the black list for LIBRA so that MIRAI does not crash when run over LIBRA sources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
Ran MIRAI over LIBRA
