### PR TITLE
Support implicit conversion of slice pointer to thin pointer via index

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -459,7 +459,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         call_visitor.destination = *destination;
         call_visitor.callee_fun_val = func_to_call;
         call_visitor.function_constant_args = func_const_args;
-        debug!("calling func {:?}", call_visitor.callee_func_ref);
+        trace!("calling func {:?}", call_visitor.callee_func_ref);
         if call_visitor.handled_as_special_function_call() {
             return;
         }
@@ -471,25 +471,23 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         {
             call_visitor.deal_with_missing_summary();
         }
-        debug!(
-            "summary {:?} {:?}",
-            func_ref_to_call.summary_cache_key, function_summary
-        );
-        debug!(
+        trace!("def_id {:?}", call_visitor.callee_def_id);
+        trace!("summary {:?} {:?}", func_ref_to_call, function_summary);
+        trace!(
             "pre env {:?}",
             call_visitor.block_visitor.bv.current_environment
         );
-        debug!("target {:?} arguments {:?}", destination, actual_args);
+        trace!("target {:?} arguments {:?}", destination, actual_args);
         call_visitor.check_preconditions_if_necessary(&function_summary);
         call_visitor.transfer_and_refine_normal_return_state(&function_summary);
         call_visitor.transfer_and_refine_cleanup_state(&function_summary);
-        debug!(
+        trace!(
             "post env {:?}",
             call_visitor.block_visitor.bv.current_environment
         );
         if function_summary.post_condition.is_some() {
             if let Some((_, b)) = &call_visitor.destination {
-                debug!(
+                trace!(
                     "post exit conditions {:?}",
                     self.bv.current_environment.exit_conditions.get(b)
                 );
@@ -1946,7 +1944,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     }
 
     /// Use for constants that are accessed via references
-    #[logfn_inputs(DEBUG)]
+    #[logfn_inputs(TRACE)]
     fn get_reference_to_constant(
         &mut self,
         literal: &rustc_middle::ty::Const<'tcx>,

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -111,11 +111,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let summary =
                 body_visitor.visit_body(self.function_constant_args, self.actual_argument_types);
             let call_was_angelic = body_visitor.assume_function_is_angelic;
-            trace!(
-                "summary {:?} {:?}",
-                self.block_visitor.bv.function_name,
-                summary
-            );
+            trace!("summary {:?} {:?}", self.callee_def_id, summary);
             let signature = self.get_function_constant_signature(self.function_constant_args);
             if let Some(func_ref) = &self.callee_func_ref {
                 // We cache the summary with call site details included so that
@@ -1866,13 +1862,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                         self.block_visitor.bv.fresh_variable_offset,
                     )
                     .refine_paths(&return_value_env);
-                debug!(
+                trace!(
                     "refined post condition before path refinement {:?}",
                     refined_post_condition
                 );
                 let refined_post_condition =
                     refined_post_condition.refine_paths(&self.block_visitor.bv.current_environment);
-                debug!("refined post condition {:?}", refined_post_condition);
+                trace!("refined post condition {:?}", refined_post_condition);
                 exit_condition = exit_condition.and(refined_post_condition);
             }
 

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,29 +139,28 @@ impl MiraiCallbacks {
     }
 
     fn is_black_listed(file_name: &str) -> bool {
-        file_name.contains("admission-control/admission-control-proto/src") // resolve error
-            || file_name.contains("consensus/src") // resolve error
+        file_name.contains("consensus/src") // resolve error
+            || file_name.contains("consensus/safety-rules/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
             || file_name.contains("common/bitvec/src") // false positives
-            || file_name.contains("common/logger/src") // z3 encoding
+            || file_name.contains("common/logger/src") // resolve error
             || file_name.contains("common/metrics/src") // stack overflow
-            || file_name.contains("language/bytecode-verifier/src") // false positives
+            || file_name.contains("language/bytecode-verifier/src") // resolve error
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
-            || file_name.contains("language/resource-viewer/src") // z3 encoding
             || file_name.contains("language/move-lang/src") // resolve error
             || file_name.contains("language/move-vm/runtime/src") // resolve error
             || file_name.contains("language/move-prover/src") // false positives
-            || file_name.contains("language/move-prover/spec-lang/src") // illegal down cast
-            || file_name.contains("language/move-prover/stackless-bytecode-generator/src") // false positives
+            || file_name.contains("language/move-prover/spec-lang/src") // false positives
+            || file_name.contains("language/move-prover/stackless-bytecode-generator/src") // resolve error
             || file_name.contains("language/tools/vm-genesis/src") // resolve error
-            || file_name.contains("language/vm/src") // takes too long
+            || file_name.contains("language/vm/src") // false positives
             || file_name.contains("network/src") // resolve error
             || file_name.contains("secure/net/src") // false positives
             || file_name.contains("secure/storage/src") // false positives
-            || file_name.contains("secure/storage/vault/src") // z3 encoding
+            || file_name.contains("secure/storage/vault/src") // resolve error
             || file_name.contains("storage/backup/backup-service/src") // resolve error
             || file_name.contains("storage/jellyfish-merkle/src") // unreachable code
-            || file_name.contains("storage/libradb/src") // 'already borrowed: BorrowMutError'
+            || file_name.contains("storage/libradb/src") // resolve error
             || file_name.contains("testsuite/cli/src") // false positives
             || file_name.contains("types/src") // resolve error
     }


### PR DESCRIPTION
## Description

It turns out that it is possible, via mind bending generics in the standard libraries, to implement a trait method that returns a thin pointer with a method that returns a fat (slice) pointer. Ouch.

Add special case gunk to deal with this edge case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
