### PR TITLE
Get rid of saved state

### DIFF
--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -137,11 +137,17 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
     /// and collect any diagnostics into the buffer.
     #[logfn(TRACE)]
     fn analyze_body(&mut self, def_id: DefId) {
-        let mut diagnostics: Vec<DiagnosticBuilder<'compilation>> = vec![];
-        // let mir = self.tcx.optimized_mir(def_id).unwrap_read_only();
+        let mut diagnostics: Vec<DiagnosticBuilder<'compilation>> = Vec::new();
+        let mut active_calls: Vec<DefId> = Vec::new();
         let mut z3_solver = Z3Solver::default();
         self.constant_value_cache.reset_heap_counter();
-        let mut body_visitor = BodyVisitor::new(self, def_id, &mut z3_solver, &mut diagnostics);
+        let mut body_visitor = BodyVisitor::new(
+            self,
+            def_id,
+            &mut z3_solver,
+            &mut diagnostics,
+            &mut active_calls,
+        );
         // Analysis local foreign contracts are not summarized and cached on demand, so we need to do it here.
         let summary = body_visitor.visit_body(&[], &[]);
         if utils::is_foreign_contract(self.tcx, def_id) {


### PR DESCRIPTION
## Description

Keep the crate visitor's state intact via a reference in BodyVisitor and then use that to get rid of the SavedVisitorState struct and the swap_visitor_state functions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra