### PR TITLE
Fix copy_from_slice.

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1029,7 +1029,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     {
                         if let PathEnum::QualifiedPath { selector, .. } = &tpath.value {
                             if matches!(selector.as_ref(), PathSelector::Field(0)) {
-                                // rpath = qualifier.0 and rvalue = &path, so thin pointer copy
+                                // tpath = qualifier.0 and rvalue = &path, so thin pointer copy
                                 self.current_environment.update_value_at(tpath, rvalue);
                                 continue;
                             }

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1404,8 +1404,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     #[logfn_inputs(TRACE)]
     fn handle_copy_non_overlapping(&mut self) {
         checked_assume!(self.actual_args.len() == 3);
-        let target_root = self.actual_args[0].0.clone();
-        let source_path = self.actual_args[1].0.clone();
+        let source_path = self.actual_args[0].0.clone();
+        let target_root = self.actual_args[1].0.clone();
         let count = self.actual_args[2].1.clone();
         let target_path = Path::new_slice(target_root, count)
             .refine_paths(&self.block_visitor.bv.current_environment);

--- a/checker/tests/run-pass/copy_from_slice.rs
+++ b/checker/tests/run-pass/copy_from_slice.rs
@@ -3,6 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#![feature(core_intrinsics)]
+use mirai_annotations::*;
+
 // A test that does a slice to slice copy where the underlying storage of the target slice is
 // not the same length as the source slice.
 
@@ -11,6 +14,14 @@ pub fn to_bytes(r: [u8; 4]) -> [u8; 8] {
 
     signature_bytes[..4].copy_from_slice(&r[..]);
     signature_bytes
+}
+
+pub fn test() {
+    let r = [1u8; 4];
+    let mut signature_bytes: [u8; 8] = [0u8; 8];
+
+    signature_bytes[..4].copy_from_slice(&r[..]);
+    verify!(signature_bytes[0] == 1);
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/slice_copy.rs
+++ b/checker/tests/run-pass/slice_copy.rs
@@ -10,31 +10,31 @@
 extern crate mirai_annotations;
 
 pub fn t1() {
-    let mut a = [1, 2, 3];
+    let a = [1, 2, 3];
     let mut b = [4, 5, 6];
     unsafe {
-        let aptr = a.as_mut_ptr();
+        let aptr = a.as_ptr();
         verify!(*aptr == 1);
         let bptr = b.as_mut_ptr();
         std::intrinsics::copy_nonoverlapping(aptr, bptr, 2);
     }
-    verify!(a[0] == 4);
-    verify!(a[1] == 5);
-    verify!(a[2] == 3);
+    verify!(b[0] == 1);
+    verify!(b[1] == 2);
+    verify!(b[2] == 6);
 }
 
-fn t2copy(a: &mut [i32], b: &mut [i32]) {
+fn t2copy(a: &[i32], b: &mut [i32]) {
     unsafe {
-        let aptr = a.as_mut_ptr();
+        let aptr = a.as_ptr();
         let bptr = b.as_mut_ptr();
         std::intrinsics::copy_nonoverlapping(aptr, bptr, 2);
     }
 }
 
 pub fn t2() {
-    let mut a = [1, 2, 3];
+    let a = [1, 2, 3];
     let mut b = [4, 5, 6];
-    t2copy(&mut b, &mut a);
+    t2copy(&a, &mut b);
     verify!(a[0] == 1);
     verify!(a[1] == 2);
     verify!(a[2] == 3);
@@ -43,18 +43,18 @@ pub fn t2() {
     verify!(b[2] == 6);
 }
 
-fn t3copy(a: &mut [i32], b: &mut [i32], count: usize) {
+fn t3copy(a: &[i32], b: &mut [i32], count: usize) {
     unsafe {
-        let aptr = a.as_mut_ptr();
+        let aptr = a.as_ptr();
         let bptr = b.as_mut_ptr();
         std::intrinsics::copy_nonoverlapping(aptr, bptr, count);
     }
 }
 
 pub fn t3() {
-    let mut a = [1, 2, 3];
+    let a = [1, 2, 3];
     let mut b = [4, 5, 6];
-    t3copy(&mut b, &mut a, 2);
+    t3copy(&a, &mut b, 2);
     verify!(a[0] == 1);
     verify!(a[1] == 2);
     verify!(a[2] == 3);


### PR DESCRIPTION
## Description

Add a special case to copy_or_move_elements to deal with thin pointer assignments that arise from copy_from_slice. Add a test case that fails. While at it, fix a stupid bug with copy_non_overlapping where src and dest were reversed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
