### PR TITLE
Support weak updates for primitive element types

### DIFF
--- a/checker/tests/run-pass/weak_update.rs
+++ b/checker/tests/run-pass/weak_update.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that does a weak update of an array element
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn test(i: usize) {
+    precondition!(i < 3);
+    let mut a = [3, 4, 5];
+    a[i] = 666;
+    verify!(a[i] == 666);
+    verify!(a[0] == 3 || a[0] == 666);
+    if i != 0 {
+        verify!(a[0] == 3);
+    } else {
+        verify!(a[0] == 3); //~ provably false verification condition
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Array index paths where the index is not known can alias paths where the indices are known, so any assignments to such paths should also perform weak updates on potentially aliased paths.

This PR only handles arrays of primitive element types.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh with new test case

