### PR TITLE
Remove deref selector when using Path::implicit_dereference

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -92,23 +92,31 @@ impl Path {
     /// they are already canonical and because doing so can lead to recursive loops as refined paths
     /// re-introduce joined paths that have been split earlier.
     /// A split path, however, can be serve as the qualifier of a newly constructed qualified path
-    /// and this path might not be canonical. This routine removes the two sources of
+    /// and this path might not be canonical. This routine tries to remove the two sources of
     /// de-canonicalization that are currently know. Essentially: when a path that binds to a value
     /// that is a reference is implicitly dereferenced by the qualifier, the canonical path will
     /// be the one without the reference, or the the actual heap block, if the path binds to a heap
-    /// location.
+    /// location. This routine returns a re-canonicalized path in the two scenarios above,
+    /// otherwise returns `None`.
+    ///
+    /// If the function returns a re-canonicalized path, which is used as the qualifier of a newly
+    /// constructed qualified path, the caller of this function should check if the selector of the
+    /// qualified path is `PathSelector::Deref`. If so, the deref selector should also be removed.
     #[logfn_inputs(DEBUG)]
-    pub fn implicit_dereference(path: Rc<Path>, environment: &Environment) -> Rc<Path> {
+    pub fn try_implicit_dereference(
+        path: &Rc<Path>,
+        environment: &Environment,
+    ) -> Option<Rc<Path>> {
         if let PathEnum::Alias { value } = &path.value {
             if let Expression::Reference(path) = &value.expression {
-                return path.clone();
+                return Some(path.clone());
             }
-        } else if let Some(value) = environment.value_map.get(&path) {
+        } else if let Some(value) = environment.value_map.get(path) {
             if let Expression::HeapBlock { .. } = &value.expression {
-                return Path::get_as_path(value.clone());
+                return Some(Path::get_as_path(value.clone()));
             }
         }
-        path
+        None
     }
 }
 

--- a/checker/tests/run-pass/implicit_deref.rs
+++ b/checker/tests/run-pass/implicit_deref.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test that checks if implicit/explicit dereference works properly when doing weak updates
+
+#[macro_use]
+extern crate mirai_annotations;
+
+struct I32 {
+    content: i32,
+}
+
+pub fn implicit_deref(cond: bool) {
+    let mut left = I32 { content: 1234 };
+    let mut right = I32 { content: 4321 };
+    let join: &mut I32;
+    if cond {
+        join = &mut left;
+    } else {
+        join = &mut right;
+    }
+    join.content = 3333; // implicit deref
+    verify!(left.content == 3333 || right.content == 3333);
+}
+
+pub fn explicit_deref(cond: bool) {
+    let mut left = 1234;
+    let mut right = 4321;
+    let join: &mut i32;
+    if cond {
+        join = &mut left;
+    } else {
+        join = &mut right;
+    }
+    *join = 3333; // explicit deref
+    verify!(left == 3333 || right == 3333);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

The function `Path::implicit_deference` is used when splitting path qualifiers while doing weak updates. If the qualifier of a qualified path is indeed canonicalized through this function, the selector should also be removed when it is `PathSelector::Deref`. This commit adds a test to check if implicit dereference works properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra