### PR TITLE
Make tests actually run in non relaxed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ can contain any of the following flags:
 
 - `--test_only`: instructs MIRAI to analyze only test methods in your crate. You must also provide the `--tests`
   option to the `cargo build` command to include those tests actually into your build.
-- `--diag=relaxed|strict`: configures level of diagnostics. With `relaxed` (the default) MIRAI
+- `--diag=relaxed|strict|paranoid`: configures level of diagnostics. With `relaxed` (the default) MIRAI
    will not report errors which are potential 'false positives'. With `strict` it will
-   report such errors. 
+   report such errors. With `paranoid` it will flag any direct or indirect call as a potential error.
 - `--single_func <name>`: the name of a specific function you want to analyze. 
 - `--`: any arguments after this marker are passed on to rustc.
 

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -288,7 +288,7 @@ pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
             // We use this to provide contracts for functions defined in crates we do not
             // wish to modify in place.
             name.clear();
-        } else {
+        } else if !name.ends_with('.') {
             name.push('.');
         }
         push_component_name(component.data, &mut name);

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -153,7 +153,6 @@ fn invoke_driver(
 ) -> usize {
     // Read MIRAI options from file content.
     let mut options = Options::default();
-    options.diag_level = DiagLevel::PARANOID;
     let mut rustc_args = vec![]; // any arguments after `--` for rustc
     {
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();
@@ -162,6 +161,7 @@ fn invoke_driver(
             rustc_args = options.parse_from_str(&captures["flags"]);
         }
     }
+    options.diag_level = DiagLevel::STRICT;
 
     // Setup rustc call.
     let mut command_line_arguments: Vec<String> = vec![

--- a/checker/tests/run-pass/contract_annotations.rs
+++ b/checker/tests/run-pass/contract_annotations.rs
@@ -39,7 +39,7 @@ trait Adder {
 
     #[pre(x > 0)]
     #[pre(self.get() <= std::i32::MAX - x)]
-    #[post(ret == old(self.get()) && self.get() > old(self.get()))]
+    #[post(ret == old(self.get()) && self.get() > old(self.get()))] //~ provably false verification condition
     fn get_and_add(&mut self, x: i32) -> i32;
 }
 
@@ -63,8 +63,8 @@ impl Adder for MyAdder {
 fn use_trait() {
     let mut a = MyAdder { x: 1 };
     checked_verify!(a.get() == 1);
-    checked_verify!(a.get_and_add(2) == 1);
-    checked_verify!(a.get() == 3);
+    checked_verify!(a.get_and_add(2) == 1); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+    checked_verify!(a.get() == 3); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
 }
 
 // Invariants


### PR DESCRIPTION
## Description

Tests are meant to run at paranoid level but instead ran at the relaxed level. Fixed the setting of the level and upped it to strict. This breaks one test, which has been annotated to expect the erroneous output. The tests that fail at paranoid strictness will be fixed in later PRs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
cargo test
