### PR TITLE
Check in summary_key_str that “num” belongs to crate “core”.

### DIFF
--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -300,7 +300,9 @@ pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
             if component.data == DefPathData::Impl {
                 if let Some(parent_def_id) = tcx.parent(def_id) {
                     if let Some(type_ns) = &type_ns {
-                        if type_ns == "num" {
+                        if type_ns == "num"
+                            && tcx.crate_name(parent_def_id.krate).as_str() == "core"
+                        {
                             append_mangled_type(&mut name, tcx.type_of(parent_def_id), tcx);
                             continue;
                         }


### PR DESCRIPTION
## Description

The [summary_key_str](https://github.com/facebookexperimental/MIRAI/blob/master/checker/src/utils.rs#L303) function incorrectly assumes that if a module is named `num`, it comes from the `core` crate. This assumption is, for example, violated by the [lexical-core](https://github.com/Alexhuszagh/rust-lexical/blob/master/lexical-core/src/util/num.rs) crate, which causes the call to `tcx.type_of(parent_def_id)` to panic. This pull request adds a check that the actual crate to which `num` belongs is `core`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

## Checklist:

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes.
- [ ] Make sure your code lints.
- [ ] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

