### PR TITLE
Defer refinement of the path in the len instruction.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1386,7 +1386,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             // With more optimization the len instruction becomes a constant.
             self.visit_constant(None, &len)
         } else {
-            let mut value_path = self.visit_place(place);
+            let mut value_path = self.visit_place_defer_refinement(place);
             if let PathEnum::QualifiedPath {
                 qualifier,
                 selector,


### PR DESCRIPTION
## Description

Tweak visit_len to ensure that the value path is always in the expected format.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
