### PR TITLE
Use a CallInfo value to compute constant values

### DIFF
--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -502,20 +502,6 @@ impl<'a, 'tcx: 'a> PersistentSummaryCache<'tcx> {
             .or_insert_with(|| utils::summary_key_str(tcx, def_id))
     }
 
-    /// Returns the cached summary corresponding to def_id, or creates a default for it.
-    #[logfn_inputs(TRACE)]
-    pub fn get_summary_for(&mut self, def_id: DefId) -> &Summary {
-        let db = &self.db;
-        let tcx = self.type_context;
-        let persistent_key = self
-            .key_cache
-            .entry(def_id)
-            .or_insert_with(|| utils::summary_key_str(tcx, def_id));
-        self.def_id_cache.entry(def_id).or_insert_with(|| {
-            Self::get_persistent_summary_for_db(db, &persistent_key).unwrap_or_default()
-        })
-    }
-
     /// Returns the cached summary corresponding to the function reference.
     /// If the reference has no def_id (and hence no function_id), the entire reference used
     /// as the key, which requires more cache instances and the hard to extract


### PR DESCRIPTION
## Description

Constant values can be computed by functions that are generic with respect to the call site. They should be summarized and in-lined accordingly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI on Libra


