### PR TITLE
Make separate visitor for crates

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -5,30 +5,19 @@
 #![allow(clippy::borrowed_box)]
 
 use crate::constant_domain::ConstantValueCache;
-use crate::expected_errors;
+use crate::crate_visitor::CrateVisitor;
 use crate::known_names::KnownNamesCache;
 use crate::options::Options;
 use crate::summaries::PersistentSummaryCache;
-use crate::utils;
-use crate::visitors::{MirVisitor, MirVisitorCrateContext};
-use crate::z3_solver::Z3Solver;
 
 use log::info;
-use log_derive::{logfn, logfn_inputs};
+use log_derive::*;
 use rustc_driver::Compilation;
-use rustc_errors::{Diagnostic, DiagnosticBuilder};
-use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_interface::{interface, Queries};
-use rustc_middle::mir;
-use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::TyCtxt;
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Result};
-use std::iter::FromIterator;
-use std::ops::Deref;
 use std::path::PathBuf;
-use std::rc::Rc;
 use tempdir::TempDir;
 
 /// Private state used to implement the callbacks.
@@ -144,17 +133,6 @@ impl rustc_driver::Callbacks for MiraiCallbacks {
     }
 }
 
-struct AnalysisInfo<'compilation, 'tcx> {
-    options: &'compilation Options,
-    persistent_summary_cache: PersistentSummaryCache<'tcx>,
-    constant_value_cache: ConstantValueCache<'tcx>,
-    diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'compilation>>>,
-    known_names_cache: KnownNamesCache,
-    substs_cache: HashMap<DefId, SubstsRef<'tcx>>,
-    // Functions to include in analysis. If None, all functions are included.
-    function_whitelist: Option<Vec<String>>,
-}
-
 impl MiraiCallbacks {
     fn is_test_black_listed(file_name: &str) -> bool {
         file_name.contains("storage/storage-service/src") || file_name.contains("client/cli/src")
@@ -209,243 +187,19 @@ impl MiraiCallbacks {
             "storing summaries for {} at {}/.summary_store.sled",
             self.file_name, summary_store_path
         );
-        let options = std::mem::take(&mut self.options);
-        let persistent_summary_cache = PersistentSummaryCache::new(tcx, summary_store_path);
-        let defs = Vec::from_iter(tcx.body_owners());
-        let constant_value_cache = ConstantValueCache::default();
-        let diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'_>>> = HashMap::new();
-        let known_names_cache = KnownNamesCache::create_cache_from_language_items();
-        let substs_cache = HashMap::new();
-        let mut analysis_info = AnalysisInfo {
-            options: &options,
-            persistent_summary_cache,
-            constant_value_cache,
-            diagnostics_for,
-            known_names_cache,
-            substs_cache,
-            function_whitelist: None,
-        };
-        Self::analyze_bodies(compiler, tcx, &defs, &mut analysis_info);
-        if !self.emit_or_check_diagnostics(&mut analysis_info.diagnostics_for) {
-            compiler.session().fatal("test failed");
-        }
-    }
-
-    /// Emit any diagnostics or, if testing, check that they are as expected.
-    #[logfn_inputs(TRACE)]
-    fn emit_or_check_diagnostics<'compilation>(
-        &mut self,
-        diagnostics_for: &mut HashMap<DefId, Vec<DiagnosticBuilder<'compilation>>>,
-    ) -> bool {
-        if self.test_run {
-            let mut expected_errors = expected_errors::ExpectedErrors::new(self.file_name.as_str());
-            let mut diags = vec![];
-            diagnostics_for.values_mut().flatten().for_each(|db| {
-                db.cancel();
-                db.clone().buffer(&mut diags)
-            });
-            expected_errors.check_messages(diags)
-        } else {
-            let mut diagnostics: Vec<&mut DiagnosticBuilder<'compilation>> =
-                diagnostics_for.values_mut().flatten().collect();
-            fn compare_diagnostics<'compilation>(
-                x: &&mut DiagnosticBuilder<'compilation>,
-                y: &&mut DiagnosticBuilder<'compilation>,
-            ) -> Ordering {
-                let xd: &Diagnostic = x.deref();
-                let yd: &Diagnostic = y.deref();
-                if xd.span.primary_spans().lt(&yd.span.primary_spans()) {
-                    Ordering::Less
-                } else if xd.span.primary_spans().gt(&yd.span.primary_spans()) {
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            }
-            diagnostics.sort_by(compare_diagnostics);
-            fn emit(db: &mut DiagnosticBuilder<'_>) {
-                db.emit();
-            }
-            diagnostics.into_iter().for_each(emit);
-            true
-        }
-    }
-
-    /// Analyze all of the bodies in the crate that is being compiled.
-    #[logfn(TRACE)]
-    fn analyze_bodies<'analysis, 'tcx>(
-        compiler: &'analysis interface::Compiler,
-        tcx: TyCtxt<'tcx>,
-        defs: &[DefId],
-        analysis_info: &mut AnalysisInfo<'analysis, 'tcx>,
-    ) {
-        // Determine the functions we want to analyze.
-        if let Some(fname) = &analysis_info.options.single_func {
-            analysis_info.function_whitelist = Some(vec![fname.clone()]);
-        } else if analysis_info.options.test_only {
-            // Extract test functions from the main test runner.
-            if let Some((entry_def_id, _)) = tcx.entry_fn(LOCAL_CRATE) {
-                let fns = Self::extract_test_fns(tcx, entry_def_id);
-                if fns.is_empty() {
-                    info!("Could not extract any tests from main entry point");
-                } else {
-                    info!("analyzing functions: {:?}", fns);
-                }
-                analysis_info.function_whitelist = Some(fns);
-            } else {
-                warn!("Did not find main entry point to identify tests",);
-                return;
-            }
-        }
-
-        // Analyze all functions that are white listed or public
-        let building_standard_summaries = std::env::var("MIRAI_START_FRESH").is_ok();
-        for def_id in defs.iter() {
-            let name = analysis_info
-                .persistent_summary_cache
-                .get_summary_key_for(*def_id);
-            if let Some(white_list) = &analysis_info.function_whitelist {
-                if !Self::included_in(white_list, name, *def_id, tcx) {
-                    if analysis_info.options.single_func.is_none() {
-                        debug!(
-                            "skipping function {} as it is not selected for analysis",
-                            name
-                        );
-                    }
-                    continue;
-                }
-                info!("analyzing function {}", name);
-            } else if !building_standard_summaries && !utils::is_public(*def_id, tcx) {
-                debug!("skipping function {} as it is not public", name);
-                continue;
-            } else if !building_standard_summaries
-                && tcx.generics_of(*def_id).requires_monomorphization(tcx)
-            {
-                debug!("skipping function {} as it is generic", name);
-                continue;
-            } else {
-                info!("analyzing function {}", name);
-            }
-            MiraiCallbacks::analyze_body(compiler, tcx, analysis_info, *def_id);
-        }
-    }
-
-    // Determine whether this function is included in the analysis.
-    #[logfn(TRACE)]
-    fn included_in(list: &[String], name: &Rc<String>, def_id: DefId, tcx: TyCtxt<'_>) -> bool {
-        let display_name = utils::def_id_display_name(tcx, def_id);
-        // We check both for display name and summary key name.
-        list.contains(&display_name) || list.contains(name.as_ref())
-    }
-
-    /// Analyze the given function body.
-    #[logfn(TRACE)]
-    fn analyze_body<'analysis, 'tcx>(
-        compiler: &'analysis interface::Compiler,
-        tcx: TyCtxt<'tcx>,
-        analysis_info: &mut AnalysisInfo<'analysis, 'tcx>,
-        def_id: DefId,
-    ) {
-        let mut buffered_diagnostics: Vec<DiagnosticBuilder<'_>> = vec![];
-        Self::visit_body(
-            def_id,
-            compiler,
-            tcx,
-            analysis_info,
-            &mut buffered_diagnostics,
-        );
-        fn cancel(mut db: DiagnosticBuilder<'_>) {
-            db.cancel();
-        }
-        if let Some(old_diags) = analysis_info
-            .diagnostics_for
-            .insert(def_id, buffered_diagnostics)
-        {
-            old_diags.into_iter().for_each(cancel)
-        }
-    }
-
-    /// Run the abstract interpreter over the function body and produce a summary of its effects
-    /// and collect any diagnostics into the buffer.
-    #[logfn(TRACE)]
-    fn visit_body<'analysis, 'compilation, 'tcx>(
-        def_id: DefId,
-        compiler: &'compilation interface::Compiler,
-        tcx: TyCtxt<'tcx>,
-        analysis_info: &'analysis mut AnalysisInfo<'compilation, 'tcx>,
-        mut buffered_diagnostics: &'analysis mut Vec<DiagnosticBuilder<'compilation>>,
-    ) {
-        let mir = tcx.optimized_mir(def_id).unwrap_read_only();
-        let mut smt_solver = Z3Solver::default();
-        analysis_info.constant_value_cache.reset_heap_counter();
-        let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
-            options: analysis_info.options,
+        let mut crate_visitor = CrateVisitor {
+            buffered_diagnostics: Vec::new(),
+            constant_value_cache: ConstantValueCache::default(),
+            diagnostics_for: HashMap::new(),
+            file_name: self.file_name.as_str(),
+            known_names_cache: KnownNamesCache::create_cache_from_language_items(),
+            options: &std::mem::take(&mut self.options),
             session: compiler.session(),
+            substs_cache: HashMap::new(),
+            summary_cache: PersistentSummaryCache::new(tcx, summary_store_path),
             tcx,
-            def_id,
-            mir,
-            summary_cache: &mut analysis_info.persistent_summary_cache,
-            constant_value_cache: &mut analysis_info.constant_value_cache,
-            known_names_cache: &mut analysis_info.known_names_cache,
-            smt_solver: &mut smt_solver,
-            substs_cache: &mut analysis_info.substs_cache,
-            buffered_diagnostics: &mut buffered_diagnostics,
-        });
-        let summary = mir_visitor.visit_body(&[], &[]);
-        // Analysis local foreign contracts are not summarized and cached on demand, so we need to do it here.
-        if utils::is_foreign_contract(tcx, def_id) {
-            analysis_info
-                .persistent_summary_cache
-                .set_summary_for(def_id, summary);
-        }
-    }
-
-    /// Extract test functions from the promoted constants of a test runner main function.
-    ///
-    /// Currently, the #[test] attribute generates code like this:
-    ///  
-    ///     extern crate test;
-    ///
-    ///     pub fn main() -> () {
-    ///       test::test_main_static(&[&test, ...)...])
-    ///     }
-    ///
-    ///     pub const test: test:TestDescAndFn = TestDecAndFn{
-    ///       ...,
-    ///       testfn: test::StaticTestFn(|| test::assert_test_result(test())
-    ///     };
-    ///
-    ///     pub fn test() { <original user test code> }
-    ///  
-    /// We can thus find the names (but not def def_id's) of the test functions in the main
-    /// method (via const test in the example). However, the constant slice in main will be promoted
-    /// into a constant initializer function in MIR, so we need to look there.
-    /// We therefore iterate overall promoted functions belonging to the main function, looking for
-    /// a statement like `_n = const <test name>` which loads the constant for a given test.
-    ///
-    /// This method is indeed not very stable and may break on changes to the compilation
-    /// scheme or the test framework.
-    fn extract_test_fns(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<String> {
-        let mut result = vec![];
-        for body in tcx.promoted_mir(def_id).iter() {
-            for b in body.basic_blocks().iter() {
-                for s in &b.statements {
-                    // The statement we are looking for has the form
-                    // `Assign(_, Rvalue(Constant(Unevaluated(def_id)))))`
-                    if let mir::StatementKind::Assign(box (
-                        _,
-                        mir::Rvalue::Use(mir::Operand::Constant(box ref con)),
-                    )) = s.kind
-                    {
-                        if let rustc_middle::ty::ConstKind::Unevaluated(def_id, _, _) =
-                            con.literal.val
-                        {
-                            result.push(utils::def_id_display_name(tcx, def_id));
-                        }
-                    }
-                }
-            }
-        }
-        result
+            test_run: self.test_run,
+        };
+        crate_visitor.analyze_some_bodies();
     }
 }

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -1,0 +1,252 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// 'compilation is the lifetime of compiler interface object supplied to the after_analysis call back.
+// 'tcx is the lifetime of the type context created during the lifetime of the after_analysis call back.
+// 'analysis is the life time of the analyze_with_mirai call back that is invoked with the type context.
+
+use crate::constant_domain::ConstantValueCache;
+use crate::expected_errors;
+use crate::known_names::KnownNamesCache;
+use crate::options::Options;
+use crate::summaries::PersistentSummaryCache;
+use crate::utils;
+use crate::visitors::{MirVisitor, MirVisitorCrateContext};
+use crate::z3_solver::Z3Solver;
+
+use log::*;
+use log_derive::{logfn, logfn_inputs};
+use mirai_annotations::*;
+use rustc_errors::{Diagnostic, DiagnosticBuilder};
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
+use rustc_middle::mir;
+use rustc_middle::ty::subst::SubstsRef;
+use rustc_middle::ty::TyCtxt;
+use rustc_session::Session;
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter, Result};
+use std::ops::Deref;
+
+/// A visitor that takes information gathered by the Rust compiler when compiling a particular
+/// crate and then analyses some of the functions in that crate to see if any of the assertions
+/// and implicit assertions in the MIR bodies might be false and generates warning for those.
+///
+// 'compilation is the lifetime of the call to MiraiCallbacks::after_analysis.
+// 'tcx is the lifetime of the closure call that calls analyze_with_mirai, which calls analyze_some_bodies.
+pub struct CrateVisitor<'compilation, 'tcx> {
+    pub buffered_diagnostics: Vec<DiagnosticBuilder<'compilation>>,
+    pub constant_value_cache: ConstantValueCache<'tcx>,
+    pub diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'compilation>>>,
+    pub file_name: &'compilation str,
+    pub known_names_cache: KnownNamesCache,
+    pub options: &'compilation Options,
+    pub session: &'compilation Session,
+    pub substs_cache: HashMap<DefId, SubstsRef<'tcx>>,
+    pub summary_cache: PersistentSummaryCache<'tcx>,
+    pub tcx: TyCtxt<'tcx>,
+    pub test_run: bool,
+}
+
+impl<'compilation, 'tcx> Debug for CrateVisitor<'compilation, 'tcx> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        "CrateVisitor".fmt(f)
+    }
+}
+
+impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
+    /// Analyze some of the bodies in the crate that is being compiled.
+    #[logfn(TRACE)]
+    pub fn analyze_some_bodies(&mut self) {
+        // Determine the functions we want to analyze.
+        let function_whitelist = self.get_function_whitelist();
+
+        // Analyze all functions that are white listed or public
+        let building_standard_summaries = std::env::var("MIRAI_START_FRESH").is_ok();
+        for def_id in self.tcx.body_owners() {
+            let name = utils::summary_key_str(self.tcx, def_id);
+            if let Some(white_list) = &function_whitelist {
+                if !self.included_in(white_list.as_ref(), name.as_str(), def_id) {
+                    if self.options.single_func.is_none() {
+                        debug!(
+                            "skipping function {} as it is not selected for analysis",
+                            name
+                        );
+                    }
+                    continue;
+                }
+                info!("analyzing function {}", name);
+            } else if !building_standard_summaries {
+                if !utils::is_public(def_id, self.tcx) {
+                    debug!("skipping function {} as it is not public", name);
+                    continue;
+                } else if self
+                    .tcx
+                    .generics_of(def_id)
+                    .requires_monomorphization(self.tcx)
+                {
+                    debug!("skipping function {} as it is generic", name);
+                    continue;
+                } else {
+                    info!("analyzing function {}", name);
+                }
+            }
+            self.analyze_body(def_id);
+        }
+        self.emit_or_check_diagnostics();
+    }
+
+    /// Use compilation options to determine a list of functions to analyze.
+    /// If this returns None, default logic is used by the caller.
+    #[logfn(TRACE)]
+    fn get_function_whitelist(&mut self) -> Option<Vec<String>> {
+        if let Some(func_name) = &self.options.single_func {
+            Some(vec![func_name.clone()])
+        } else if self.options.test_only {
+            // Extract test functions from the main test runner.
+            if let Some((entry_def_id, _)) = self.tcx.entry_fn(LOCAL_CRATE) {
+                let fns = self.extract_test_fns(entry_def_id);
+                if fns.is_empty() {
+                    info!("Could not extract any tests from main entry point");
+                } else {
+                    info!("analyzing functions: {:?}", fns);
+                }
+                Some(fns)
+            } else {
+                warn!("Did not find main entry point to identify tests",);
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    // Determine whether this function is included in the analysis.
+    #[logfn(TRACE)]
+    fn included_in(&self, list: &[String], name: &str, def_id: DefId) -> bool {
+        let display_name = utils::def_id_display_name(self.tcx, def_id);
+        // We check both for display name and summary key name.
+        list.iter()
+            .map(|e| e.as_str())
+            .any(|e| e.eq(&display_name) || e.eq(name))
+    }
+
+    /// Run the abstract interpreter over the function body and produce a summary of its effects
+    /// and collect any diagnostics into the buffer.
+    #[logfn(TRACE)]
+    fn analyze_body(&mut self, def_id: DefId) {
+        let mut diagnostics: Vec<DiagnosticBuilder<'compilation>> = vec![];
+        let mir = self.tcx.optimized_mir(def_id).unwrap_read_only();
+        let mut z3_solver = Z3Solver::default();
+        self.constant_value_cache.reset_heap_counter();
+        let mut mir_visitor = MirVisitor::new(MirVisitorCrateContext {
+            options: self.options,
+            session: self.session,
+            tcx: self.tcx,
+            def_id,
+            mir,
+            summary_cache: &mut self.summary_cache,
+            constant_value_cache: &mut self.constant_value_cache,
+            known_names_cache: &mut self.known_names_cache,
+            smt_solver: &mut z3_solver,
+            substs_cache: &mut self.substs_cache,
+            buffered_diagnostics: &mut diagnostics,
+        });
+        // Analysis local foreign contracts are not summarized and cached on demand, so we need to do it here.
+        let summary = mir_visitor.visit_body(&[], &[]);
+        if utils::is_foreign_contract(self.tcx, def_id) {
+            self.summary_cache.set_summary_for(def_id, summary);
+        }
+        let old_diags = self.diagnostics_for.insert(def_id, diagnostics);
+        checked_assume!(old_diags.is_none());
+    }
+
+    /// Extract test functions from the promoted constants of a test runner main function.
+    ///
+    /// Currently, the #[test] attribute generates code like this:
+    ///
+    ///     extern crate test;
+    ///
+    ///     pub fn main() -> () {
+    ///       test::test_main_static(&[&test, ...)...])
+    ///     }
+    ///
+    ///     pub const test: test:TestDescAndFn = TestDecAndFn{
+    ///       ...,
+    ///       testfn: test::StaticTestFn(|| test::assert_test_result(test())
+    ///     };
+    ///
+    ///     pub fn test() { <original user test code> }
+    ///
+    /// We can thus find the names (but not def def_id's) of the test functions in the main
+    /// method (via const test in the example). However, the constant slice in main will be promoted
+    /// into a constant initializer function in MIR, so we need to look there.
+    /// We therefore iterate overall promoted functions belonging to the main function, looking for
+    /// a statement like `_n = const <test name>` which loads the constant for a given test.
+    ///
+    /// This method is indeed not very stable and may break on changes to the compilation
+    /// scheme or the test framework.
+    fn extract_test_fns(&self, def_id: DefId) -> Vec<String> {
+        let mut result = vec![];
+        for body in self.tcx.promoted_mir(def_id).iter() {
+            for b in body.basic_blocks().iter() {
+                for s in &b.statements {
+                    // The statement we are looking for has the form
+                    // `Assign(_, Rvalue(Constant(Unevaluated(def_id)))))`
+                    if let mir::StatementKind::Assign(box (
+                        _,
+                        mir::Rvalue::Use(mir::Operand::Constant(box ref con)),
+                    )) = s.kind
+                    {
+                        if let rustc_middle::ty::ConstKind::Unevaluated(def_id, _, _) =
+                            con.literal.val
+                        {
+                            result.push(utils::def_id_display_name(self.tcx, def_id));
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    /// Emit any diagnostics or, if testing, check that they are as expected.
+    #[logfn_inputs(TRACE)]
+    fn emit_or_check_diagnostics(&mut self) {
+        if self.test_run {
+            let mut expected_errors = expected_errors::ExpectedErrors::new(self.file_name);
+            let mut diags = vec![];
+            self.diagnostics_for.values_mut().flatten().for_each(|db| {
+                db.cancel();
+                db.clone().buffer(&mut diags)
+            });
+            if !expected_errors.check_messages(diags) {
+                self.session.fatal("test failed");
+            }
+        } else {
+            let mut diagnostics: Vec<&mut DiagnosticBuilder<'_>> =
+                self.diagnostics_for.values_mut().flatten().collect();
+            fn compare_diagnostics<'a>(
+                x: &&mut DiagnosticBuilder<'a>,
+                y: &&mut DiagnosticBuilder<'a>,
+            ) -> Ordering {
+                let xd: &Diagnostic = x.deref();
+                let yd: &Diagnostic = y.deref();
+                if xd.span.primary_spans().lt(&yd.span.primary_spans()) {
+                    Ordering::Less
+                } else if xd.span.primary_spans().gt(&yd.span.primary_spans()) {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            }
+            diagnostics.sort_by(compare_diagnostics);
+            fn emit(db: &mut DiagnosticBuilder<'_>) {
+                db.emit();
+            }
+            diagnostics.into_iter().for_each(emit);
+        }
+    }
+}

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -37,6 +37,7 @@ extern crate log;
 pub mod abstract_value;
 pub mod callbacks;
 pub mod constant_domain;
+pub mod crate_visitor;
 pub mod environment;
 pub mod expected_errors;
 pub mod expression;


### PR DESCRIPTION
## Description

Move code that relates to visiting a crate out of the callbacks module into a new crate_visitor module and package it up as a visitor.

This is the first in a series of re-factorings to make the code more compartmentalized. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over LIbra

