### PR TITLE
Use a map of counters to track recursive calls

### DIFF
--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -139,7 +139,7 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
     #[logfn(TRACE)]
     fn analyze_body(&mut self, def_id: DefId) {
         let mut diagnostics: Vec<DiagnosticBuilder<'compilation>> = Vec::new();
-        let mut active_calls: Vec<DefId> = Vec::new();
+        let mut active_calls_map: HashMap<DefId, u64> = HashMap::new();
         let mut z3_solver = Z3Solver::default();
         self.constant_value_cache.reset_heap_counter();
         let mut body_visitor = BodyVisitor::new(
@@ -147,7 +147,7 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
             def_id,
             &mut z3_solver,
             &mut diagnostics,
-            &mut active_calls,
+            &mut active_calls_map,
         );
         // Analysis local foreign contracts are not summarized and cached on demand, so we need to do it here.
         let summary = body_visitor.visit_body(&[], &[]);


### PR DESCRIPTION
## Description

In order to properly support self recursive functions, more than one active call per function must be allowed. To support this in a future PR, this PR replaces the active_calls vector with a hash map.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
