### PR TITLE
Refine rather than simplify to reduce &*ptr to just ptr

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -804,7 +804,7 @@ pub fn is_thin_pointer(ty_kind: &TyKind<'_>) -> bool {
 pub fn is_slice_pointer(ty_kind: &TyKind<'_>) -> bool {
     if let TyKind::RawPtr(TypeAndMut { ty: target, .. }) | TyKind::Ref(_, target, _) = ty_kind {
         // Pointers to sized arrays are thin pointers.
-        matches!(&target.kind, TyKind::Slice(..))
+        matches!(&target.kind, TyKind::Slice(..)) || is_slice_pointer(&target.kind)
     } else {
         false
     }


### PR DESCRIPTION
## Description

Doing the &*ptr -> ptr transformation inside the factory function for qualified paths makes it difficult to defer the refinement when needed to ensure that &* is treated differently from & composed with *.

Also fix is_slice_pointer to report that pointers to slice pointers are themselves slice pointers.

Finally, add a bunch of comments to document these intricacies a bit better.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
