### PR TITLE
Fix resolve error and a stack overflow.

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -163,23 +163,19 @@ impl MiraiCallbacks {
     fn is_black_listed(file_name: &str) -> bool {
         file_name.contains("admission_control/admission-control-proto/src") // z3 encoding error
             || file_name.contains("crypto/crypto/src") // resolve error because of Box::as_ref not being inlined
-            || file_name.contains("crypto/crypto-derive/src") // resolve error because of Box::as_ref not being inlined
-            || file_name.contains("common/bitvec/src") // stack overflow
+            || file_name.contains("crypto/crypto-derive/src") // false positives
+            || file_name.contains("common/bitvec/src") // false positives
             || file_name.contains("common/bounded-executor/src") // false positive: possible assertion failed: ptr.as_ptr() as usize & NUM_FLAG == 0
             || file_name.contains("common/debug-interface/src") // false positives
             || file_name.contains("common/futures-semaphore/src") // false positive: possible assertion failed: ptr.as_ptr() as usize & NUM_FLAG == 0
-            || file_name.contains("common/metrics/src") // takes too long
-            || file_name.contains("common/temppath/src") // stack overflow
+            || file_name.contains("common/metrics/src") // false positives
             || file_name.contains("consensus/src") // Z3 encoding error
-            || file_name.contains("config/src") // unimplemented case
-            || file_name.contains("language/bytecode-verifier/src") // stack overflow
+            || file_name.contains("language/bytecode-verifier/src") // takes too long
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
             || file_name.contains("language/stdlib/src") // false positives
             || file_name.contains("language/move-lang/src") // takes too long
             || file_name.contains("language/move-vm/state/src") // false positives
-            || file_name.contains("language/move-vm/runtime/src") // rustc metadata decoder panic
-            || file_name.contains("language/transaction-builder/src") // resolve error
             || file_name.contains("language/vm/src") // takes too long
             || file_name.contains("network/src") // false positives
             || file_name.contains("client/cli/src") // takes too long
@@ -189,7 +185,7 @@ impl MiraiCallbacks {
             || file_name.contains("storage/libradb/src") // takes too long
             || file_name.contains("storage/schemadb/src") // takes too long
             || file_name.contains("storage/scratchpad/src") // resolve error
-            || file_name.contains("types/src") // resolve error
+            || file_name.contains("types/src") // takes too long
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.

--- a/validate.sh
+++ b/validate.sh
@@ -15,7 +15,7 @@ cargo audit
 cargo clippy -- -D warnings
 # Build
 cd checker; cargo rustc --lib -- -D rust-2018-idioms
-cd ..; cargo build
+cd ..
 
 # Install MIRAI into cargo
 cargo uninstall mirai || true


### PR DESCRIPTION
## Description

Propagate the right generic arguments when calling indirectly. Guard against infinite recursion that happened when a type projection simply changed the life time generic arguments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
