### PR TITLE
Base special case for fat pointers on a decision made with rustc types

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -161,7 +161,7 @@ impl MiraiCallbacks {
     }
 
     fn is_black_listed(file_name: &str) -> bool {
-        file_name.contains("admission_control/admission-control-proto/src") // z3 encoding error
+        file_name.contains("admission-control/admission-control-proto/src") // resolve error
             || file_name.contains("crypto/crypto/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") // false positives
             || file_name.contains("common/bitvec/src") // false positives

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -10,7 +10,7 @@ use crate::path::Path;
 
 use log_derive::logfn_inputs;
 use mirai_annotations::*;
-use rustc::ty::TyKind;
+use rustc::ty::{Ty, TyCtxt, TyKind};
 use rustc_ast::ast;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -834,6 +834,30 @@ impl<'a> From<&TyKind<'a>> for ExpressionType {
 }
 
 impl ExpressionType {
+    pub fn as_rustc_type<'a>(&self, tcx: TyCtxt<'a>) -> Ty<'a> {
+        use self::ExpressionType::*;
+        match self {
+            Bool => tcx.types.bool,
+            Char => tcx.types.char,
+            F32 => tcx.types.f32,
+            F64 => tcx.types.f64,
+            I8 => tcx.types.i8,
+            I16 => tcx.types.i16,
+            I32 => tcx.types.i32,
+            I64 => tcx.types.i64,
+            I128 => tcx.types.i128,
+            Isize => tcx.types.isize,
+            U8 => tcx.types.u8,
+            U16 => tcx.types.u16,
+            U32 => tcx.types.u32,
+            U64 => tcx.types.u64,
+            U128 => tcx.types.u128,
+            Usize => tcx.types.usize,
+            Reference => tcx.mk_ty(TyKind::Str),
+            NonPrimitive => tcx.types.trait_object_dummy_self,
+        }
+    }
+
     /// Returns true if this type is one of the floating point number types.
     #[logfn_inputs(TRACE)]
     pub fn is_floating_point_number(&self) -> bool {


### PR DESCRIPTION
## Description

ExpressionType is not precise enough to tell whether a path points to a fat or thin pointer. The current heuristic of seeing if the first leaf node of a path is a reference type can and does go wrong.

Fix this by providing lookup_path_and_refine_result with a rustc Ty rather than a MIRAI ExpressionType.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
