### PR TITLE
Use make_typed_unknown more widely.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1656,7 +1656,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         let len = if let Ok(ty_and_layout) = self.bv.tcx.layout_of(param_env.and(ty)) {
             Rc::new((ty_and_layout.layout.size.bytes() as u128).into())
         } else {
-            AbstractValue::make_typed_unknown(ExpressionType::U128)
+            AbstractValue::make_typed_unknown(ExpressionType::U128, path.clone())
         };
         let alignment = Rc::new(1u128.into());
         let value = match null_op {

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -383,13 +383,8 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     }
                 }
                 result.unwrap_or_else(|| {
-                    let result = AbstractValue::make_from(
-                        Expression::Variable {
-                            path: path.clone(),
-                            var_type: result_type.clone(),
-                        },
-                        1,
-                    );
+                    let result =
+                        AbstractValue::make_typed_unknown(result_type.clone(), path.clone());
                     if result_type != ExpressionType::NonPrimitive {
                         self.current_environment
                             .update_value_at(path, result.clone());
@@ -397,7 +392,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     result
                 })
             } else {
-                AbstractValue::make_typed_unknown(result_type.clone())
+                AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
             }
         } else {
             refined_val
@@ -527,13 +522,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
             .value_at(&path)
             .cloned()
             .unwrap_or_else(|| {
-                AbstractValue::make_from(
-                    Expression::Variable {
-                        path: path.clone(),
-                        var_type: expression_type.clone(),
-                    },
-                    1,
-                )
+                AbstractValue::make_typed_unknown(expression_type.clone(), path.clone())
             })
     }
 

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -64,13 +64,22 @@ impl Environment {
         }
         if let Some((join_condition, true_path, false_path)) = self.try_to_split(&path) {
             // If path is an abstraction that can match more than one path, we need to do weak updates.
-            let default = AbstractValue::make_typed_unknown(value.expression.infer_type());
             let true_val = join_condition.conditional_expression(
                 value.clone(),
-                self.value_at(&true_path).unwrap_or(&default).clone(),
+                self.value_at(&true_path)
+                    .unwrap_or(&AbstractValue::make_typed_unknown(
+                        value.expression.infer_type(),
+                        true_path.clone(),
+                    ))
+                    .clone(),
             );
             let false_val = join_condition.conditional_expression(
-                self.value_at(&false_path).unwrap_or(&default).clone(),
+                self.value_at(&false_path)
+                    .unwrap_or(&AbstractValue::make_typed_unknown(
+                        value.expression.infer_type(),
+                        false_path.clone(),
+                    ))
+                    .clone(),
                 value.clone(),
             );
             self.update_value_at(true_path, true_val);

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -5,7 +5,7 @@
 
 use crate::abstract_value::AbstractValue;
 use crate::environment::Environment;
-use crate::expression::{Expression, ExpressionType};
+use crate::expression::ExpressionType;
 use crate::path::{Path, PathEnum};
 use crate::path::{PathRefinement, PathSelector};
 use crate::utils;
@@ -85,12 +85,9 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'analysis, 'tcx> {
                                 (&substs.get(j).unwrap().expect_ty().kind).into();
                             let closure_field_path = Path::new_field(path.clone(), j - (i + 1))
                                 .refine_paths(environment);
-                            let closure_field_val = AbstractValue::make_from(
-                                Expression::Variable {
-                                    path: closure_field_path.clone(),
-                                    var_type,
-                                },
-                                1,
+                            let closure_field_val = AbstractValue::make_typed_unknown(
+                                var_type,
+                                closure_field_path.clone(),
                             );
                             first_state.value_map = first_state
                                 .value_map


### PR DESCRIPTION
## Description

Use make_typed_unknown more widely.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
