### PR TITLE
Keep track of tag checks from preconditions

### DIFF
--- a/checker/src/tag_domain.rs
+++ b/checker/src/tag_domain.rs
@@ -164,11 +164,11 @@ impl TagDomain {
 
 /// Transfer functions
 impl TagDomain {
-    /// Return a new tag domain element by setting `tag` to True in `self`.
+    /// Return a new tag domain element by setting `tag` to `val` in `self`.
     #[logfn_inputs(TRACE)]
-    pub fn add_tag(&self, tag: Tag) -> Self {
+    pub fn set_tag(&self, tag: Tag, val: BoolDomain) -> Self {
         TagDomain {
-            map: self.map.insert(tag, BoolDomain::True),
+            map: self.map.insert(tag, val),
             value_for_untracked_tags: self.value_for_untracked_tags,
         }
     }

--- a/checker/tests/run-pass/tag_domain.rs
+++ b/checker/tests/run-pass/tag_domain.rs
@@ -26,8 +26,9 @@ const SECRET_SANITIZER: TagPropagationSet = tag_propagation_set!(TagPropagation:
 
 type SecretSanitizer = SecretSanitizerKind<SECRET_SANITIZER>;
 
-pub fn test() {
-    let secret = 23333;
+pub fn test(secret: i32) {
+    precondition!(does_not_have_tag!(&secret, SecretTaint));
+    precondition!(does_not_have_tag!(&secret, SecretSanitizer));
 
     add_tag!(&secret, SecretTaint);
     verify!(has_tag!(&secret, SecretTaint));


### PR DESCRIPTION
## Description

The commit improves the precision of tag checks by refining tag abstractions when refining an abstract value with respect to a path condition. For example, if the path condition assumes (e.g., by preconditions) `has_tag!(param, Secret)` where `param` is a parameter, we want to update the abstract value of `param` to reflect that it has tag `Secret`. The information is needed to propagate tag `Secret` precisely when `param` is used in a compound expression later in the function.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra
