### PR TITLE
Specialize types of operands that are closures

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,7 +139,8 @@ impl MiraiCallbacks {
     }
 
     fn is_black_listed(file_name: &str) -> bool {
-        file_name.contains("consensus/src") // resolve error
+        file_name.contains("config/management/src") // false positives
+            || file_name.contains("consensus/src") // resolve error
             || file_name.contains("consensus/safety-rules/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
             || file_name.contains("common/bitvec/src") // false positives
@@ -147,7 +148,6 @@ impl MiraiCallbacks {
             || file_name.contains("common/logger/src") // resolve error
             || file_name.contains("common/metrics/src") // stack overflow
             || file_name.contains("config/config-builder/src") // false positives
-            || file_name.contains("execution/executor/src") // apparently assigning a thin pointer to a fat pointer without a cast
             || file_name.contains("language/bytecode-verifier/src") // resolve error
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
@@ -157,14 +157,10 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-prover/spec-lang/src") // false positives
             || file_name.contains("language/resource-viewer/src") // illegal down cast
             || file_name.contains("language/move-prover/stackless-bytecode-generator/src") // resolve error
-            || file_name.contains("language/stdlib/src") // fat thin
-            || file_name.contains("language/stdlib/compiled/src") // fat thin
             || file_name.contains("language/tools/vm-genesis/src") // resolve error
-            || file_name.contains("language/transaction-builder/src") // fat thin
+            || file_name.contains("language/tools/genesis-viewer/src") // false positives
             || file_name.contains("language/vm/src") // false positives
             || file_name.contains("network/src") // resolve error
-            || file_name.contains("secure/json-rpc/src") // apparently assigning a thin pointer to a fat pointer without a cast
-            || file_name.contains("secure/key-manager/src") // apparently assigning a thin pointer to a fat pointer without a cast
             || file_name.contains("secure/net/src") // false positives
             || file_name.contains("secure/storage/src") // false positives
             || file_name.contains("secure/storage/vault/src") // resolve error
@@ -172,8 +168,8 @@ impl MiraiCallbacks {
             || file_name.contains("storage/jellyfish-merkle/src") // unreachable code
             || file_name.contains("storage/backup/backup-cli/src") // panics
             || file_name.contains("storage/libradb/src") // resolve error
-            || file_name.contains("storage/scratchpad/src") // apparently assigning a thin pointer to a fat pointer without a cast
             || file_name.contains("testsuite/cli/src") // false positives
+            || file_name.contains("testsuite/cli/libra-wallet/src") // takes too long
             || file_name.contains("types/src") // resolve error
     }
 

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -211,13 +211,9 @@ pub fn summarize(
     unwind_environment: &Environment,
     tcx: TyCtxt<'_>,
 ) -> Summary {
-    trace!(
+    debug!(
         "summarize env {:?} pre {:?} post {:?} unwind cond {:?} unwind env {:?}",
-        exit_environment,
-        preconditions,
-        post_condition,
-        unwind_condition,
-        unwind_environment
+        exit_environment, preconditions, post_condition, unwind_condition, unwind_environment
     );
     let mut preconditions: Vec<Precondition> = add_provenance(preconditions, tcx);
     let mut side_effects = if let Some(exit_environment) = exit_environment {


### PR DESCRIPTION
## Description

Specialize closure types with generic arguments to improve trait resolution.
Remove duplicate visit_function_reference.
Tweak handling of unexpected pointer assignments to not crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
