### PR TITLE
Remove some uses of debug string formatting from name mangling code.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1904,7 +1904,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     && other
                         .less_or_equal(t.modulo_value())
                         .as_bool_if_known()
-                        .expect("constant folding to work")
+                        .unwrap_or(false)
                 {
                     return x.remainder(other);
                 }


### PR DESCRIPTION
## Description

The mangling code is meant to produce strings that can be used in foreign contracts. The stuff coming out of the debug formatters is seldom useful for that.

Also fix a small bug that showed up in Libra CI runs.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
