### PR TITLE
Fix indirect calls via call_once, etc.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -165,6 +165,7 @@ impl MiraiCallbacks {
             || file_name.contains("crypto/crypto-derive/src") // resolve error
             || file_name.contains("common/futures-semaphore/src") // false positives
             || file_name.contains("common/logger/src") // src/librustc/mir/interpret/mod.rs:492: expected allocation ID 10 to point to memory
+            || file_name.contains("common/metrics/src") // index out of bounds
             || file_name.contains("crypto/crypto/src") // resolve error
             || file_name.contains("types/src") // resolve error
             || file_name.contains("language/vm/src") // false positives

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -53,6 +53,7 @@ type JoinOrWiden =
 impl Environment {
     /// Returns a reference to the value associated with the given path, if there is one.
     #[logfn_inputs(TRACE)]
+    #[logfn(TRACE)]
     pub fn value_at(&self, path: &Rc<Path>) -> Option<&Rc<AbstractValue>> {
         self.value_map.get(path)
     }

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -239,7 +239,6 @@ impl Summary {
 
 /// Constructs a summary of a function body by processing state information gathered during
 /// abstract interpretation of the body.
-#[logfn(TRACE)]
 #[allow(clippy::too_many_arguments)]
 pub fn summarize(
     argument_count: usize,
@@ -250,6 +249,14 @@ pub fn summarize(
     unwind_environment: &Environment,
     tcx: TyCtxt<'_>,
 ) -> Summary {
+    trace!(
+        "summarize env {:?} pre {:?} post {:?} unwind cond {:?} unwind env {:?}",
+        exit_environment,
+        preconditions,
+        post_condition,
+        unwind_condition,
+        unwind_environment
+    );
     let mut preconditions: Vec<Precondition> = add_provenance(preconditions, tcx);
     let mut side_effects = extract_side_effects(exit_environment, argument_count);
     let mut unwind_side_effects = extract_side_effects(unwind_environment, argument_count);

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -91,8 +91,8 @@ pub fn argument_types_key_str<'tcx>(
 /// Appends a string to str with the constraint that it must uniquely identify ty and also
 /// be a valid identifier (so that core library contracts can be written for type specialized
 /// generic trait methods).
-#[logfn(TRACE)]
 fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) {
+    trace!("append_mangled_type {:?} to {}", ty.kind, str);
     use syntax::ast;
     use TyKind::*;
     match ty.kind {

--- a/checker/tests/run-pass/call_once.rs
+++ b/checker/tests/run-pass/call_once.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls a closure via FnOnce::call_once
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn call_once<F, T, V>(f: F, arg: (T, V)) -> T
+where
+    F: FnOnce((T, V)) -> T,
+{
+    f(arg)
+}
+
+pub fn main() {
+    let f = |(x, _y)| x;
+    let x = call_once(f, ((10, 20), 30));
+    verify!(x.0 == 10);
+    verify!(x.1 == 20);
+}


### PR DESCRIPTION
## Description

Fix the indirect calling logic to properly use the generic arguments of call_once (etc.) as the signature for the arguments expected by the function being called indirectly.

Also add some code to avoid copying structures as single values. This is somewhat complicated by needing to do so when the structure is a parameter or part of a parameter, in which case the concrete structure is unknown and the detailed copy must be done by the caller that knows the concrete structure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh with new test case
ran MIRAI on Libra

