### PR TITLE
Test slice copy with parameterized count

### DIFF
--- a/checker/tests/run-pass/slice_copy.rs
+++ b/checker/tests/run-pass/slice_copy.rs
@@ -43,4 +43,24 @@ pub fn t2() {
     verify!(b[2] == 6);
 }
 
+fn t3copy(a: &mut [i32], b: &mut [i32], count: usize) {
+    unsafe {
+        let aptr = a.as_mut_ptr();
+        let bptr = b.as_mut_ptr();
+        std::intrinsics::copy_nonoverlapping(aptr, bptr, count);
+    }
+}
+
+pub fn t3() {
+    let mut a = [1, 2, 3];
+    let mut b = [4, 5, 6];
+    t3copy(&mut b, &mut a, 2);
+    verify!(a[0] == 1);
+    verify!(a[1] == 2);
+    verify!(a[2] == 3);
+    verify!(b[0] == 1);
+    verify!(b[1] == 2);
+    verify!(b[2] == 6);
+}
+
 pub fn main() {}


### PR DESCRIPTION
## Description

Add a test case for slice copy with a parameterized (i.e. unknown) count. Fix the bug exposed by it by making sure that effect paths with index and slice selectors that have values containing parameters are properly refined when incorporating a summary into the caller state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh with new test case
ran MIRAI over Libra
