### PR TITLE
Change instances of insert calls into insert_mut calls

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -240,11 +240,10 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     #[logfn_inputs(TRACE)]
     fn visit_goto(&mut self, target: mir::BasicBlock) {
         // Propagate the entry condition to the successor block.
-        self.bv.current_environment.exit_conditions = self
-            .bv
+        self.bv
             .current_environment
             .exit_conditions
-            .insert(target, self.bv.current_environment.entry_condition.clone());
+            .insert_mut(target, self.bv.current_environment.entry_condition.clone());
     }
 
     /// `discr` evaluates to an integer; jump depending on its value
@@ -313,17 +312,15 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             let not_cond = cond.logical_not();
             default_exit_condition = default_exit_condition.and(not_cond);
             let target = targets[i];
-            self.bv.current_environment.exit_conditions = self
-                .bv
+            self.bv
                 .current_environment
                 .exit_conditions
-                .insert(target, exit_condition);
+                .insert_mut(target, exit_condition);
         }
-        self.bv.current_environment.exit_conditions = self
-            .bv
+        self.bv
             .current_environment
             .exit_conditions
-            .insert(targets[values.len()], default_exit_condition);
+            .insert_mut(targets[values.len()], default_exit_condition);
     }
 
     /// Indicates that the landing pad is finished and unwinding should
@@ -391,17 +388,15 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         //todo: probably should remove all paths that are rooted in place.
 
         // Propagate the entry condition to the successor blocks.
-        self.bv.current_environment.exit_conditions = self
-            .bv
+        self.bv
             .current_environment
             .exit_conditions
-            .insert(target, self.bv.current_environment.entry_condition.clone());
+            .insert_mut(target, self.bv.current_environment.entry_condition.clone());
         if let Some(unwind_target) = unwind {
-            self.bv.current_environment.exit_conditions =
-                self.bv.current_environment.exit_conditions.insert(
-                    unwind_target,
-                    self.bv.current_environment.entry_condition.clone(),
-                );
+            self.bv.current_environment.exit_conditions.insert_mut(
+                unwind_target,
+                self.bv.current_environment.entry_condition.clone(),
+            );
         }
     }
 
@@ -962,11 +957,10 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         cond_val.clone()
                     });
             if !panic_exit_condition.is_bottom() {
-                self.bv.current_environment.exit_conditions = self
-                    .bv
+                self.bv
                     .current_environment
                     .exit_conditions
-                    .insert(cleanup_target, panic_exit_condition);
+                    .insert_mut(cleanup_target, panic_exit_condition);
             }
         };
         let normal_exit_condition = self
@@ -979,11 +973,10 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 not_cond_val
             });
         if !normal_exit_condition.is_bottom() {
-            self.bv.current_environment.exit_conditions = self
-                .bv
+            self.bv
                 .current_environment
                 .exit_conditions
-                .insert(target, normal_exit_condition);
+                .insert_mut(target, normal_exit_condition);
 
             // Check the condition and issue a warning or infer a precondition.
             if self.bv.check_for_errors {
@@ -1218,11 +1211,10 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         self.bv.assume_function_is_angelic = true;
         if let Some(target) = target {
             // Propagate the entry condition to the successor block.
-            self.bv.current_environment.exit_conditions = self
-                .bv
+            self.bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, self.bv.current_environment.entry_condition.clone());
+                .insert_mut(*target, self.bv.current_environment.entry_condition.clone());
         }
     }
 
@@ -2450,7 +2442,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             if i < k_limits::MAX_BYTE_ARRAY_LENGTH {
                 let index_value = self.get_u128_const_val(last_index);
                 let index_path = Path::new_index(array_path.clone(), index_value);
-                value_map = value_map.insert(index_path, operand);
+                value_map.insert_mut(index_path, operand);
             }
         }
         let length_path = Path::new_length(array_path.clone());

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -180,7 +180,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 &mut first_state,
                 &path,
             );
-            first_state.value_map = first_state.value_map.insert(path.clone(), val.clone());
+            first_state.value_map.insert_mut(path.clone(), val.clone());
         }
 
         // Update the current environment
@@ -1233,8 +1233,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                                             p.replace_root(qualifier, new_block_path.clone());
                                         let new_reference =
                                             AbstractValue::make_reference(new_block_path);
-                                        updated_value_map =
-                                            updated_value_map.insert(path.clone(), new_reference);
+                                        updated_value_map.insert_mut(path.clone(), new_reference);
                                     }
                                 }
                                 Expression::Variable { path: p, var_type } => {
@@ -1245,8 +1244,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                                             var_type.clone(),
                                             new_block_path,
                                         );
-                                        updated_value_map =
-                                            updated_value_map.insert(path.clone(), new_variable);
+                                        updated_value_map.insert_mut(path.clone(), new_variable);
                                     }
                                 }
                                 _ => (),
@@ -1449,8 +1447,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                                     _self.current_environment.value_map.remove(&path);
                                 return;
                             }
-                            _self.current_environment.value_map =
-                                _self.current_environment.value_map.insert(path, new_value);
+                            _self
+                                .current_environment
+                                .value_map
+                                .insert_mut(path, new_value);
                         },
                     );
                 }
@@ -1502,8 +1502,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                                 _self.current_environment.value_map.remove(&path);
                             return;
                         }
-                        _self.current_environment.value_map =
-                            _self.current_environment.value_map.insert(path, new_value);
+                        _self
+                            .current_environment
+                            .value_map
+                            .insert_mut(path, new_value);
                     },
                 );
             },
@@ -1515,8 +1517,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     move_elements,
                     |_self, path, old_value, new_value| {
                         let weak_value = condition.conditional_expression(new_value, old_value);
-                        _self.current_environment.value_map =
-                            _self.current_environment.value_map.insert(path, weak_value);
+                        _self
+                            .current_environment
+                            .value_map
+                            .insert_mut(path, weak_value);
                     },
                 )
             },
@@ -1863,7 +1867,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 let weakened_value = index
                     .less_than(count.clone())
                     .conditional_expression(unknown_value.clone(), value.clone());
-                value_map = value_map.insert(path.clone(), weakened_value);
+                value_map.insert_mut(path.clone(), weakened_value);
             }
         }
         self.current_environment.value_map = value_map;
@@ -1907,7 +1911,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 let updated_value =
                     join_condition.conditional_expression(additional_value, value.clone());
 
-                new_value_map = new_value_map.insert(path.clone(), updated_value);
+                new_value_map.insert_mut(path.clone(), updated_value);
             }
         }
         self.current_environment.value_map = new_value_map;
@@ -2078,10 +2082,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                         root_rustc_type,
                         false,
                         |_self, path, _, new_value| {
-                            _self.current_environment.value_map = _self
+                            _self
                                 .current_environment
                                 .value_map
-                                .insert(path, new_value.add_tag(tag));
+                                .insert_mut(path, new_value.add_tag(tag));
                         },
                     );
                 }
@@ -2138,10 +2142,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     root_rustc_type,
                     false,
                     |_self, path, _, new_value| {
-                        _self.current_environment.value_map = _self
+                        _self
                             .current_environment
                             .value_map
-                            .insert(path, new_value.add_tag(tag));
+                            .insert_mut(path, new_value.add_tag(tag));
                     },
                 );
             },
@@ -2172,8 +2176,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     |_self, path, old_value, new_value| {
                         let weak_value =
                             condition.conditional_expression(new_value.add_tag(tag), old_value);
-                        _self.current_environment.value_map =
-                            _self.current_environment.value_map.insert(path, weak_value);
+                        _self
+                            .current_environment
+                            .value_map
+                            .insert_mut(path, weak_value);
                     },
                 )
             },

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -503,12 +503,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     self.report_calls_to_special_functions();
                 }
                 if let Some((_, target)) = &self.destination {
-                    self.block_visitor.bv.current_environment.exit_conditions = self
-                        .block_visitor
+                    self.block_visitor
                         .bv
                         .current_environment
                         .exit_conditions
-                        .insert(*target, abstract_value::FALSE.into());
+                        .insert_mut(*target, abstract_value::FALSE.into());
                 }
                 return true;
             }
@@ -541,12 +540,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .current_environment
                 .entry_condition
                 .clone();
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         }
     }
 
@@ -1017,12 +1015,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .current_environment
                 .entry_condition
                 .clone();
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         } else {
             assume_unreachable!();
         }
@@ -1077,22 +1074,20 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             .entry_condition
             .and(assumed_condition.clone());
         if let Some((_, target)) = &self.destination {
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         } else {
             assume_unreachable!();
         }
         if let Some(cleanup_target) = self.cleanup {
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(cleanup_target, abstract_value::FALSE.into());
+                .insert_mut(cleanup_target, abstract_value::FALSE.into());
         }
     }
 
@@ -1247,12 +1242,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .current_environment
                 .entry_condition
                 .clone();
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         } else {
             assume_unreachable!();
         }
@@ -1268,12 +1262,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             .entry_condition
             .and(condition);
         if let Some((_, target)) = &self.destination {
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         } else {
             assume_unreachable!();
         }
@@ -1310,12 +1303,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             .entry_condition
             .clone();
         if let Some((_, target)) = &self.destination {
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         } else {
             assume_unreachable!();
         }
@@ -1364,12 +1356,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .current_environment
                 .entry_condition
                 .clone();
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         } else {
             assume_unreachable!();
         }
@@ -2040,12 +2031,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 exit_condition = exit_condition.and(refined_post_condition);
             }
 
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(*target, exit_condition);
+                .insert_mut(*target, exit_condition);
         }
     }
 
@@ -2072,12 +2062,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             if let Some(unwind_condition) = &function_summary.unwind_condition {
                 exit_condition = exit_condition.and(unwind_condition.clone());
             }
-            self.block_visitor.bv.current_environment.exit_conditions = self
-                .block_visitor
+            self.block_visitor
                 .bv
                 .current_environment
                 .exit_conditions
-                .insert(cleanup_target, exit_condition);
+                .insert_mut(cleanup_target, exit_condition);
         }
     }
 

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -90,7 +90,7 @@ impl Environment {
         //in the environment.
         //Conversely, if this path is contained in a path that is already in the environment, then
         //that path should be updated weakly.
-        self.value_map = self.value_map.insert(path, value);
+        self.value_map.insert_mut(path, value);
     }
 
     /// If the path contains an abstract value that was constructed with a join, the path is
@@ -249,20 +249,20 @@ impl Environment {
             let p = path.clone();
             match value_map2.get(path) {
                 Some(val2) => {
-                    value_map = value_map.insert(p, join_or_widen(val1, val2, path));
+                    value_map.insert_mut(p, join_or_widen(val1, val2, path));
                 }
                 None => {
                     checked_assume!(!val1.is_bottom());
                     if !path.is_rooted_by_parameter() {
                         // joining val1 and bottom
                         // The bottom value corresponds to dead (impossible) code, so the join collapses.
-                        value_map = value_map.insert(p, val1.clone());
+                        value_map.insert_mut(p, val1.clone());
                     } else {
                         let val2 = AbstractValue::make_typed_unknown(
                             val1.expression.infer_type(),
                             path.clone(),
                         );
-                        value_map = value_map.insert(p, join_or_widen(val1, &val2, path));
+                        value_map.insert_mut(p, join_or_widen(val1, &val2, path));
                     };
                 }
             }
@@ -273,13 +273,13 @@ impl Environment {
                 if !path.is_rooted_by_parameter() {
                     // joining bottom and val2
                     // The bottom value corresponds to dead (impossible) code, so the join collapses.
-                    value_map = value_map.insert(path.clone(), val2.clone());
+                    value_map.insert_mut(path.clone(), val2.clone());
                 } else {
                     let val1 = AbstractValue::make_typed_unknown(
                         val2.expression.infer_type(),
                         path.clone(),
                     );
-                    value_map = value_map.insert(path.clone(), join_or_widen(&val1, val2, path));
+                    value_map.insert_mut(path.clone(), join_or_widen(&val1, val2, path));
                 };
             }
         }

--- a/checker/src/fixed_point_visitor.rs
+++ b/checker/src/fixed_point_visitor.rs
@@ -111,7 +111,7 @@ impl<'fixed, 'analysis, 'compilation, 'tcx, E>
         block_visitor.visit_basic_block(bb, &mut self.terminator_state);
         self.out_state
             .insert(bb, self.bv.current_environment.clone());
-        self.already_visited = self.already_visited.insert(bb);
+        self.already_visited.insert_mut(bb);
     }
 
     /// Repeatedly evaluate the loop body starting at loop_anchor until widening

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -94,9 +94,9 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                                 var_type,
                                 closure_field_path.clone(),
                             );
-                            first_state.value_map = first_state
+                            first_state
                                 .value_map
-                                .insert(closure_field_path, closure_field_val);
+                                .insert_mut(closure_field_path, closure_field_val);
                         }
                     }
                 }


### PR DESCRIPTION
## Description

`rpds::HashTrieMap` and `rpds::RedBlackTreeMap` provide a method `insert_mut` such that `map = map.insert(key, value)` is equivalent to `map.insert_mut(key, value)`. This commit changes all such instances with `insert` calls into `insert_mut` calls.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra

