### PR TITLE
Preserve type info when generalizing.

### DIFF
--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -67,13 +67,13 @@ impl Environment {
         }
         if let Some((join_condition, true_path, false_path)) = self.try_to_split(&path) {
             // If path is an abstraction that can match more than one path, we need to do weak updates.
-            let top = Rc::new(abstract_value::TOP);
+            let default = AbstractValue::make_typed_unknown(value.expression.infer_type());
             let true_val = join_condition.conditional_expression(
                 value.clone(),
-                self.value_at(&true_path).unwrap_or(&top).clone(),
+                self.value_at(&true_path).unwrap_or(&default).clone(),
             );
             let false_val = join_condition.conditional_expression(
-                self.value_at(&false_path).unwrap_or(&top).clone(),
+                self.value_at(&false_path).unwrap_or(&default).clone(),
                 value.clone(),
             );
             self.update_value_at(true_path, true_val);


### PR DESCRIPTION
## Description

Update some comments and preserve type information when replacing a value with a too large expression with a more abstract version.

This doesn't fix anything, but it seems like the right thing to do.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

