### PR TITLE
Devirtualize calls made inside closures

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -182,6 +182,7 @@ impl MiraiCallbacks {
             || self.file_name.contains("language/bytecode-verifier/src")
             || self.file_name.contains("common/executable-helpers/src")
             || self.file_name.contains("client/cli/src")
+            || self.file_name.contains("consensus/safety-rules/src")
         {
             return;
         }

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -125,14 +125,20 @@ impl Options {
             make_options_parser().get_matches_from(mirai_args.iter())
         };
 
-        self.single_func = matches.value_of("single_func").map(|s| s.to_string());
-        self.test_only = matches.is_present("test_only");
-        self.diag_level = match matches.value_of("diag").unwrap() {
-            "relaxed" => DiagLevel::RELAXED,
-            "strict" => DiagLevel::STRICT,
-            "paranoid" => DiagLevel::PARANOID,
-            _ => assume_unreachable!(),
-        };
+        if matches.is_present("single_func") {
+            self.single_func = matches.value_of("single_func").map(|s| s.to_string());
+        }
+        if matches.is_present("test_only") {
+            self.test_only = true;
+        }
+        if matches.is_present("diag") {
+            self.diag_level = match matches.value_of("diag").unwrap() {
+                "relaxed" => DiagLevel::RELAXED,
+                "strict" => DiagLevel::STRICT,
+                "paranoid" => DiagLevel::PARANOID,
+                _ => assume_unreachable!(),
+            };
+        }
         args[rustc_args_start..args.len()].to_vec()
     }
 }

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -153,6 +153,7 @@ fn invoke_driver(
 ) -> usize {
     // Read MIRAI options from file content.
     let mut options = Options::default();
+    options.diag_level = DiagLevel::PARANOID;
     let mut rustc_args = vec![]; // any arguments after `--` for rustc
     {
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();
@@ -161,7 +162,6 @@ fn invoke_driver(
             rustc_args = options.parse_from_str(&captures["flags"]);
         }
     }
-    options.diag_level = DiagLevel::STRICT;
 
     // Setup rustc call.
     let mut command_line_arguments: Vec<String> = vec![

--- a/checker/tests/run-pass/contract_annotations.rs
+++ b/checker/tests/run-pass/contract_annotations.rs
@@ -39,7 +39,7 @@ trait Adder {
 
     #[pre(x > 0)]
     #[pre(self.get() <= std::i32::MAX - x)]
-    #[post(ret == old(self.get()) && self.get() > old(self.get()))] //~ provably false verification condition
+    #[post(ret == old(self.get()) && self.get() > old(self.get()))]
     fn get_and_add(&mut self, x: i32) -> i32;
 }
 
@@ -63,8 +63,8 @@ impl Adder for MyAdder {
 fn use_trait() {
     let mut a = MyAdder { x: 1 };
     checked_verify!(a.get() == 1);
-    checked_verify!(a.get_and_add(2) == 1); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
-    checked_verify!(a.get() == 3); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+    checked_verify!(a.get_and_add(2) == 1);
+    checked_verify!(a.get() == 3);
 }
 
 // Invariants

--- a/checker/tests/run-pass/generic_trait_override.rs
+++ b/checker/tests/run-pass/generic_trait_override.rs
@@ -27,8 +27,10 @@ impl Tr<i32> for Foo {
 }
 
 #[test]
-pub fn main() {
+pub fn t1() {
     let foo = Foo { bar: 1 };
     verify!(foo.actual() == 1);
     verify!(foo.actual() == 2); //~ provably false verification condition
 }
+
+pub fn main() {}

--- a/checker/tests/run-pass/trait_contracts.rs
+++ b/checker/tests/run-pass/trait_contracts.rs
@@ -41,9 +41,11 @@ impl Adder for MyAdder {
 }
 
 #[test]
-pub fn main() {
+pub fn test() {
     let mut a = MyAdder(3);
     a.decrement();
     checked_verify!(a.current() < 3);
     verify!(a.current() == 1); //~ provably false verification condition
 }
+
+pub fn main() {}

--- a/checker/tests/run-pass/trait_override.rs
+++ b/checker/tests/run-pass/trait_override.rs
@@ -27,8 +27,10 @@ impl Tr for Foo {
 }
 
 #[test]
-pub fn main() {
+pub fn t1() {
     let foo = Foo { bar: 1 };
     verify!(foo.actual() == 1);
     verify!(foo.actual() == 2); //~ provably false verification condition
 }
+
+pub fn main() {}

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -231,6 +231,10 @@ pub mod core {
 
     pub mod hash {
         pub mod Hasher {
+            fn finish() {
+                panic!("use StableHasher::finalize instead");
+            }
+
             pub fn write<T>(_self: &mut T, _bytes: &[u8]) {
                 // todo: provide non default models for interesting types
             }


### PR DESCRIPTION
## Description

Closure functions need to bind the Self generic parameter of functions they call to the self type of the function inside which they are enclosed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
Ran MIRAI over Libra
