### PR TITLE
Tweak readable version of an impl method summary key string

### DIFF
--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -317,10 +317,11 @@ pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
                             continue;
                         }
                     }
-                }
-                if let Some(type_ns) = &type_ns {
-                    name.push_str(&type_ns);
-                    continue;
+                    if type_ns.is_some() {
+                        let def_path_str = tcx.def_path_str(parent_def_id).replace("::", "_");
+                        name.push_str(&def_path_str);
+                        continue;
+                    }
                 }
             }
             let da = component.disambiguator.to_string();


### PR DESCRIPTION
## Description

When a module has several impl blocks, the first path component string that is in the type namespace is not enough to make the path unique. I can't figure out how to reliably get more information directly from the def path, but tcx.def_path_str somehow figures things out, so I'm just using that and hoping that replacing "::" with "_" is enough to make the resulting key string something that can be expressed in Rust syntax.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra (and observed that a key string that was ambiguous is now sufficiently qualified).
