### PR TITLE
Remove duplicate of get_function_constant_args

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -494,7 +494,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     }
 
     #[logfn_inputs(TRACE)]
-    fn get_function_constant_args(
+    pub fn get_function_constant_args(
         &self,
         actual_args: &[(Rc<Path>, Rc<AbstractValue>)],
     ) -> Vec<(Rc<Path>, Rc<AbstractValue>)> {

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -152,6 +152,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/bytecode-verifier/src") // false positives
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
+            || file_name.contains("language/resource-viewer/src") // z3 encoding
             || file_name.contains("language/stdlib/src") // false positives
             || file_name.contains("language/move-lang/src") // resolve error
             || file_name.contains("language/move-vm/state/src") // false positives


### PR DESCRIPTION
## Description

Remove duplicate of get_function_constant_args

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

