### PR TITLE
Recursive loops

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -140,6 +140,7 @@ impl MiraiCallbacks {
 
     fn is_black_listed(file_name: &str) -> bool {
         file_name.contains("admission-control/admission-control-proto/src") // resolve error
+            || file_name.contains("consensus/src") // resolve error
             || file_name.contains("crypto/crypto/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") // false positives
             || file_name.contains("common/bitvec/src") // false positives
@@ -153,6 +154,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/stdlib/src") // false positives
             || file_name.contains("language/move-lang/src") // resolve error
             || file_name.contains("language/move-vm/state/src") // false positives
+            || file_name.contains("language/vm/src") // takes too long
             || file_name.contains("network/src") // false positives
             || file_name.contains("network/onchain-discovery/src") // false positives
             || file_name.contains("client/cli/src") // false positives   


### PR DESCRIPTION
## Description

Allow self recursive functions to descend several calls deep before terminating the recursive loop (which may carry on forever if the base case condition is abstract).

The result of termination is that the caller of a terminated call sees BOTTOM for the result of the recursive call, and hence eliminates all branches that include such calls, effectively computing a summary for the base case. It the next caller up then get's to analyze both the base case and the recursive case using the base case summary. The next caller up from that does it again, but produces a summary where all outputs are widened. The next caller up does it again and then things stop.

The widening means that analysis of self recursive functions are now sound, rather than unsoundly assuming that only the base case ever happens. There is still work to be done to reason usefully about the widened values.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
