### PR TITLE
Support verification of constant-time security

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.9.1",
+ "mirai-annotations 1.9.2",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -339,13 +339,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.9.1"
+version = "1.9.2"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.9.1",
+ "mirai-annotations 1.9.2",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
  "contracts 0.4.0 (git+https://gitlab.com/karroffel/contracts.git?branch=master)",
- "mirai-annotations 1.9.1",
+ "mirai-annotations 1.9.2",
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ dependencies = [
 name = "taint-error"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.9.1",
+ "mirai-annotations 1.9.2",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.9.1"
+version = "1.9.2"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -65,13 +65,49 @@ pub enum TagPropagation {
     UninterpretedCall,
 }
 
-/// Provide a way to create tag transfer masks. It is equivalent to bitwise-or of all its arguments.
+/// Provide a way to create tag propagation sets. It is equivalent to bitwise-or of all its arguments.
 #[macro_export]
 macro_rules! tag_propagation_set {
     ($($x:expr),*) => {
         0 $(| (1 << ($x as u8)))*
     };
 }
+
+/// A tag propagation set indicating a tag is propagated by all operations.
+pub const TAG_PROPAGATION_ALL: TagPropagationSet = tag_propagation_set!(
+    TagPropagation::Add,
+    TagPropagation::AddOverflows,
+    TagPropagation::And,
+    TagPropagation::BitAnd,
+    TagPropagation::BitNot,
+    TagPropagation::BitOr,
+    TagPropagation::BitXor,
+    TagPropagation::Cast,
+    TagPropagation::Div,
+    TagPropagation::Equals,
+    TagPropagation::GreaterOrEqual,
+    TagPropagation::GreaterThan,
+    TagPropagation::IntrinsicBinary,
+    TagPropagation::IntrinsicBitVectorUnary,
+    TagPropagation::IntrinsicFloatingPointUnary,
+    TagPropagation::LessOrEqual,
+    TagPropagation::LessThan,
+    TagPropagation::LogicalNot,
+    TagPropagation::Mul,
+    TagPropagation::MulOverflows,
+    TagPropagation::Ne,
+    TagPropagation::Neg,
+    TagPropagation::Or,
+    TagPropagation::Offset,
+    TagPropagation::Rem,
+    TagPropagation::Shl,
+    TagPropagation::ShlOverflows,
+    TagPropagation::Shr,
+    TagPropagation::ShrOverflows,
+    TagPropagation::Sub,
+    TagPropagation::SubOverflows,
+    TagPropagation::UninterpretedCall
+);
 
 /// Equivalent to a no op when used with an unmodified Rust compiler.
 /// When compiled with MIRAI, this causes MIRAI to associate (tag) the value with the given type.

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1626,9 +1626,6 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             Expression::Reference(path) | Expression::Variable { path, .. } => {
                 path.is_rooted_by_zeroed_heap_block()
             }
-            Expression::UnknownTagCheck { operand, .. } => {
-                operand.is_contained_in_zeroed_heap_block()
-            }
             _ => false,
         }
     }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -200,6 +200,8 @@ impl MiraiCallbacks {
         );
         let mut crate_visitor = CrateVisitor {
             buffered_diagnostics: Vec::new(),
+            constant_time_tag_cache: None,
+            constant_time_tag_not_found: false,
             constant_value_cache: ConstantValueCache::default(),
             diagnostics_for: HashMap::new(),
             file_name: self.file_name.as_str(),

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -13,6 +13,7 @@ use crate::expected_errors;
 use crate::known_names::KnownNamesCache;
 use crate::options::Options;
 use crate::summaries::PersistentSummaryCache;
+use crate::tag_domain::Tag;
 use crate::utils;
 use crate::z3_solver::Z3Solver;
 
@@ -38,6 +39,8 @@ use std::ops::Deref;
 // 'tcx is the lifetime of the closure call that calls analyze_with_mirai, which calls analyze_some_bodies.
 pub struct CrateVisitor<'compilation, 'tcx> {
     pub buffered_diagnostics: Vec<DiagnosticBuilder<'compilation>>,
+    pub constant_time_tag_cache: Option<Tag>,
+    pub constant_time_tag_not_found: bool,
     pub constant_value_cache: ConstantValueCache<'tcx>,
     pub diagnostics_for: HashMap<DefId, Vec<DiagnosticBuilder<'compilation>>>,
     pub file_name: &'compilation str,

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -576,7 +576,7 @@ impl Debug for Expression {
                 checking_presence,
             } => f.write_fmt(format_args!(
                 "({:?}).check_tag({:?}, {})",
-                operand, tag.def_id, checking_presence
+                operand, tag, checking_presence
             )),
             Expression::Variable { path, var_type } => {
                 f.write_fmt(format_args!("{:?}: {:?}", path, var_type))

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -33,6 +33,11 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .default_value("relaxed")
         .help("Level of diagnostics.\n")
         .long_help("With `relaxed`, false positives will be avoided where possible.\nWith 'strict' optimistic assumptions are made about unanalyzable calls.\nWith `paranoid`, all errors will be reported.\n"))
+    .arg(Arg::with_name("constant_time")
+        .long("constant_time")
+        .takes_value(true)
+        .help("Enable verification of constant-time security.")
+        .long_help("Name is a top-level crate type"))
 }
 
 /// Represents options passed to MIRAI.
@@ -41,6 +46,7 @@ pub struct Options {
     pub single_func: Option<String>,
     pub test_only: bool,
     pub diag_level: DiagLevel,
+    pub constant_time_tag_name: Option<String>,
 }
 
 /// Represents diag level.
@@ -137,6 +143,9 @@ impl Options {
                 "paranoid" => DiagLevel::PARANOID,
                 _ => assume_unreachable!(),
             };
+        }
+        if matches.is_present("constant_time") {
+            self.constant_time_tag_name = matches.value_of("constant_time").map(|s| s.to_owned());
         }
         args[rustc_args_start..].to_vec()
     }

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -304,6 +304,7 @@ impl Z3Solver {
                 cases,
                 default,
             } => self.general_switch(discriminator, cases, default),
+            Expression::TaggedExpression { operand, .. } => self.get_as_z3_ast(&operand.expression),
             Expression::Top | Expression::Bottom => self.general_fresh_const(),
             Expression::UninterpretedCall {
                 result_type: var_type,
@@ -1044,6 +1045,9 @@ impl Z3Solver {
             Expression::Reference(path) => self.numeric_reference(path),
             Expression::Shl { left, right } => self.numeric_shl(left, right),
             Expression::Shr { left, right, .. } => self.numeric_shr(left, right),
+            Expression::TaggedExpression { operand, .. } => {
+                self.get_as_numeric_z3_ast(&operand.expression)
+            }
             Expression::Top | Expression::Bottom => self.numeric_fresh_const(),
             Expression::UninterpretedCall {
                 result_type: var_type,

--- a/checker/tests/run-pass/constant_time_taint.rs
+++ b/checker/tests/run-pass/constant_time_taint.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for verifying constant-time security via taint analysis
+
+// MIRAI_FLAGS --constant_time ConstantTimeTaintKind
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use mirai_annotations::{TagPropagationSet, TAG_PROPAGATION_ALL};
+
+struct ConstantTimeTaintKind<const MASK: TagPropagationSet> {}
+
+type ConstantTimeTaint = ConstantTimeTaintKind<TAG_PROPAGATION_ALL>;
+
+pub fn test1(secret: i32) {
+    precondition!(has_tag!(&secret, ConstantTimeTaint));
+    if secret ^ 99991 > 5 {
+    } else {
+    }
+    //~ the branch condition has a ConstantTimeTaintKind tag
+}
+
+pub fn test2(secret: i32) {
+    precondition!(has_tag!(&secret, ConstantTimeTaint));
+    let mut info = 0;
+    while info != secret {
+        info = info.saturating_add(1);
+    }
+    //~ the branch condition has a ConstantTimeTaintKind tag
+}
+
+pub fn test3(secret: i32) {
+    precondition!(has_tag!(&secret, ConstantTimeTaint));
+    let _ = if secret | 99991 < 5 { true } else { false };
+    //~ the branch condition has a ConstantTimeTaintKind tag
+}
+
+pub fn test4(secret: i32, public: i32) -> i32 {
+    precondition!(has_tag!(&secret, ConstantTimeTaint));
+    precondition!(does_not_have_tag!(&public, ConstantTimeTaint));
+    let mut result = secret;
+    let mut i = public;
+    while i < 99991 {
+        if i < 10007 {
+            result = result ^ i;
+        } else {
+            result = result.saturating_add(23333);
+        }
+        i = i + 1;
+    }
+    result
+}
+
+pub fn test5(v: &[i32; 4]) {
+    precondition!(
+        has_tag!(&v[0], ConstantTimeTaint)
+            && does_not_have_tag!(&v[1], ConstantTimeTaint)
+            && has_tag!(&v[2], ConstantTimeTaint)
+            && does_not_have_tag!(&v[3], ConstantTimeTaint)
+    );
+    let mut i = 0;
+    while i < 4 {
+        if i % 2 != 0 {
+            // todo: improve the precision of lookup_weak_value
+            if v[i] > 0 {
+            } else {
+            }
+            //~ the branch condition may have a ConstantTimeTaintKind tag
+        }
+        i = i + 1;
+    }
+}
+
+fn work_on_non_secret(non_secret: i32) {
+    if non_secret > 5 {
+    } else {
+    }
+}
+
+pub fn main() {
+    let non_secret = 99991;
+    verify!(does_not_have_tag!(&non_secret, ConstantTimeTaint));
+    work_on_non_secret(non_secret);
+}


### PR DESCRIPTION
## Description

This commit adds a command-line option `--constant_time TYPE_NAME` where `TYPE_NAME` is the name of a top-level crate tag type (#532). When the option is specified, MIRAI uses the tag domain to reason about constant-time security: every branch condition should *not* have the tag specified by `TYPE_NAME`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra


