### PR TITLE
Get function references from function types.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -608,7 +608,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     &self.bv.type_visitor.generic_argument_map,
                 );
                 match specialized_closure_ty.kind {
-                    TyKind::Closure(def_id, substs) => {
+                    TyKind::Closure(def_id, substs) | TyKind::FnDef(def_id, substs) => {
                         return extract_func_ref(self.visit_function_reference(
                             def_id,
                             specialized_closure_ty,
@@ -621,7 +621,9 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                                 ty,
                                 &self.bv.type_visitor.generic_argument_map,
                             );
-                        if let TyKind::Closure(def_id, substs) = specialized_closure_ty.kind {
+                        if let TyKind::Closure(def_id, substs) | TyKind::FnDef(def_id, substs) =
+                            specialized_closure_ty.kind
+                        {
                             return extract_func_ref(self.visit_function_reference(
                                 def_id,
                                 specialized_closure_ty,


### PR DESCRIPTION
## Description

Non constant operands that provide functions to call do not have to be typed as closures, but can be plain function pointers as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
