### PR TITLE
Fix get_as_path.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -170,11 +170,9 @@ impl MiraiCallbacks {
             || file_name.contains("crypto/crypto/src") // resolve error
             || file_name.contains("config/src") // unimplemented case
             || file_name.contains("common/num-variants/src") // resolve error
-            || file_name.contains("env_logger") // unreachable code
             || file_name.contains("language/bytecode-verifier/src") // stack overflow
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
-            || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // unreachable code
-            || file_name.contains("language/stdlib/src") // unreachable code
+            || file_name.contains("language/stdlib/src") // false positives
             || file_name.contains("language/move-lang/src") // takes too long
             || file_name.contains("language/move-vm/state/src") // false positives
             || file_name.contains("language/move-vm/runtime/src") // rustc metadata decoder panic

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -75,14 +75,13 @@ impl Path {
     /// returns a path can be used as the root of paths that define the heap value.
     #[logfn_inputs(TRACE)]
     pub fn get_as_path(value: Rc<AbstractValue>) -> Rc<Path> {
-        precondition!(matches!(value.expression, Expression::HeapBlock {..}));
         Rc::new(match &value.expression {
             Expression::HeapBlock { .. } => PathEnum::HeapBlock { value }.into(),
             Expression::Offset { .. } => PathEnum::Offset { value }.into(),
             Expression::Reference(path)
             | Expression::Variable { path, .. }
             | Expression::Widen { path, .. } => path.as_ref().clone(),
-            _ => verify_unreachable!("value is {:?}", value),
+            _ => PathEnum::Constant { value }.into(),
         })
     }
 }


### PR DESCRIPTION
## Description

Make get_as_path safe for arbitrary values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
