### PR TITLE
Fix attach_tag_to_elements

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -2014,12 +2014,12 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
         }
 
         self.distribute_over_target_joins(
-            value_path.clone(),
+            value_path,
             Rc::new(abstract_value::TRUE),
             &|_self, sub_path| {
                 _self.non_patterned_copy_or_move_elements(
+                    sub_path.clone(),
                     sub_path,
-                    value_path.clone(),
                     root_rustc_type,
                     false,
                     |_self, path, _, new_value| {
@@ -2032,8 +2032,8 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
             },
             &|_self, sub_path, condition| {
                 _self.non_patterned_copy_or_move_elements(
+                    sub_path.clone(),
                     sub_path,
-                    value_path.clone(),
                     root_rustc_type,
                     false,
                     |_self, path, old_value, new_value| {

--- a/checker/tests/run-pass/tag_struct.rs
+++ b/checker/tests/run-pass/tag_struct.rs
@@ -52,9 +52,7 @@ pub fn test3(cond: bool) {
         join = &right;
     }
     add_tag!(join, SecretTaint);
-    // todo: try to split path first when attaching tags
     verify!(has_tag!(&left.content, SecretTaint) || has_tag!(&right.content, SecretTaint));
-    //~ provably false verification condition
 }
 
 pub fn test4(foo: Foo, cond: bool) {


### PR DESCRIPTION
## Description

The method `attach_tag_to_elements` should use decomposed value paths (with respect to joins) as both the source and the target of strong/weak updates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh (MIRAI on MIRAI failed)
ran MIRAI over Libra