### PR TITLE
Implement weak updates for tags

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1037,9 +1037,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
 
             // Augment the tags associated at the source with a new tag.
-            self.block_visitor
-                .bv
-                .attach_tag_to_elements(tag, source_path, source_rustc_type);
+            self.block_visitor.bv.attach_tag_to_elements(
+                tag,
+                abstract_value::TRUE.into(),
+                source_path,
+                source_rustc_type,
+            );
         }
 
         // Update exit conditions.

--- a/checker/tests/run-pass/tag_domain.rs
+++ b/checker/tests/run-pass/tag_domain.rs
@@ -26,8 +26,9 @@ const SECRET_SANITIZER: TagPropagationSet = tag_propagation_set!(TagPropagation:
 
 type SecretSanitizer = SecretSanitizerKind<SECRET_SANITIZER>;
 
-pub fn test() {
-    let secret = 23333;
+pub fn test(secret: i32) {
+    precondition!(does_not_have_tag!(&secret, SecretTaint));
+    precondition!(does_not_have_tag!(&secret, SecretSanitizer));
 
     add_tag!(&secret, SecretTaint);
     verify!(has_tag!(&secret, SecretTaint));
@@ -35,7 +36,8 @@ pub fn test() {
 
     let info = secret | 1;
     verify!(has_tag!(&info, SecretTaint));
-    verify!(does_not_have_tag!(&info, SecretSanitizer));
+    // todo: keep track of tag information from preconditions
+    verify!(does_not_have_tag!(&info, SecretSanitizer)); //~ possible false verification condition
 
     let encrypted = info ^ 99991;
     add_tag!(&encrypted, SecretSanitizer);
@@ -48,7 +50,8 @@ pub fn test() {
 
     let polluted = temp | secret;
     verify!(has_tag!(&polluted, SecretTaint));
-    verify!(does_not_have_tag!(&polluted, SecretSanitizer));
+    // todo: keep track of tag information from preconditions
+    verify!(does_not_have_tag!(&polluted, SecretSanitizer)); //~ possible false verification condition
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/tag_weak_updates.rs
+++ b/checker/tests/run-pass/tag_weak_updates.rs
@@ -24,7 +24,7 @@ pub fn test1(i: usize) {
     let v = [1, 2, 3];
     add_tag!(&v[i], SecretTaint);
     verify!(has_tag!(&v[i], SecretTaint));
-    verify!(does_not_have_tag!(&v[0], SecretTaint)); // todo: implement weak updates for tags
+    verify!(has_tag!(&v[0], SecretTaint)); //~ possible false verification condition
 }
 
 pub fn test2(v: &[i32], i: usize) {
@@ -32,6 +32,15 @@ pub fn test2(v: &[i32], i: usize) {
     add_tag!(&v[i], SecretTaint);
     verify!(has_tag!(&v[i], SecretTaint));
     verify!(has_tag!(&v[0], SecretTaint)); //~ possible false verification condition
+}
+
+pub fn test3(i: usize) {
+    precondition!(i < 3usize);
+    let v = [1, 2, 3];
+    add_tag!(&v[0], SecretTaint);
+    verify!(has_tag!(&v[0], SecretTaint));
+    verify!(does_not_have_tag!(&v[1], SecretTaint));
+    verify!(has_tag!(&v[i], SecretTaint)); //~ possible false verification condition
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

This commit implements weak updates for adding tags. For example, when tagging an indexed path `a[i]` where `i` is unknown, we need to update all indexed paths rooted at `a` in a way that they may be tagged.

This commit is not in a good shape yet because there are some issues, but I think it would be convenient to have code around during a discussion. The first issue is that the logic of `attach_tag_to_elements` is very similar to that of `copy_or_move_elements`, and there are many duplicate code segments (for example, the treatment of index patterns). It is possible to unify the two routines by adding a parameter to `copy_or_move_elements` to indicate some extra operations right before we move/copy an element. I propose to implement a general routine like `copy_or_move_elements_with_op` in a way that both `copy_or_move_elements` and `attach_tag_to_elements` can invoke it.

The other issue is the logic for `copy_or_move_elements`. Currently, it handles patterns and then invokes `Environment::update_value_at`, which can split a path that was constructed via join. However, it seems that we need to split the path first, because the target path might be a join of multiple indexed paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra