### PR TITLE
Keep better track of the rustc type of the value expected at a heap path

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1373,10 +1373,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         checked_assume!(self.actual_args.len() == 2);
         let length = self.actual_args[0].1.clone();
         let alignment = self.actual_args[1].1.clone();
+        let tcx = self.block_visitor.bv.tcx;
+        let byte_slice = tcx.mk_slice(tcx.types.u8);
         let heap_path = Path::get_as_path(
             self.block_visitor
                 .bv
-                .get_new_heap_block(length, alignment, false),
+                .get_new_heap_block(length, alignment, false, byte_slice),
         );
         AbstractValue::make_reference(heap_path)
     }
@@ -1387,10 +1389,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         checked_assume!(self.actual_args.len() == 2);
         let length = self.actual_args[0].1.clone();
         let alignment = self.actual_args[1].1.clone();
+        let tcx = self.block_visitor.bv.tcx;
+        let byte_slice = tcx.mk_slice(tcx.types.u8);
         let heap_path = Path::get_as_path(
             self.block_visitor
                 .bv
-                .get_new_heap_block(length, alignment, true),
+                .get_new_heap_block(length, alignment, true, byte_slice),
         );
         AbstractValue::make_reference(heap_path)
     }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -178,10 +178,14 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'analysis, 'tcx> {
                         &self.generic_argument_map,
                     )
                 } else {
-                    info!("path.value is {:?}", path.value);
+                    info!(
+                        "local var path.value is {:?} at {:?}",
+                        path.value, current_span
+                    );
                     self.tcx.types.err
                 }
             }
+            PathEnum::HeapBlock { value } => value.expression.infer_type().as_rustc_type(self.tcx),
             PathEnum::Parameter { ordinal } => {
                 if self.actual_argument_types.len() >= *ordinal {
                     self.actual_argument_types[*ordinal - 1]
@@ -191,7 +195,10 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'analysis, 'tcx> {
                         &self.generic_argument_map,
                     )
                 } else {
-                    info!("path.value is {:?}", path.value);
+                    info!(
+                        "parameter path.value is {:?} at {:?}",
+                        path.value, current_span
+                    );
                     self.tcx.types.err
                 }
             }
@@ -300,11 +307,14 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'analysis, 'tcx> {
                 if let Some(def_id) = def_id {
                     return self.tcx.type_of(*def_id);
                 }
-                info!("path.value is {:?}", path.value);
+                info!(
+                    "static variable path.value is {:?} at {:?}",
+                    path.value, current_span
+                );
                 self.tcx.types.err
             }
             _ => {
-                info!("path.value is {:?}", path.value);
+                info!("path.value is {:?} at {:?}", path.value, current_span);
                 self.tcx.types.err
             }
         }


### PR DESCRIPTION
## Description

It is sometimes necessary to know the Rustc type of a value located at a path that has been constructed from composing paths obtained from summaries with paths obtained from MIR. Such paths can contain heap addresses and there is currently no case to handle that. Add such a case. Also populate the path type cache, which accounts for most of the changes in this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
