### PR TITLE
move_or_copy_elements should do weak updates in all cases

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -164,6 +164,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/vm/src") // false positives
             || file_name.contains("network/src") // resolve error
             || file_name.contains("secure/json-rpc/src") // apparently assigning a thin pointer to a fat pointer without a cast
+            || file_name.contains("secure/key-manager/src") // apparently assigning a thin pointer to a fat pointer without a cast
             || file_name.contains("secure/net/src") // false positives
             || file_name.contains("secure/storage/src") // false positives
             || file_name.contains("secure/storage/vault/src") // resolve error

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -130,11 +130,14 @@ impl Environment {
                 if let Some((join_condition, true_path, false_path)) = self.try_to_split(qualifier)
                 {
                     let true_path = if let Some(deref_true_path) =
-                        Path::try_implicit_dereference(&true_path, &self)
+                        Path::try_to_dereference(&true_path, &self)
                     {
                         if *selector.as_ref() == PathSelector::Deref {
+                            // deref_true_path is now the canonical version of true_path
                             deref_true_path
                         } else {
+                            // The selector implicit dereferences true_path, so deref_true_path.selector
+                            // is thus a shorter version, which should be canonical.
                             Path::new_qualified(deref_true_path, selector.clone())
                         }
                     } else {
@@ -142,11 +145,14 @@ impl Environment {
                     };
 
                     let false_path = if let Some(deref_false_path) =
-                        Path::try_implicit_dereference(&false_path, &self)
+                        Path::try_to_dereference(&false_path, &self)
                     {
                         if *selector.as_ref() == PathSelector::Deref {
+                            // deref_false_path is now the canonical version of false_path
                             deref_false_path
                         } else {
+                            // The selector implicit dereferences true_path, so deref_false_path.selector
+                            // is thus a shorter version, which should be canonical.
                             Path::new_qualified(deref_false_path, selector.clone())
                         }
                     } else {

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -92,10 +92,10 @@ impl Path {
     /// they are already canonical and because doing so can lead to recursive loops as refined paths
     /// re-introduce joined paths that have been split earlier.
     /// A split path, however, can be serve as the qualifier of a newly constructed qualified path
-    /// and this path might not be canonical. This routine tries to remove the two sources of
+    /// and the qualified path might not be canonical. This routine tries to remove the two sources of
     /// de-canonicalization that are currently know. Essentially: when a path that binds to a value
-    /// that is a reference is implicitly dereferenced by the qualifier, the canonical path will
-    /// be the one without the reference, or the the actual heap block, if the path binds to a heap
+    /// that is a reference is implicitly dereferenced by the selector, the canonical path will
+    /// be the one without the reference, or the actual heap block, if the path binds to a heap
     /// location. This routine returns a re-canonicalized path in the two scenarios above,
     /// otherwise returns `None`.
     ///
@@ -103,10 +103,7 @@ impl Path {
     /// constructed qualified path, the caller of this function should check if the selector of the
     /// qualified path is `PathSelector::Deref`. If so, the deref selector should also be removed.
     #[logfn_inputs(DEBUG)]
-    pub fn try_implicit_dereference(
-        path: &Rc<Path>,
-        environment: &Environment,
-    ) -> Option<Rc<Path>> {
+    pub fn try_to_dereference(path: &Rc<Path>, environment: &Environment) -> Option<Rc<Path>> {
         if let PathEnum::Alias { value } = &path.value {
             if let Expression::Reference(path) = &value.expression {
                 return Some(path.clone());

--- a/checker/tests/run-pass/weak_update_small_struct.rs
+++ b/checker/tests/run-pass/weak_update_small_struct.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that assigns to a location of type struct that is unknown at compile time.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+struct Bool {
+    content: bool,
+}
+
+pub fn test(cond: bool) {
+    let mut left = Bool { content: false };
+    let mut right = Bool { content: false };
+    let join;
+    if cond {
+        join = &mut left;
+    } else {
+        join = &mut right;
+    }
+    *join = Bool { content: true };
+    verify!(left.content || right.content);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Use update_value_at more consistently so that weak updates happen.

Fixes #537

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra