### PR TITLE
Track closures inside of opaque types.

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1805,7 +1805,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
             }
         }
         let target_type: ExpressionType = (&root_rustc_type.kind).into();
-        if target_type != ExpressionType::NonPrimitive || no_children {
+        if target_type != ExpressionType::NonPrimitive
+            || no_children
+            || root_rustc_type.is_closure()
+        {
             let old_value =
                 self.lookup_path_and_refine_result(target_path.clone(), root_rustc_type);
             // Just copy/move (rpath, value) itself.

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -944,6 +944,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let func_const = ConstantDomain::Function(func_ref.clone());
             let def_id = func_ref.def_id.expect("defined when used here");
             let generic_arguments = self.block_visitor.bv.cv.substs_cache.get(&def_id).cloned();
+            if let Some(substs) = generic_arguments {
+                argument_map = self
+                    .block_visitor
+                    .bv
+                    .type_visitor
+                    .get_generic_arguments_map(def_id, substs, &actual_argument_types)
+            }
             let mut block_visitor = BlockVisitor::<E>::new(self.block_visitor.bv);
             let mut indirect_call_visitor = CallVisitor::new(
                 &mut block_visitor,
@@ -975,7 +982,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 Summary::default()
             }
         } else {
-            info!("unknown callee {:?}", callee);
+            warn!("unknown callee {:?}", callee);
             self.deal_with_missing_summary();
             Summary::default()
         };

--- a/checker/tests/run-pass/for_each_fold.rs
+++ b/checker/tests/run-pass/for_each_fold.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Tests generic specialization and function constant tracking.
+
+pub trait Iterator {
+    type Item;
+
+    fn for_each<F>(self, f: F)
+    where
+        Self: Sized,
+        F: FnMut(Self::Item),
+    {
+        #[inline]
+        fn call<T>(mut f: impl FnMut(T)) -> impl FnMut((), T) {
+            move |(), item| f(item)
+        }
+
+        self.fold((), call(f));
+    }
+
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut accum = init;
+        while let Some(x) = self.next() {
+            accum = f(accum, x);
+        }
+        accum
+    }
+
+    fn next(&mut self) -> Option<Self::Item>;
+}
+
+pub struct Foo {
+    count: usize,
+}
+
+impl Iterator for Foo {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count == 123 {
+            self.count = 0;
+            Some(111)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn main() {
+    let foo = Foo { count: 123 };
+    foo.for_each(|x| assert!(x == 111));
+}


### PR DESCRIPTION
## Description

Closures were not being copied correctly and we were not finding them when hiding inside of opaque types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
