### PR TITLE
Fix Z3 encoding of intrinsic calls just enough to be well typed.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1313,7 +1313,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         )
     }
 
-    /// Returns (self as u(8|16|64|128)).f() where f is an intrinsic bit vector unary function.
+    /// Returns (self as u(8|16|32|64|128)).f() where f is an intrinsic bit vector unary function.
     #[logfn_inputs(TRACE)]
     fn intrinsic_bit_vector_unary(&self, bit_length: u8, name: KnownNames) -> Self {
         if let Expression::CompileTimeConstant(v1) = &self.expression {

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -169,7 +169,6 @@ impl MiraiCallbacks {
             || file_name.contains("common/debug-interface/src") // false positives
             || file_name.contains("common/futures-semaphore/src") // false positive: possible assertion failed: ptr.as_ptr() as usize & NUM_FLAG == 0
             || file_name.contains("common/metrics/src") // false positives
-            || file_name.contains("consensus/src") // Z3 encoding error
             || file_name.contains("language/bytecode-verifier/src") // takes too long
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -579,7 +579,11 @@ impl Expression {
                 | KnownNames::StdIntrinsicsFsubFast => left.expression.infer_type(),
                 _ => assume_unreachable!("invalid name {:?} for intrinsic binary", name),
             },
-            Expression::IntrinsicBitVectorUnary { operand, name, .. } => match name {
+            Expression::IntrinsicBitVectorUnary {
+                operand,
+                name,
+                bit_length,
+            } => match name {
                 KnownNames::StdIntrinsicsBitreverse | KnownNames::StdIntrinsicsBswap => {
                     operand.expression.infer_type()
                 }
@@ -587,7 +591,17 @@ impl Expression {
                 | KnownNames::StdIntrinsicsCtlzNonzero
                 | KnownNames::StdIntrinsicsCtpop
                 | KnownNames::StdIntrinsicsCttz
-                | KnownNames::StdIntrinsicsCttzNonzero => ExpressionType::U32,
+                | KnownNames::StdIntrinsicsCttzNonzero => {
+                    // u(8|16|32|64|128)
+                    match bit_length {
+                        8 => ExpressionType::U8,
+                        16 => ExpressionType::U16,
+                        32 => ExpressionType::U32,
+                        64 => ExpressionType::U64,
+                        128 => ExpressionType::U128,
+                        _ => unreachable!("the type checker should not allow this"),
+                    }
+                }
                 _ => assume_unreachable!("invalid name {:?} for intrinsic bit vector unary", name),
             },
             Expression::IntrinsicFloatingPointUnary { name, .. } => match name {


### PR DESCRIPTION
## Description

Calls to rust intrinsics (built-in, no MIR) are not currently supported in Z3, but need at least stub support to avoid Z3 from crashing with a type error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
