### PR TITLE
Implement std::mem::transmute inside MIRAI

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2022,7 +2022,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 alternate,
                 ..
             } => consequent.refers_to_unknown_location() || alternate.refers_to_unknown_location(),
-            Expression::Join { left, right, .. } => {
+            Expression::Join { left, right, .. } | Expression::Offset { left, right } => {
                 left.refers_to_unknown_location() || right.refers_to_unknown_location()
             }
             Expression::Reference(..) => true,

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -93,9 +93,9 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     }
 
     /// Calls a specialized visitor for each kind of statement.
-    #[logfn_inputs(TRACE)]
+    #[logfn_inputs(DEBUG)]
     fn visit_statement(&mut self, location: mir::Location, statement: &mir::Statement<'tcx>) {
-        trace!("env {:?}", self.bv.current_environment);
+        debug!("env {:?}", self.bv.current_environment);
         self.bv.current_location = location;
         let mir::Statement { kind, source_info } = statement;
         self.bv.current_span = source_info.span;
@@ -182,14 +182,14 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     }
 
     /// Calls a specialized visitor for each kind of terminator.
-    #[logfn_inputs(TRACE)]
+    #[logfn_inputs(DEBUG)]
     fn visit_terminator(
         &mut self,
         location: mir::Location,
         source_info: mir::SourceInfo,
         kind: &mir::TerminatorKind<'tcx>,
     ) {
-        trace!("env {:?}", self.bv.current_environment);
+        debug!("env {:?}", self.bv.current_environment);
         self.bv.current_location = location;
         self.bv.current_span = source_info.span;
         match kind {
@@ -412,11 +412,13 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             func_ref_to_call = fr;
         } else {
             self.report_missing_summary();
-            info!(
-                "function {} can't be reliably analyzed because it calls an unknown function. {:?}",
-                utils::summary_key_str(self.bv.tcx, self.bv.def_id),
-                self.bv.current_span
-            );
+            if self.bv.check_for_errors {
+                info!(
+                    "function {} can't be reliably analyzed because it calls an unknown function. {:?}",
+                    utils::summary_key_str(self.bv.tcx, self.bv.def_id),
+                    self.bv.current_span
+                );
+            }
             return;
         }
         let callee_def_id = func_ref_to_call

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -308,7 +308,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
     ) -> Rc<AbstractValue> {
         let result_type: ExpressionType = (&result_rustc_type.kind).into();
         match &path.value {
-            PathEnum::Alias { value } => {
+            PathEnum::Alias { value } | PathEnum::Offset { value } => {
                 return value.clone();
             }
             PathEnum::QualifiedPath {

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -302,7 +302,7 @@ impl Path {
         }
     }
 
-    /// Returns the path to the first leaf field of the structure described by result_rustc_type.
+    /// Returns the path to the first leaf field of the structure described by path_rustc_type.
     /// A field that is of type struct, is not a leaf field.
     /// The field at offset 0 must be a thin pointer.
     #[logfn(TRACE)]
@@ -310,16 +310,16 @@ impl Path {
         tcx: TyCtxt<'tcx>,
         environment: &Environment,
         path: &Rc<Path>,
-        result_rustc_type: Ty<'tcx>,
+        path_rustc_type: Ty<'tcx>,
     ) -> Option<Rc<Path>> {
         trace!(
             "get_path_to_thin_pointer_at_offset_0 {:?} {:?}",
             path,
-            result_rustc_type
+            path_rustc_type
         );
-        match &result_rustc_type.kind {
+        match &path_rustc_type.kind {
             TyKind::Ref(..) | TyKind::RawPtr(..) => {
-                if type_visitor::is_slice_pointer(&result_rustc_type.kind) {
+                if type_visitor::is_slice_pointer(&path_rustc_type.kind) {
                     Some(Path::new_field(path.clone(), 0))
                 } else {
                     Some(path.clone())

--- a/checker/tests/run-pass/transmute.rs
+++ b/checker/tests/run-pass/transmute.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses std::mem::transmute
+
+#![feature(core_intrinsics)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub unsafe fn t1(ptr: *mut i32) {
+    *ptr = 123;
+    let non_null_ptr = std::ptr::NonNull::new_unchecked(ptr);
+    let ptr2 = std::mem::transmute::<std::ptr::NonNull<i32>, *const i32>(non_null_ptr);
+    verify!(*ptr2 == 123);
+}
+
+pub unsafe fn t2(ptr: *mut i32) {
+    *ptr = 123;
+    let non_null_ptr = std::mem::transmute::<*const i32, std::ptr::NonNull<i32>>(ptr);
+    verify!(*non_null_ptr.as_ptr() == 123);
+}
+
+pub unsafe fn t3() {
+    let a = std::alloc::alloc(std::alloc::Layout::from_size_align(4, 2).unwrap());
+    let cptr = std::intrinsics::arith_offset(a, 2);
+    let bptr: *mut u8 = std::mem::transmute::<*const u8, *mut u8>(cptr);
+    *bptr = 7;
+    verify!(*cptr == 7);
+    let cptr1 = std::intrinsics::arith_offset(cptr, 1);
+    let bptr1: *mut u8 = std::mem::transmute::<*const u8, *mut u8>(cptr1);
+    *bptr1 = 1;
+    verify!(*cptr1 == 1);
+    // todo: smash together byte pairs in the heap model when this kind of cast happens
+    // let ptr0 = std::mem::transmute::<*mut u8, *mut u16>(a);
+    // let ptr1 = std::intrinsics::arith_offset(ptr0, 1);
+    // println!("{}", *ptr1);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Make transmute work for pointer to struct and struct to pointer conversions (pretty much a special case for NonNull<T> to *T). Also add test cases and fix up problems that showed up with the way Offset pointers were handled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
