### PR TITLE
Relocate heap addresses imported from summaries

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -3046,7 +3046,16 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             Expression::GreaterThan { left, right } => left
                 .refine_parameters(arguments, result, fresh)
                 .greater_than(right.refine_parameters(arguments, result, fresh)),
-            Expression::HeapBlock { .. } => self.clone(),
+            Expression::HeapBlock {
+                abstract_address,
+                is_zeroed,
+            } => AbstractValue::make_from(
+                Expression::HeapBlock {
+                    abstract_address: *abstract_address + fresh,
+                    is_zeroed: *is_zeroed,
+                },
+                1,
+            ),
             Expression::HeapBlockLayout {
                 length,
                 alignment,

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -568,13 +568,16 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
         };
         if summary.is_computed && !summary.side_effects.is_empty() {
             let side_effects = summary.side_effects.clone();
+            self.fresh_variable_offset += 1_000_000;
             // Effects on the path
             self.transfer_and_refine(&side_effects, path.clone(), &Path::new_result(), &None, &[]);
             // Effects on the heap
             for (path, value) in side_effects.iter() {
                 if path.is_rooted_by_abstract_heap_block() {
-                    self.current_environment
-                        .update_value_at(path.clone(), value.clone());
+                    self.current_environment.update_value_at(
+                        path.refine_parameters(&[], &None, self.fresh_variable_offset),
+                        value.refine_parameters(&[], &None, self.fresh_variable_offset),
+                    );
                 }
             }
             true

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1928,10 +1928,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                                 self.block_visitor.bv.fresh_variable_offset,
                             )
                             .refine_paths(&self.block_visitor.bv.current_environment);
-                        self.block_visitor
-                            .bv
-                            .current_environment
-                            .update_value_at(path.clone(), rvalue);
+                        self.block_visitor.bv.current_environment.update_value_at(
+                            path.refine_parameters(
+                                self.actual_args,
+                                result_path,
+                                self.block_visitor.bv.fresh_variable_offset,
+                            ),
+                            rvalue,
+                        );
                     }
                     check_for_early_return!(self.block_visitor.bv);
                 }

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -650,6 +650,10 @@ impl PathRefinement for Rc<Path> {
         fresh: usize,
     ) -> Rc<Path> {
         match &self.value {
+            PathEnum::HeapBlock { value } => {
+                let refined_value = value.refine_parameters(arguments, result, fresh);
+                Path::get_as_path(refined_value)
+            }
             PathEnum::LocalVariable { ordinal } => {
                 if (*ordinal) != 999_999 {
                     // This is a handy place to put a break point.


### PR DESCRIPTION
## Description

Heap addresses imported via the summary of a called function must be relocated to distinguish them from heap addresses allocated in the function itself.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
