### PR TITLE
Remove unnecessary feature from annotations crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.9.0",
+ "mirai-annotations 1.9.1",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -339,13 +339,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.9.0"
+version = "1.9.1"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.9.0",
+ "mirai-annotations 1.9.1",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
  "contracts 0.4.0 (git+https://gitlab.com/karroffel/contracts.git?branch=master)",
- "mirai-annotations 1.9.0",
+ "mirai-annotations 1.9.1",
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ dependencies = [
 name = "taint-error"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.9.0",
+ "mirai-annotations 1.9.1",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -3,9 +3,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-#![feature(const_generics)]
-#![allow(incomplete_features)]
-
 // A set of macros and functions to use for annotating source files that are being checked with MIRAI
 
 /// Provides a way to specify a value that should be treated abstractly by the verifier.
@@ -25,7 +22,7 @@ macro_rules! abstract_value {
     };
 }
 
-/// A type for transfer  of MIRAI tag types. The type is an alias of `u128`.
+/// A type used to specify how tag types transfer over operations. The type is an alias of `u128`.
 /// Each bit of the bit vector controls the transfer function for an operation.
 /// If a bit is set to one, the corresponding operation will propagate the tag.
 /// If a bit is set to zero, the corresponding operation will block the tag.


### PR DESCRIPTION
## Description

Remove #![feature(const_generics)] from the mirai_annotations crate.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh

