### PR TITLE
Rewrite FixedPointVisitor::get_initial_state_from_predecessors

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -147,24 +147,21 @@ impl MiraiCallbacks {
             || file_name.contains("common/debug-interface/src") // false positives
             || file_name.contains("common/futures-semaphore/src") // false positive: possible assertion failed: ptr.as_ptr() as usize & NUM_FLAG == 0
             || file_name.contains("common/metrics/src") // false positives
-            || file_name.contains("execution/executor/src") // takes too long
-            || file_name.contains("language/bytecode-verifier/src") // takes too long
+            || file_name.contains("language/bytecode-verifier/src") // false positives
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
             || file_name.contains("language/stdlib/src") // false positives
-            || file_name.contains("language/move-lang/src") // takes too long
+            || file_name.contains("language/move-lang/src") // resolve error
             || file_name.contains("language/move-vm/state/src") // false positives
-            || file_name.contains("language/transaction-builder/src") // takes too long
             || file_name.contains("network/src") // false positives
-            || file_name.contains("client/cli/src") // takes too long   
+            || file_name.contains("client/cli/src") // false positives   
             || file_name.contains("client/libra_wallet/src") // false positive: self.execute(offset, len, |buffer| dst[..len].copy_from_slice(buffer));
             || file_name.contains("secure/storage/vault/src") // z3 encoding
             || file_name.contains("state-synchronizer/src") // false positives
             || file_name.contains("storage/jellyfish-merkle/src") // false positives due to complex loops beyond what we can handle right now
-            || file_name.contains("storage/libradb/src") // takes too long
-            || file_name.contains("storage/schemadb/src") // takes too long
+            || file_name.contains("storage/libradb/src") // 'already borrowed: BorrowMutError'
             || file_name.contains("storage/scratchpad/src") // false positives
-            || file_name.contains("types/src") // takes too long
+            || file_name.contains("types/src") // resolve error
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.


### PR DESCRIPTION
## Description

Always use join rather than conditional expression for merging in the out states of loop body blocks that branch back to the loop anchor block. This helps with fixed point convergence.

Also, do not include the exit conditions of the back branches into the path condition of the loop anchor block. This helps to prevent path conditions from growing exponentially in size.

Fixes #212

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

