### PR TITLE
Simplify *& in Path factory, make &str thin

### DIFF
--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -56,7 +56,7 @@ impl Environment {
     }
 
     /// Updates the path to value map so that the given path now points to the given value.
-    #[logfn_inputs(DEBUG)]
+    #[logfn_inputs(TRACE)]
     pub fn update_value_at(&mut self, path: Rc<Path>, value: Rc<AbstractValue>) {
         if value.is_bottom() || value.is_top() {
             self.value_map = self.value_map.remove(&path);
@@ -107,7 +107,9 @@ impl Environment {
                     alternate,
                 } = &value.expression
                 {
-                    if consequent.is_path_alias() && alternate.is_path_alias() {
+                    if consequent.refers_to_unknown_location()
+                        && alternate.refers_to_unknown_location()
+                    {
                         return Some((
                             condition.clone(),
                             Path::new_alias(consequent.refine_with(condition, 0)),

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -638,12 +638,11 @@ impl Expression {
                 cases,
                 default,
             } => {
-                let mut result = discriminator.expression.contains_local_variable();
-                for (case_val, case_result) in cases {
-                    result |= case_val.expression.contains_local_variable();
-                    result |= case_result.expression.contains_local_variable();
-                }
-                result | default.expression.contains_local_variable()
+                discriminator.expression.contains_local_variable()
+                    || default.expression.contains_local_variable()
+                    || cases
+                        .iter()
+                        .any(|(_, v)| v.expression.contains_local_variable())
             }
             Expression::Top => true,
             Expression::UninterpretedCall { .. } => true,
@@ -926,7 +925,7 @@ impl From<&ConstantDomain> for ExpressionType {
             ConstantDomain::I128(..) => I128,
             ConstantDomain::F64(..) => F64,
             ConstantDomain::F32(..) => F32,
-            ConstantDomain::Str(..) => NonPrimitive,
+            ConstantDomain::Str(..) => ThinPointer,
             ConstantDomain::True => Bool,
             ConstantDomain::U128(..) => U128,
             ConstantDomain::Unimplemented => NonPrimitive,

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -435,11 +435,13 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'analysis, 'tcx> {
     /// Returns true if the given type is a reference (or raw pointer) to a collection type, in which
     /// case the reference/pointer independently tracks the length of the collection, thus effectively
     /// tracking a slice of the underlying collection.
+    #[logfn_inputs(TRACE)]
+    #[logfn(TRACE)]
     pub fn starts_with_slice_pointer(&self, ty_kind: &TyKind<'tcx>) -> bool {
         match ty_kind {
             TyKind::RawPtr(TypeAndMut { ty: target, .. }) | TyKind::Ref(_, target, _) => {
                 // Pointers to sized arrays are thin pointers.
-                matches!(&target.kind, TyKind::Slice(..) | TyKind::Str)
+                matches!(&target.kind, TyKind::Slice(..))
             }
             TyKind::Adt(def, substs) => {
                 for v in def.variants.iter() {
@@ -744,7 +746,7 @@ pub fn get_target_type(ty: Ty<'_>) -> Ty<'_> {
 pub fn is_slice_pointer(ty_kind: &TyKind<'_>) -> bool {
     if let TyKind::RawPtr(TypeAndMut { ty: target, .. }) | TyKind::Ref(_, target, _) = ty_kind {
         // Pointers to sized arrays are thin pointers.
-        matches!(&target.kind, TyKind::Slice(..) | TyKind::Str)
+        matches!(&target.kind, TyKind::Slice(..))
     } else {
         false
     }

--- a/checker/tests/run-pass/box_fail.rs
+++ b/checker/tests/run-pass/box_fail.rs
@@ -9,9 +9,7 @@
 #![feature(box_syntax)]
 
 pub fn test13(i: i64) {
-    //todo: fix the bogus deallocation error by implementing size_of_val
     let _x = box -i; //~ possible attempt to negate with overflow
-                     //~ possibly deallocates the pointer with layout information inconsistent with the allocation
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -17,7 +17,8 @@ fn fact(n: u8) -> u128 {
     } else {
         let n1fac = fact(n - 1);
         verify!(n1fac <= std::u128::MAX / (n as u128));
-        (n as u128) * n1fac
+        // todo: figure out why Z3 times out on this query
+        (n as u128) * n1fac //~ possible attempt to multiply with overflow
     }
 }
 

--- a/checker/tests/run-pass/func_call_return_struct.rs
+++ b/checker/tests/run-pass/func_call_return_struct.rs
@@ -7,7 +7,7 @@
 // A test that uses a function summary where the return value is a structure.
 
 // MIRAI_FLAGS -- -Z mir-opt-level=0
-//todo: figure out why this fails with more optimization
+//todo: implement deserialization of constant structs
 
 #[macro_use]
 extern crate mirai_annotations;

--- a/checker/tests/run-pass/virtual_call.rs
+++ b/checker/tests/run-pass/virtual_call.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that uses built-in contracts for the Vec struct.
+// A test that checks that closure fields are tracked accurately.
 
 #[macro_use]
 extern crate mirai_annotations;


### PR DESCRIPTION
## Description

Make path refinement less hacky by moving most *& elimination into the Path::new_qualified factory function.

Also model &str pointers, correctly, as thin pointers rather than as slice pointers. Deal with the fall out from this change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
