### PR TITLE
Propagate generic argument map

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -162,7 +162,7 @@ impl MiraiCallbacks {
 
     fn is_black_listed(file_name: &str) -> bool {
         file_name.contains("admission_control/admission-control-proto/src") // z3 encoding error
-            || file_name.contains("crypto/crypto/src") // resolve error because of Box::as_ref not being inlined
+            || file_name.contains("crypto/crypto/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") // false positives
             || file_name.contains("common/bitvec/src") // false positives
             || file_name.contains("common/bounded-executor/src") // false positive: possible assertion failed: ptr.as_ptr() as usize & NUM_FLAG == 0
@@ -184,7 +184,7 @@ impl MiraiCallbacks {
             || file_name.contains("storage/jellyfish-merkle/src") // false positives due to complex loops beyond what we can handle right now
             || file_name.contains("storage/libradb/src") // takes too long
             || file_name.contains("storage/schemadb/src") // takes too long
-            || file_name.contains("storage/scratchpad/src") // resolve error
+            || file_name.contains("storage/scratchpad/src") // false positives
             || file_name.contains("types/src") // takes too long
     }
 


### PR DESCRIPTION
## Description

Don't wipe out the caller's generic argument map when the callee has no generic parameters or when it has promoted constants.

Also propagate the right length constant when specializing a sized array type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI on Libra
