### PR TITLE
Make joined target paths into a pattern

### DIFF
--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -98,7 +98,10 @@ impl Environment {
     /// and alternate, respectively. These paths can then be weakly updated to reflect the
     /// lack of precise knowledge at compile time.
     #[logfn_inputs(TRACE)]
-    fn try_to_split(&mut self, path: &Rc<Path>) -> Option<(Rc<AbstractValue>, Rc<Path>, Rc<Path>)> {
+    pub fn try_to_split(
+        &mut self,
+        path: &Rc<Path>,
+    ) -> Option<(Rc<AbstractValue>, Rc<Path>, Rc<Path>)> {
         match &path.value {
             PathEnum::Alias { value } => {
                 if let Expression::ConditionalExpression {

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -310,6 +310,9 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                     PathSelector::Index(_) => {
                         return get_element_type(t);
                     }
+                    PathSelector::Layout => {
+                        return self.tcx.types.trait_object_dummy_self;
+                    }
                     PathSelector::Slice(_) => {
                         return if type_visitor::is_slice_pointer(&t.kind) {
                             t


### PR DESCRIPTION
## Description

Make copy_or_move_elements explicitly aware of target paths that contain joined paths, so that recursive pattern expansion can reach inside such joins.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
