### PR TITLE
Add annotations to tag values with types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.7.0",
+ "mirai-annotations 1.8.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -344,13 +344,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.7.0"
+version = "1.8.0"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.7.0",
+ "mirai-annotations 1.8.0",
 ]
 
 [[package]]
@@ -591,7 +591,7 @@ name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
  "contracts 0.3.0 (git+https://gitlab.com/karroffel/contracts.git)",
- "mirai-annotations 1.7.0",
+ "mirai-annotations 1.8.0",
 ]
 
 [[package]]
@@ -660,7 +660,7 @@ dependencies = [
 name = "taint-error"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.7.0",
+ "mirai-annotations 1.8.0",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"


### PR DESCRIPTION
## Description

Provide a way to add and track type tags on arbitrary values. For example taint sources can add a "this value is tainted in this way" tag and taint sanitizers can add "this value has been sanitized from this kind of taint".

Once added a tag cannot be removed and it is illegal to modify the value (lest the tag becomes meaningless).

Still to be designed and provided is a way to to control the behavior of transfer functions. I.e. if a value is constructed from an argument that is tagged, does it get tagged? Clearly that depends on the kind of tag. I intend to use marker traits to control this, pending further design and implementation work.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
Not testable right now.
