### PR TITLE
Simplifications help keep paths conditions in check.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -177,6 +177,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-lang/src") // takes too long
             || file_name.contains("language/move-vm/state/src") // false positives
             || file_name.contains("language/move-vm/runtime/src") // rustc metadata decoder panic
+            || file_name.contains("language/transaction-builder/src") // resolve error
             || file_name.contains("language/vm/vm-runtime/src") // resolve error
             || file_name.contains("language/vm/src") // resolve error
             || file_name.contains("network/src") // false positives


### PR DESCRIPTION
## Description

When refining with a condition of the form a && b, first refine with a then with b so that the path condition is recursively broken up into elemental terms and all simplification opportunities arising from the refinement are uncovered.

Also add the pattern` [x || !(x || y)] -> x || !y` to the simplification of or operations.

These changes make a difference in early parts of the control flow of the vector_append test case, by preventing a path condition from overflowing the maximum expression size, but are not enough for the entire test case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

