### PR TITLE
Stacked heap counters

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,7 +139,8 @@ impl MiraiCallbacks {
     }
 
     fn is_black_listed(file_name: &str) -> bool {
-        file_name.contains("config/management/src") // false positives
+        file_name.contains("client/libra-dev/src") // illegal down cast
+            || file_name.contains("config/management/src") // false positives
             || file_name.contains("consensus/src") // resolve error
             || file_name.contains("consensus/safety-rules/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -1043,13 +1043,14 @@ impl<'tcx> ConstantValueCache<'tcx> {
         })
     }
 
-    /// Resets the heap block counter to 0.
     /// Do this for every function body to ensure that its analysis is not dependent on what
     /// happened elsewhere. Also remember to relocate heap addresses from summaries of other
     /// functions when transferring callee state to the caller's state.
     #[logfn_inputs(TRACE)]
-    pub fn reset_heap_counter(&mut self) {
-        self.heap_address_counter = 0;
+    pub fn swap_heap_counter(&mut self, new_value: usize) -> usize {
+        let old_value = self.heap_address_counter;
+        self.heap_address_counter = new_value;
+        old_value
     }
 }
 

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -144,7 +144,6 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
         let mut diagnostics: Vec<DiagnosticBuilder<'compilation>> = Vec::new();
         let mut active_calls_map: HashMap<DefId, u64> = HashMap::new();
         let mut z3_solver = Z3Solver::default();
-        self.constant_value_cache.reset_heap_counter();
         let mut body_visitor = BodyVisitor::new(
             self,
             def_id,


### PR DESCRIPTION
## Description

Every function body must be analyzed with a heap counter starting at zero. The code that was to ensure this inadvertently got bypassed when on-demand body analysis was introduced. Replaced it with a stack discipline.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
