### PR TITLE
Make tests run in paranoid mode by default

### DIFF
--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -125,14 +125,20 @@ impl Options {
             make_options_parser().get_matches_from(mirai_args.iter())
         };
 
-        self.single_func = matches.value_of("single_func").map(|s| s.to_string());
-        self.test_only = matches.is_present("test_only");
-        self.diag_level = match matches.value_of("diag").unwrap() {
-            "relaxed" => DiagLevel::RELAXED,
-            "strict" => DiagLevel::STRICT,
-            "paranoid" => DiagLevel::PARANOID,
-            _ => assume_unreachable!(),
-        };
+        if matches.is_present("single_func") {
+            self.single_func = matches.value_of("single_func").map(|s| s.to_string());
+        }
+        if matches.is_present("test_only") {
+            self.test_only = true;
+        }
+        if matches.is_present("diag") {
+            self.diag_level = match matches.value_of("diag").unwrap() {
+                "relaxed" => DiagLevel::RELAXED,
+                "strict" => DiagLevel::STRICT,
+                "paranoid" => DiagLevel::PARANOID,
+                _ => assume_unreachable!(),
+            };
+        }
         args[rustc_args_start..args.len()].to_vec()
     }
 }

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -153,6 +153,7 @@ fn invoke_driver(
 ) -> usize {
     // Read MIRAI options from file content.
     let mut options = Options::default();
+    options.diag_level = DiagLevel::PARANOID;
     let mut rustc_args = vec![]; // any arguments after `--` for rustc
     {
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();
@@ -161,7 +162,6 @@ fn invoke_driver(
             rustc_args = options.parse_from_str(&captures["flags"]);
         }
     }
-    options.diag_level = DiagLevel::STRICT;
 
     // Setup rustc call.
     let mut command_line_arguments: Vec<String> = vec![

--- a/checker/tests/run-pass/generic_trait_override.rs
+++ b/checker/tests/run-pass/generic_trait_override.rs
@@ -27,8 +27,10 @@ impl Tr<i32> for Foo {
 }
 
 #[test]
-pub fn main() {
+pub fn t1() {
     let foo = Foo { bar: 1 };
     verify!(foo.actual() == 1);
     verify!(foo.actual() == 2); //~ provably false verification condition
 }
+
+pub fn main() {}

--- a/checker/tests/run-pass/trait_contracts.rs
+++ b/checker/tests/run-pass/trait_contracts.rs
@@ -41,9 +41,11 @@ impl Adder for MyAdder {
 }
 
 #[test]
-pub fn main() {
+pub fn test() {
     let mut a = MyAdder(3);
     a.decrement();
     checked_verify!(a.current() < 3);
     verify!(a.current() == 1); //~ provably false verification condition
 }
+
+pub fn main() {}

--- a/checker/tests/run-pass/trait_override.rs
+++ b/checker/tests/run-pass/trait_override.rs
@@ -27,8 +27,10 @@ impl Tr for Foo {
 }
 
 #[test]
-pub fn main() {
+pub fn t1() {
     let foo = Foo { bar: 1 };
     verify!(foo.actual() == 1);
     verify!(foo.actual() == 2); //~ provably false verification condition
 }
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Options specified via the environment variable MIRAI_FLAGS were completely obliterated by command line options (if present). Likewise, MIRAI_FLAGS obliterated the default option values, even when those were non standard, as is the case in the integration test framework.

Fixing this makes it possible to run tests in paranoid mode by default, which uncovered some test cases that were problematic because they put the #[test] attribute on the main function, which does not do what you would expect since you end up with two main functions and of which the second calls a standard library function that has no MIR body and thus causes the test to fail in paranoid mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh

