### PR TITLE
Cleanup non_patterned_copy_or_move_elements

### DIFF
--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -1046,8 +1046,7 @@ impl<'a> From<&TyKind<'a>> for ExpressionType {
             TyKind::Uint(ast::UintTy::U128) => ExpressionType::U128,
             TyKind::Float(ast::FloatTy::F32) => ExpressionType::F32,
             TyKind::Float(ast::FloatTy::F64) => ExpressionType::F64,
-            TyKind::Closure(..)
-            | TyKind::Dynamic(..)
+            TyKind::Dynamic(..)
             | TyKind::Foreign(..)
             | TyKind::FnDef(..)
             | TyKind::FnPtr(..)


### PR DESCRIPTION
## Description

Clean up and generalize non_patterned_copy_or_move_elements so that it can be re-used for attaching taint tags to values.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
