### PR TITLE
Clarify code for joining with bottom.

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -383,8 +383,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     }
                 }
                 result.unwrap_or_else(|| {
-                    let result =
-                        AbstractValue::make_typed_unknown(result_type.clone(), path.clone());
+                    let result = if let PathEnum::LocalVariable { .. } = path.value {
+                        refined_val
+                    } else {
+                        AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
+                    };
                     if result_type != ExpressionType::NonPrimitive {
                         self.current_environment
                             .update_value_at(path, result.clone());
@@ -392,7 +395,16 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     result
                 })
             } else {
-                AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
+                let result = if let PathEnum::LocalVariable { .. } = path.value {
+                    refined_val
+                } else {
+                    AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
+                };
+                if result_type != ExpressionType::NonPrimitive {
+                    self.current_environment
+                        .update_value_at(path, result.clone());
+                }
+                result
             }
         } else {
             refined_val

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -305,7 +305,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .active_calls_map
                 .get(&func_ref.def_id.unwrap())
                 .unwrap_or(&0u64);
-            info!("call depth {:?}", call_depth);
             let result = self
                 .block_visitor
                 .bv


### PR DESCRIPTION
## Description

BOTTOM has not been much used up to now, but needs to work properly for analysis of self recursive functions to be sound. This PR cleans up things related to BOTTOM.

One of the chief things to bear in mind when reading this code is that the absence of (path, value) pair in an environment has multiple causes.

If the path is a local variable, it means the local has not been initialized and thus that references to its value are forbidden and thus that the result of looking up the local should be BOTTOM. While code generated by the compiler will never cause such lookups to happen, self recursion can have this effect because we need to force the recursion to always terminate statically and for the leaf recursive call to analyze only the base (non-recursive) case.

For other kinds of paths, however, the absence of a (path, value) entry in an environment means that the value is unknown (TOP, but with known location and type),

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
