### PR TITLE
Cleanup get_as_path

### DIFF
--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -132,8 +132,8 @@ impl Environment {
             }) => match (&consequent.expression, &alternate.expression) {
                 (Expression::HeapBlock { .. }, Expression::HeapBlock { .. }) => Some((
                     condition.clone(),
-                    Rc::new(Path::get_as_path(consequent.clone())),
-                    Rc::new(Path::get_as_path(alternate.clone())),
+                    Path::get_as_path(consequent.clone()),
+                    Path::get_as_path(alternate.clone()),
                 )),
                 (Expression::Reference(path1), Expression::Reference(path2))
                     if path1 != path && path2 != path =>

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -350,7 +350,7 @@ fn extract_reachable_heap_allocations(
         let mut new_roots: HashSet<Rc<AbstractValue>> = HashSet::new();
         for heap_root in heap_roots.iter() {
             if visited_heap_roots.insert(heap_root.clone()) {
-                let root = Rc::new(Path::get_as_path(heap_root.clone()));
+                let root = Path::get_as_path(heap_root.clone());
                 for (path, value) in env
                     .value_map
                     .iter()

--- a/checker/src/visitors.rs
+++ b/checker/src/visitors.rs
@@ -2492,7 +2492,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         let length = call_info.actual_args[0].1.clone();
         let alignment = call_info.actual_args[1].1.clone();
         let heap_path = Path::get_as_path(self.get_new_heap_block(length, alignment, false));
-        AbstractValue::make_reference(Rc::new(heap_path))
+        AbstractValue::make_reference(heap_path)
     }
 
     /// Returns a new heap memory block with the given byte length and with the zeroed flag set.
@@ -2502,7 +2502,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         let length = call_info.actual_args[0].1.clone();
         let alignment = call_info.actual_args[1].1.clone();
         let heap_path = Path::get_as_path(self.get_new_heap_block(length, alignment, true));
-        AbstractValue::make_reference(Rc::new(heap_path))
+        AbstractValue::make_reference(heap_path)
     }
 
     /// Removes the heap block and all paths rooted in it from the current environment.
@@ -3386,7 +3386,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
                 Expression::HeapBlock { .. } => {
                     if let PathEnum::QualifiedPath { selector, .. } = &tpath.value {
                         if let PathSelector::Slice(..) = selector.as_ref() {
-                            let source_path = Rc::new(Path::get_as_path(rvalue.clone()));
+                            let source_path = Path::get_as_path(rvalue.clone());
                             let target_type =
                                 Self::get_element_type(self.get_path_rustc_type(&target_path));
                             self.copy_or_move_elements(
@@ -3555,8 +3555,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
                                                 },
                                                 1,
                                             );
-                                            let new_block_path =
-                                                Rc::new(Path::get_as_path(new_block));
+                                            let new_block_path = Path::get_as_path(new_block);
                                             let new_reference =
                                                 AbstractValue::make_reference(new_block_path);
                                             updated_value_map = updated_value_map
@@ -4494,7 +4493,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
             .entry(self.current_location)
             .or_insert_with(|| AbstractValue::make_from(constants.get_new_heap_block(is_zeroed), 1))
             .clone();
-        let block_path = Rc::new(Path::get_as_path(block.clone()));
+        let block_path = Path::get_as_path(block.clone());
         let layout_path = Path::new_layout(block_path);
         let layout = AbstractValue::make_from(
             Expression::HeapBlockLayout {
@@ -5212,7 +5211,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
                     self.get_new_heap_block(Rc::new(1u128.into()), Rc::new(1u128.into()), false);
                 if let Expression::HeapBlock { .. } = &e.expression {
                     let p = Path::new_discriminant(
-                        Rc::new(Path::get_as_path(e.clone())),
+                        Path::get_as_path(e.clone()),
                         &self.current_environment,
                     );
                     let d = Rc::new(self.constant_value_cache.get_u128_for(*data).clone().into());
@@ -5441,7 +5440,7 @@ impl<'analysis, 'compilation, 'tcx, E> MirVisitor<'analysis, 'compilation, 'tcx,
         if byte_len > k_limits::MAX_BYTE_ARRAY_LENGTH {
             return array_value;
         }
-        let array_path: Rc<Path> = Rc::new(Path::get_as_path(array_value));
+        let array_path = Path::get_as_path(array_value);
         let mut last_index: u128 = 0;
         for (i, operand) in self
             .get_element_values(bytes, elem_type, len)

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -183,10 +183,7 @@ impl Z3Solver {
     fn get_as_z3_ast(&self, expression: &Expression) -> z3_sys::Z3_ast {
         match expression {
             Expression::HeapBlock { .. } => {
-                let path = Rc::new(Path::get_as_path(AbstractValue::make_from(
-                    expression.clone(),
-                    1,
-                )));
+                let path = Path::get_as_path(AbstractValue::make_from(expression.clone(), 1));
                 self.general_variable(&path, &expression.infer_type())
             }
             Expression::Add { .. }
@@ -678,10 +675,7 @@ impl Z3Solver {
     fn get_as_numeric_z3_ast(&self, expression: &Expression) -> (bool, z3_sys::Z3_ast) {
         match expression {
             Expression::HeapBlock { .. } => {
-                let path = Rc::new(Path::get_as_path(AbstractValue::make_from(
-                    expression.clone(),
-                    1,
-                )));
+                let path = Path::get_as_path(AbstractValue::make_from(expression.clone(), 1));
                 self.numeric_variable(expression, &path, &expression.infer_type())
             }
             Expression::Add { left, right } => {
@@ -1226,10 +1220,7 @@ impl Z3Solver {
     fn get_as_bv_z3_ast(&self, expression: &Expression, num_bits: u32) -> z3_sys::Z3_ast {
         match expression {
             Expression::HeapBlock { .. } => {
-                let path = Rc::new(Path::get_as_path(AbstractValue::make_from(
-                    expression.clone(),
-                    1,
-                )));
+                let path = Path::get_as_path(AbstractValue::make_from(expression.clone(), 1));
                 self.bv_variable(&path, &expression.infer_type(), num_bits)
             }
             Expression::Add { left, right } => {


### PR DESCRIPTION
## Description

A mechanical refactor to remove redundant code from get_as_path callers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
