### PR TITLE
Smaller limit for the depth that nested refine_with calls can go.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -446,7 +446,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             other
         } else {
             let other = if self_bool.is_none() {
-                other.refine_with(self, 1)
+                other.refine_with(self, 5)
             } else {
                 other
             };
@@ -750,8 +750,8 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         }
 
         // if self { consequent } else { alternate } implies self in the consequent and !self in the alternate
-        consequent = consequent.refine_with(self, 1);
-        alternate = alternate.refine_with(&self.logical_not(), 1);
+        consequent = consequent.refine_with(self, 5);
+        alternate = alternate.refine_with(&self.logical_not(), 5);
 
         let expression_size = self
             .expression_size


### PR DESCRIPTION
## Description

Some recursive calls to refine_with need to start with a fresh depth limit to be effective for the particular patterns they are meant to catch. However, this leads to exponential blowup of the number of refine calls if not limited to a smaller depth than normal root calls. This tweaks the limits so that the blow up does not happen in the test suite, while not disabling the pattern match that is needed for limiting expression size.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
