### PR TITLE
Implement easy case for array repeat literals

### DIFF
--- a/checker/tests/run-pass/array_repeat.rs
+++ b/checker/tests/run-pass/array_repeat.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls visit_repeat
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn main() {
+    let x = [1; 2];
+    verify!(x[0] == 1);
+    verify!(x[1] == 1);
+}


### PR DESCRIPTION
## Description

Array literals in the form of repeat expressions ([val; len]) occur in the standard libraries so supporting them might help. Also we now have slice paths, so supporting them is easy. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh with new test case
ran MIRAI over Libra
