### PR TITLE
Do not check statements when checking for errors.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -175,6 +175,7 @@ impl MiraiCallbacks {
             || file_name.contains("storage/scratchpad/src") // resolve error
             || file_name.contains("common/num-variants/src") // resolve error
             || file_name.contains("language/bytecode-verifier/src") // stack overflow
+            || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/transaction-builder/src") // slice len
             || file_name.contains("language/move-lang/src") // Z3 encoding error
             || file_name.contains("language/move-vm/state/src") // false positives


### PR DESCRIPTION
## Description

Remember the environment as it was before reaching the terminator of a basic block. Since (pretty much) all error situations occur only during the processing of terminators, this makes it possible to not execute statements redundantly during the error checking phase. This is nice from a performance point of view, but the real reason for doing this is to make debug logs less voluminous and confusing.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
