### PR TITLE
Implement transfer functions for the tag domain

### DIFF
--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -32,17 +32,47 @@ macro_rules! abstract_value {
 pub type TagPropagationSet = u128;
 
 /// An enum type of controllable operations for MIRAI tag types.
-/// todo: add all other controllable operations.
+#[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone)]
 pub enum TagPropagation {
-    Add = 1 << 0,
-    Xor = 1 << 1,
+    Add,
+    AddOverflows,
+    And,
+    BitAnd,
+    BitNot,
+    BitOr,
+    BitXor,
+    Cast,
+    Div,
+    Equals,
+    GreaterOrEqual,
+    GreaterThan,
+    IntrinsicBinary,
+    IntrinsicBitVectorUnary,
+    IntrinsicFloatingPointUnary,
+    LessOrEqual,
+    LessThan,
+    LogicalNot,
+    Mul,
+    MulOverflows,
+    Ne,
+    Neg,
+    Or,
+    Offset,
+    Rem,
+    Shl,
+    ShlOverflows,
+    Shr,
+    ShrOverflows,
+    Sub,
+    SubOverflows,
+    UninterpretedCall,
 }
 
 /// Provide a way to create tag transfer masks. It is equivalent to bitwise-or of all its arguments.
 #[macro_export]
 macro_rules! tag_propagation_set {
     ($($x:expr),*) => {
-        0 $(| ($x as mirai_annotations::TagPropagationSet))*
+        0 $(| (1 << ($x as u8)))*
     };
 }
 

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -5,6 +5,7 @@
 
 use crate::abstract_value::AbstractValue;
 use crate::abstract_value::AbstractValueTrait;
+use crate::bool_domain::BoolDomain;
 use crate::constant_domain::ConstantDomain;
 use crate::environment::Environment;
 use crate::expression::{Expression, ExpressionType, LayoutSource};
@@ -15,6 +16,7 @@ use crate::path::{Path, PathEnum, PathSelector};
 use crate::smt_solver::{SmtResult, SmtSolver};
 use crate::summaries;
 use crate::summaries::{Precondition, Summary};
+use crate::tag_domain::Tag;
 use crate::type_visitor::TypeVisitor;
 use crate::{abstract_value, type_visitor};
 
@@ -1747,5 +1749,20 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
         self.current_environment
             .update_value_at(layout_path, layout);
         block
+    }
+
+    /// Attach `tag` (whose presence is indicated by `val`) to the value located at `source_path`.
+    /// todo: implement weak updates.
+    #[logfn_inputs(TRACE)]
+    pub fn attach_tag_to_elements(
+        &mut self,
+        tag: Tag,
+        val: BoolDomain,
+        source_path: Rc<Path>,
+        source_rustc_type: Ty<'tcx>,
+    ) {
+        let source_exp_type: ExpressionType = (&source_rustc_type.kind).into();
+        self.current_environment
+            .update_value_with_tag(tag, val, source_path, source_exp_type);
     }
 }

--- a/checker/src/bool_domain.rs
+++ b/checker/src/bool_domain.rs
@@ -28,3 +28,51 @@ impl From<bool> for BoolDomain {
         }
     }
 }
+
+/// Transfer functions
+impl BoolDomain {
+    /// Return the join of two Boolean domain elements, which is essentially the set union.
+    #[logfn_inputs(TRACE)]
+    pub fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            // [Top join _] -> Top
+            // [False join True] -> Top
+            (BoolDomain::Top, _)
+            | (_, BoolDomain::Top)
+            | (BoolDomain::False, BoolDomain::True)
+            | (BoolDomain::True, BoolDomain::False) => BoolDomain::Top,
+
+            // [False join False] -> False
+            // [False join Bottom] -> False
+            (BoolDomain::False, _) | (_, BoolDomain::False) => BoolDomain::False,
+
+            // [True join True] -> True
+            // [True join Bottom] -> True
+            (BoolDomain::True, _) | (_, BoolDomain::True) => BoolDomain::True,
+
+            // [Bottom join Bottom] -> Bottom
+            (BoolDomain::Bottom, BoolDomain::Bottom) => BoolDomain::Bottom,
+        }
+    }
+
+    /// Return the logical-or of two Boolean domain elements.
+    #[logfn_inputs(TRACE)]
+    pub fn or(&self, other: &Self) -> Self {
+        match (self, other) {
+            // [Bottom || _] -> Bottom
+            (BoolDomain::Bottom, _) | (_, BoolDomain::Bottom) => BoolDomain::Bottom,
+
+            // [True || True] -> True
+            // [True || False] -> True
+            // [True || Top] -> True
+            (BoolDomain::True, _) | (_, BoolDomain::True) => BoolDomain::True,
+
+            // [Top || Top] -> Top
+            // [Top || False] -> Top
+            (BoolDomain::Top, _) | (_, BoolDomain::Top) => BoolDomain::Top,
+
+            // [False || False] -> False
+            (BoolDomain::False, BoolDomain::False) => BoolDomain::False,
+        }
+    }
+}

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -654,6 +654,63 @@ impl Expression {
         }
     }
 
+    /// Returns a value from the enum `TagPropagation` which reflects the expression kind.
+    /// If the tag propagation behavior for the expression is not controllable, e.g., for
+    /// control-flow expressions such as Conditional or Switch, returns None.
+    #[logfn_inputs(TRACE)]
+    pub fn get_tag_propagation(&self) -> Option<TagPropagation> {
+        match self {
+            Expression::Top => None,
+            Expression::Bottom => None,
+            Expression::Add { .. } => Some(TagPropagation::Add),
+            Expression::AddOverflows { .. } => Some(TagPropagation::AddOverflows),
+            Expression::And { .. } => Some(TagPropagation::And),
+            Expression::BitAnd { .. } => Some(TagPropagation::BitAnd),
+            Expression::BitNot { .. } => Some(TagPropagation::BitNot),
+            Expression::BitOr { .. } => Some(TagPropagation::BitOr),
+            Expression::BitXor { .. } => Some(TagPropagation::BitXor),
+            Expression::Cast { .. } => Some(TagPropagation::Cast),
+            Expression::CompileTimeConstant { .. } => None,
+            Expression::ConditionalExpression { .. } => None,
+            Expression::Div { .. } => Some(TagPropagation::Div),
+            Expression::Equals { .. } => Some(TagPropagation::Equals),
+            Expression::GreaterOrEqual { .. } => Some(TagPropagation::GreaterOrEqual),
+            Expression::GreaterThan { .. } => Some(TagPropagation::GreaterThan),
+            Expression::HeapBlock { .. } => None,
+            Expression::HeapBlockLayout { .. } => None,
+            Expression::IntrinsicBinary { .. } => Some(TagPropagation::IntrinsicBinary),
+            Expression::IntrinsicBitVectorUnary { .. } => {
+                Some(TagPropagation::IntrinsicBitVectorUnary)
+            }
+            Expression::IntrinsicFloatingPointUnary { .. } => {
+                Some(TagPropagation::IntrinsicFloatingPointUnary)
+            }
+            Expression::Join { .. } => None,
+            Expression::LessOrEqual { .. } => Some(TagPropagation::LessOrEqual),
+            Expression::LessThan { .. } => Some(TagPropagation::LessThan),
+            Expression::LogicalNot { .. } => Some(TagPropagation::LogicalNot),
+            Expression::Mul { .. } => Some(TagPropagation::Mul),
+            Expression::MulOverflows { .. } => Some(TagPropagation::MulOverflows),
+            Expression::Ne { .. } => Some(TagPropagation::Ne),
+            Expression::Neg { .. } => Some(TagPropagation::Neg),
+            Expression::Or { .. } => Some(TagPropagation::Or),
+            Expression::Offset { .. } => Some(TagPropagation::Offset),
+            Expression::Reference { .. } => None,
+            Expression::Rem { .. } => Some(TagPropagation::Rem),
+            Expression::Shl { .. } => Some(TagPropagation::Shl),
+            Expression::ShlOverflows { .. } => Some(TagPropagation::ShlOverflows),
+            Expression::Shr { .. } => Some(TagPropagation::Shr),
+            Expression::ShrOverflows { .. } => Some(TagPropagation::ShrOverflows),
+            Expression::Sub { .. } => Some(TagPropagation::Sub),
+            Expression::SubOverflows { .. } => Some(TagPropagation::SubOverflows),
+            Expression::Switch { .. } => None,
+            Expression::UninterpretedCall { .. } => Some(TagPropagation::UninterpretedCall),
+            Expression::UnknownModelField { .. } => None,
+            Expression::Variable { .. } => None,
+            Expression::Widen { .. } => None,
+        }
+    }
+
     /// Returns the type of value the expression should result in, if well formed.
     /// (both operands are of the same type for binary operators, conditional branches match).
     #[logfn_inputs(TRACE)]

--- a/checker/src/tag_domain.rs
+++ b/checker/src/tag_domain.rs
@@ -6,14 +6,25 @@
 use crate::bool_domain::BoolDomain;
 
 use log_derive::logfn_inputs;
-use mirai_annotations::TagPropagationSet;
+use mirai_annotations::*;
 use rpds::{rbt_map, RedBlackTreeMap};
 use rustc_hir::def_id::DefId;
 
-/// A tag is represented as a pair of its tag kind and its control mask.
-/// The tag kind is the name of the declared tag type, and the control mask is associated to the
+/// Check if a value of enum type `TagPropagation` is included in a tag propagation set.
+macro_rules! does_propagate_tag {
+    ($set:expr, $x:expr) => {
+        ($set & (1 << ($x as u8))) != 0
+    };
+}
+
+/// A tag is represented as a pair of its tag kind and its propagation set.
+/// The tag kind is the name of the declared tag type, and the propagation set is associated to the
 /// tag type as a const generic parameter.
-pub type Tag = (DefId, TagPropagationSet);
+#[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone)]
+pub struct Tag {
+    pub def_id: DefId,
+    pub prop_set: TagPropagationSet,
+}
 
 /// An element of the tag domain is essentially an over-approximation for present and absent tags.
 /// The approximation is denoted as a map from tags to lifted Boolean values (`BoolDomain`).
@@ -37,6 +48,7 @@ impl TagDomain {
 /// Transfer functions
 impl TagDomain {
     /// Return a new tag domain element by adding the `tag` whose presence is indicated by `val`.
+    #[logfn_inputs(TRACE)]
     pub fn add_tag(&self, tag: Tag, val: BoolDomain) -> Self {
         TagDomain {
             map: self.map.insert(tag, val),
@@ -44,7 +56,51 @@ impl TagDomain {
     }
 
     /// Return a lifted Boolean that indicates the presence of `tag` in the tag domain element.
+    #[logfn_inputs(TRACE)]
     pub fn has_tag(&self, tag: &Tag) -> BoolDomain {
         *self.map.get(tag).unwrap_or(&BoolDomain::False)
+    }
+
+    /// Return the union of two tag domain elements, which is pointwise logical-or on lifted Booleans.
+    #[logfn_inputs(TRACE)]
+    pub fn union(&self, other: &Self) -> Self {
+        let mut new_map = rbt_map![];
+        for (tag, val) in self.map.iter().chain(other.map.iter()) {
+            let cur_val = *new_map.get(tag).unwrap_or(&BoolDomain::False);
+            let new_val = cur_val.or(val);
+            new_map.insert_mut(*tag, new_val);
+        }
+        TagDomain { map: new_map }
+    }
+
+    /// Return the join of two tag domain elements, which is pointwise join on lifted Booleans.
+    #[logfn_inputs(TRACE)]
+    pub fn join(&self, other: &Self) -> Self {
+        let mut new_map = rbt_map![];
+        for (tag, val) in self.map.iter().chain(other.map.iter()) {
+            let cur_val = *new_map.get(tag).unwrap_or(&BoolDomain::False);
+            let new_val = cur_val.join(val);
+            new_map.insert_mut(*tag, new_val);
+        }
+        TagDomain { map: new_map }
+    }
+
+    /// Return a tag domain element that filters out tags which are not propagated by an expression.
+    #[logfn_inputs(TRACE)]
+    pub fn filter(&self, exp_tag_prop: TagPropagation) -> Self {
+        precondition!((exp_tag_prop as u8) < 128);
+        let new_map: RedBlackTreeMap<Tag, BoolDomain> = self
+            .map
+            .iter()
+            .filter_map(|(tag, val)| {
+                let tag_propagation_set = tag.prop_set;
+                if does_propagate_tag!(tag_propagation_set, exp_tag_prop) {
+                    Some((*tag, *val))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        TagDomain { map: new_map }
     }
 }

--- a/checker/tests/run-pass/tag_domain.rs
+++ b/checker/tests/run-pass/tag_domain.rs
@@ -15,26 +15,42 @@ use mirai_annotations::{TagPropagation, TagPropagationSet};
 
 struct SecretTaint<const MASK: TagPropagationSet> {}
 
-const SECRET_TAINT: TagPropagationSet =
-    tag_propagation_set!(TagPropagation::Add, TagPropagation::Xor);
+const SECRET_TAINT: TagPropagationSet = tag_propagation_set!(TagPropagation::BitOr);
 
 struct SecretSanitizer<const MASK: TagPropagationSet> {}
 
-const SECRET_SANITIZER: TagPropagationSet = tag_propagation_set!();
+const SECRET_SANITIZER: TagPropagationSet = tag_propagation_set!(TagPropagation::BitXor);
 
-pub fn main() {
-    let secret = 23333;
+pub fn test1(secret: i32) {
     add_tag!(&secret, SecretTaint<SECRET_TAINT>);
     verify!(has_tag!(&secret, SecretTaint<SECRET_TAINT>));
     verify!(does_not_have_tag!(
         &secret,
         SecretSanitizer<SECRET_SANITIZER>
     ));
-    let info = secret + 1;
-    // verify!(has_tag!(&info, SecretTaint<SECRET_TAINT>));
-    // verify!(does_not_have_tag!(&info, SecretSanitizer<SECRET_SANITIZER>));
+    let info = secret | 1;
+    verify!(has_tag!(&info, SecretTaint<SECRET_TAINT>));
+    verify!(does_not_have_tag!(&info, SecretSanitizer<SECRET_SANITIZER>));
     let encrypted = info ^ 99991;
     add_tag!(&encrypted, SecretSanitizer<SECRET_SANITIZER>);
-    // verify!(has_tag!(&encrypted, SecretTaint<SECRET_TAINT>));
+    verify!(does_not_have_tag!(&encrypted, SecretTaint<SECRET_TAINT>));
     verify!(has_tag!(&encrypted, SecretSanitizer<SECRET_SANITIZER>));
+    let temp = encrypted ^ 10003;
+    verify!(does_not_have_tag!(&temp, SecretTaint<SECRET_TAINT>));
+    verify!(has_tag!(&temp, SecretSanitizer<SECRET_SANITIZER>));
+    let polluted = temp | secret;
+    verify!(has_tag!(&polluted, SecretTaint<SECRET_TAINT>));
+    verify!(does_not_have_tag!(
+        &polluted,
+        SecretSanitizer<SECRET_SANITIZER>
+    ));
 }
+
+pub fn test2(v: Vec<i32>, i: usize) {
+    precondition!(i < v.len() && v.len() == 3);
+    add_tag!(&v[i], SecretTaint<SECRET_TAINT>);
+    verify!(has_tag!(&v[i], SecretTaint<SECRET_TAINT>));
+    verify!(does_not_have_tag!(&v[0], SecretTaint<SECRET_TAINT>)); // todo: implement weak updates for tags
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

This commit implements transfer functions for the tag domain (introduced in #532). Similar to the interval domain, tags are computed on demand via function `AbstractValue::get_tags`. The transfer function looks up each tag's propagation set (of type `mirai_annotations::TagPropagationSet`) to decide whether an expression should propagate the tag from sub-expressions or not.

The function `BodyVisitor::attach_tag_to_elements` and `Environment::update_value_with_tag` implement the tag adding routine. They are similar to `BodyVisitor::copy_or_move_elements` and `Environment::update_value_at`, but they don't enumerate possible paths rooted at the tagged value. On the other hand, when checking if a value--located at a qualified path--has a tag, one has to also check if its qualifier has been attached with a tag. The mechanism is implemented by function `CallVisitor::handle_has_tag`.

Caveats: weak updates for tags are not implemented; expression simplifications (which happen in methods of `AbstractValueTrait`) may lose track of tags.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra
