### PR TITLE
No longer assume parameter 0 is "Self" if it is an unmatched generic.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -199,6 +199,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/compiler/bytecode-source-map/src")
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src")
             || file_name.contains("config/config-builder/src")
+            || file_name.contains("secure/storage/vault/src")
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.


### PR DESCRIPTION
## Description

By now, matching on the symbol "Self" is safer and sufficient.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra