### PR TITLE
Use explicit check for model fields rooted in parameters

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -186,10 +186,20 @@ impl Path {
     #[logfn_inputs(TRACE)]
     pub fn is_rooted_by_abstract_heap_address(&self) -> bool {
         match &self.value {
-            PathEnum::QualifiedPath { qualifier, .. } => match qualifier.value {
-                PathEnum::AbstractHeapAddress { .. } => true,
-                _ => false,
-            },
+            PathEnum::QualifiedPath { qualifier, .. } => {
+                qualifier.is_rooted_by_abstract_heap_address()
+            }
+            PathEnum::AbstractHeapAddress { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// True if path qualifies a parameter, or another qualified path rooted by a parameter.
+    #[logfn_inputs(TRACE)]
+    pub fn is_rooted_by_parameter(&self) -> bool {
+        match &self.value {
+            PathEnum::QualifiedPath { qualifier, .. } => qualifier.is_rooted_by_parameter(),
+            PathEnum::Parameter { .. } => true,
             _ => false,
         }
     }

--- a/validate.sh
+++ b/validate.sh
@@ -30,7 +30,7 @@ cd target/debug/deps
 tar -c -f ../../../binaries/summary_store.tar .summary_store.sled
 cd ../../..
 
-# Install MIRAI into cargo again, so that this time it uses the new sumary store
+# Install MIRAI into cargo again, so that this time it uses the new summary store
 cargo uninstall mirai || true
 cargo install --path ./checker
 


### PR DESCRIPTION
## Description

Getting a model field from a parameter is problematic since the parameter is unknown and therefore it is premature to use the default if the model field does not exist in the current environment. The current test for this depends on there being an environmental entry for root value of a model field before we conclude that the model field is really absent.  This is problematic when the root value is a composite value since these should not have entries of their own (only their leafs should have entries).

To fix this the check now sees if the path to the model field is rooted in a parameter. If it is, the caller has to resolve the value of the field, if not, the absence of an entry for the model field means that the default must be used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

