### PR TITLE
Fix some oopsies in the path refinement code.

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -584,10 +584,11 @@ impl PathRefinement for Rc<Path> {
                                     // drop the explicit deref
                                     return Path::new_qualified(
                                         qualifier.clone(),
-                                        selector.clone(),
+                                        refined_selector,
                                     );
                                 }
                             }
+                            return Path::new_qualified(path.clone(), refined_selector);
                         }
                         Expression::Reference(path) => {
                             match refined_selector.as_ref() {
@@ -606,7 +607,10 @@ impl PathRefinement for Rc<Path> {
                                 }
                                 _ => {
                                     // drop the explicit reference
-                                    return Path::new_qualified(path.clone(), selector.clone());
+                                    return Path::new_qualified(
+                                        path.clone(),
+                                        refined_selector.clone(),
+                                    );
                                 }
                             }
                         }
@@ -620,7 +624,7 @@ impl PathRefinement for Rc<Path> {
                             }
                             _ => {
                                 // drop the explicit reference
-                                return Path::new_qualified(path.clone(), selector.clone());
+                                return Path::new_qualified(path.clone(), refined_selector.clone());
                             }
                         }
                     }


### PR DESCRIPTION
## Description

Fix some obviously wrong refinement code. Oops.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh (needs this fix to work when going to a new nightly rustc compiler)
ran MIRAI over Libra
