### PR TITLE
Generalize weak updates to non primitive values

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -61,6 +61,15 @@ impl From<PathEnum> for Path {
 }
 
 impl Path {
+    /// Returns a qualified path of the form root.selectors[0].selectors[1]...
+    pub fn add_selectors(root: &Rc<Path>, selectors: &[Rc<PathSelector>]) -> Rc<Path> {
+        let mut result = root.clone();
+        for selector in selectors.iter() {
+            result = Path::new_qualified(result, selector.clone());
+        }
+        result
+    }
+
     /// Requires an abstract value that is an AbstractHeapAddress expression and
     /// returns a path can be used as the root of paths that define the heap value.
     pub fn get_as_path(value: Rc<AbstractValue>) -> Path {

--- a/checker/tests/run-pass/weak_update.rs
+++ b/checker/tests/run-pass/weak_update.rs
@@ -9,7 +9,7 @@
 #[macro_use]
 extern crate mirai_annotations;
 
-pub fn test(i: usize) {
+pub fn test1(i: usize) {
     precondition!(i < 3);
     let mut a = [3, 4, 5];
     a[i] = 666;
@@ -19,6 +19,34 @@ pub fn test(i: usize) {
         verify!(a[0] == 3);
     } else {
         verify!(a[0] == 3); //~ provably false verification condition
+    }
+}
+
+pub struct Foo {
+    pub bar: u32,
+    pub bas: i32,
+}
+
+pub fn test2(i: usize) {
+    precondition!(i < 3);
+    let mut a = [
+        Foo { bar: 3, bas: -3 },
+        Foo { bar: 4, bas: -4 },
+        Foo { bar: 5, bas: -5 },
+    ];
+    a[i] = Foo {
+        bar: 666,
+        bas: -666,
+    };
+    verify!(a[i].bar == 666);
+    verify!(a[i].bas == -666);
+    verify!(a[0].bar == 3 || a[0].bar == 666);
+    verify!(a[0].bas == -3 || a[0].bas == -666);
+    if i != 0 {
+        verify!(a[0].bar == 3);
+        verify!(a[0].bas == -3);
+    } else {
+        verify!(a[0].bar == 3); //~ provably false verification condition
     }
 }
 


### PR DESCRIPTION
## Description

Do some path manipulation so that joins can be done over index values embedded inside paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh with new test case
ran MIRAI over Libra.