### PR TITLE
Add support for unrecoverable!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.6.1",
+ "mirai-annotations 1.7.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -344,13 +344,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.6.1"
+version = "1.7.0"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.6.1",
+ "mirai-annotations 1.7.0",
 ]
 
 [[package]]
@@ -591,7 +591,7 @@ name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
  "contracts 0.3.0 (git+https://gitlab.com/karroffel/contracts.git)",
- "mirai-annotations 1.6.1",
+ "mirai-annotations 1.7.0",
 ]
 
 [[package]]
@@ -660,7 +660,7 @@ dependencies = [
 name = "taint-error"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.6.1",
+ "mirai-annotations 1.7.0",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.6.1"
+version = "1.7.0"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/README.md
+++ b/annotations/README.md
@@ -32,6 +32,7 @@ Additionally we also have:
 * assumed_postcondition! which is an assume at the definition site, rather than a verify.
 * assume_preconditions! which assumes that the caller has satisfied all (inferred) preconditions of the next call.
 * assume_unreachable! which assumes that it is unreachable for reasons beyond what MIRAI can reason about.
+* unrecoverable! which is the same as panic! but explicitly indicates that this is not a programming mistake.
 * verify_unreachable! which requires MIRAI to verify that it is not unreachable.
 
 This crate also provides macros for describing and constraining abstract state that only has meaning to MIRAI. These are:

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -621,6 +621,19 @@ macro_rules! debug_checked_precondition_ne {
     );
 }
 
+/// Terminates the program with a panic that is tagged as being an unrecoverable error.
+/// Use this for errors that arise in correct programs due to external factors.
+/// For example, if a file that is essential for running cannot be found for some reason.
+#[macro_export]
+macro_rules! unrecoverable {
+    ($fmt:expr) => (
+        panic!(concat!("unrecoverable: ", stringify!($fmt)));
+    );
+    ($fmt:expr, $($arg:tt)+) => (
+        panic!(concat!("unrecoverable: ", stringify!($fmt)), $($arg)+);
+    );
+}
+
 /// Equivalent to a no op when used with an unmodified Rust compiler.
 /// When compiled with MIRAI, this causes MIRAI to check the condition and
 /// emit a diagnostic unless it can prove it to be true.

--- a/checker/tests/run-pass/unrecoverable.rs
+++ b/checker/tests/run-pass/unrecoverable.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that calls calls unrecoverable! and panic! in way that demonstrates their respective use cases.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub fn test1() {
+    unrecoverable!("Something happened for which the correct response is termination");
+}
+
+pub fn test2(message: &str) {
+    unrecoverable!("this happened {}", message);
+}
+
+pub fn test3() {
+    panic!("Whoa execution should never get here, bug bug bug!"); //~ Whoa execution should never get here, bug bug bug!
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

panic! is used for different purposes, which makes it hard to decide if a particular use should be regarded as a programming mistake when it happens at runtime.

In code that we do not control giving a diagnostic is conservative (sound). In code that we do control, the guidance is to use unrecoverable! for panics that are used to terminate the execution of a correct program that has encountered an environment in which it cannot continue executing.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh (new test case)
ran MIRAI over Libra

