### PR TITLE
Fix treatment of the path in Widen expressions

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2617,9 +2617,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     }
                 }
             }
-            Expression::Widen { path, operand, .. } => {
-                operand.refine_paths(environment).widen(&path)
-            }
+            Expression::Widen { path, operand, .. } => operand
+                .refine_paths(environment)
+                .widen(&path.refine_paths(environment)),
         }
     }
 
@@ -2860,9 +2860,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     )
                 }
             }
-            Expression::Widen { path, operand, .. } => {
-                operand.refine_parameters(arguments, fresh).widen(&path)
-            }
+            Expression::Widen { path, operand, .. } => operand
+                .refine_parameters(arguments, fresh)
+                .widen(&path.refine_parameters(arguments, fresh)),
         }
     }
 

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -786,7 +786,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
     /// target_path and rvalue is value refined by replacing all occurrences of parameter values
     /// with the corresponding actual values.
     #[logfn_inputs(TRACE)]
-    fn transfer_and_refine(
+    pub fn transfer_and_refine(
         &mut self,
         effects: &[(Rc<Path>, Rc<AbstractValue>)],
         target_path: Rc<Path>,
@@ -891,6 +891,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     } else if rtype == ExpressionType::NonPrimitive {
                         self.copy_or_move_elements(tpath.clone(), path.clone(), target_type, false);
                     }
+                }
+                Expression::Widen { operand, .. } => {
+                    let rvalue = operand.widen(&tpath);
+                    self.current_environment.update_value_at(tpath, rvalue);
+                    continue;
                 }
                 _ => {}
             }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -154,6 +154,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-lang/src") // resolve error
             || file_name.contains("language/move-vm/state/src") // false positives
             || file_name.contains("network/src") // false positives
+            || file_name.contains("network/onchain-discovery/src") // false positives
             || file_name.contains("client/cli/src") // false positives   
             || file_name.contains("client/libra_wallet/src") // false positive: self.execute(offset, len, |buffer| dst[..len].copy_from_slice(buffer));
             || file_name.contains("secure/storage/vault/src") // z3 encoding


### PR DESCRIPTION
## Description

The path included in Widen expressions should be refined and it should be updated when a widened expression is transferred from a function summary to a call environment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
