### PR TITLE
Handle PathSelector::ConstantIndex in get_path_rustc_type.

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -928,7 +928,7 @@ impl Debug for PathSelector {
                 min_length,
                 from_end,
             } => f.write_fmt(format_args!(
-                "[offset: {}, min_length: {}, from_end: {}",
+                "[offset: {}, min_length: {}, from_end: {}]",
                 offset, min_length, from_end
             )),
             PathSelector::ConstantSlice { from, to, from_end } => {

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -316,7 +316,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                             return self.tcx.mk_tup(field_tys);
                         }
                     }
-                    PathSelector::Index(_) => {
+                    PathSelector::Index(_) | PathSelector::ConstantIndex { .. } => {
                         return get_element_type(t);
                     }
                     PathSelector::Layout => {


### PR DESCRIPTION
## Description

Add a missing case that came up during debugging a complex scenario.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
