### PR TITLE
Simplify some common patterns

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -165,6 +165,7 @@ impl MiraiCallbacks {
             || file_name.contains("bindgen") // resolve error
             || file_name.contains("crypto/crypto-derive/src") // resolve error
             || file_name.contains("common/bitvec/src") // stack overflow
+            || file_name.contains("common/debug-interface") // false positives
             || file_name.contains("common/security-logger/src") // resolve error
             || file_name.contains("consensus/src") // Z3 encoding error
             || file_name.contains("crypto/crypto/src") // resolve error
@@ -181,7 +182,6 @@ impl MiraiCallbacks {
             || file_name.contains("network/src") // false positives
             || file_name.contains("client/cli/src") // takes too long
             || file_name.contains("client/libra_wallet/src") // resolve error
-            || file_name.contains("regex") // index of bounds
             || file_name.contains("state-synchronizer/src") // false positives
             || file_name.contains("storage/jellyfish-merkle/src") // complex loops beyond what we can handle right now
             || file_name.contains("storage/libradb/src") // resolve error

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -3,8 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 //
-use crate::abstract_value::AbstractValue;
-use crate::abstract_value::AbstractValueTrait;
+use crate::abstract_value::{self, AbstractValue, AbstractValueTrait};
 use crate::constant_domain::ConstantDomain;
 use crate::environment::Environment;
 use crate::expression::{Expression, ExpressionType};
@@ -472,7 +471,14 @@ impl PathRefinement for Rc<Path> {
             PathEnum::Offset { value } => {
                 Path::get_as_path(value.refine_parameters(arguments, fresh))
             }
-            PathEnum::Parameter { ordinal } => arguments[*ordinal - 1].0.clone(),
+            PathEnum::Parameter { ordinal } => {
+                if *ordinal > arguments.len() {
+                    debug!("Summary refers to a parameter that does not have a matching argument");
+                    Path::new_constant(Rc::new(abstract_value::BOTTOM))
+                } else {
+                    arguments[*ordinal - 1].0.clone()
+                }
+            }
             PathEnum::Result => Path::new_local(fresh),
             PathEnum::QualifiedPath {
                 qualifier,


### PR DESCRIPTION
## Description

As the analysis gets more precise and carries on for longer before giving up, expressions can grow beyond the k-limit of 1000 terms. At this point such expressions become TOP and the analysis loses precision and spews false positives. Such expressions also make debugging difficult.

Since a lot of the terms in such expressions are highly stylized they can be efficiently simplified with heuristic pattern matching rules. As new rules become useful, I add them the existing set, hence this PR.

Of note when reviewing these rules: The expressions are functional and are not expected to fail. I.e. all side effects and range checks have already been performed elsewhere.

The rules are somewhat subtle and easy to get wrong, so careful review will be much appreciated.

Also included here is a "fix" that stops the analyzer from crashing in a situation that ought not arise.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
cargo test
