### PR TITLE
Add test case for get_model_field

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -780,7 +780,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         }
         let (cond_as_bool, entry_cond_as_bool) = self.check_condition_value_and_reachability(cond);
 
-        // If we never get here, rather call unreachable!()
+        // If we never get here, rather call verify_unreachable!()
         if !entry_cond_as_bool.unwrap_or(true) {
             let span = self.bv.current_span;
             let message =

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1171,7 +1171,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     #[logfn_inputs(TRACE)]
     fn handle_get_model_field(&mut self) {
         let destination = self.destination;
-        if let Some((place, target)) = &destination {
+        if let Some((place, _)) = &destination {
             let target_type = self
                 .block_visitor
                 .bv
@@ -1181,7 +1181,10 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
             // The current value, if any, of the model field are a set of (path, value) pairs
             // where each path is rooted by qualifier.model_field(..)
-            let qualifier = self.actual_args[0].0.clone();
+            let mut qualifier = self.actual_args[0].0.clone();
+            if matches!(&self.actual_argument_types[0].kind, TyKind::Ref{..}) {
+                qualifier = Path::new_deref(qualifier);
+            }
             let field_name = self.coerce_to_string(&self.actual_args[1].0);
             let source_path = Path::new_model_field(qualifier, field_name)
                 .refine_paths(&self.block_visitor.bv.current_environment);
@@ -1236,17 +1239,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     }
                 }
             }
-            let exit_condition = self
-                .block_visitor
-                .bv
-                .current_environment
-                .entry_condition
-                .clone();
-            self.block_visitor
-                .bv
-                .current_environment
-                .exit_conditions
-                .insert_mut(*target, exit_condition);
+            self.use_entry_condition_as_exit_condition();
         } else {
             assume_unreachable!();
         }
@@ -1338,7 +1331,10 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         checked_assume!(self.actual_args.len() == 3);
         let destination = self.destination;
         if let Some((_, target)) = &destination {
-            let qualifier = self.actual_args[0].0.clone();
+            let mut qualifier = self.actual_args[0].0.clone();
+            if matches!(&self.actual_argument_types[0].kind, TyKind::Ref{..}) {
+                qualifier = Path::new_deref(qualifier);
+            }
             let field_name = self.coerce_to_string(&self.actual_args[1].0);
             let target_path = Path::new_model_field(qualifier, field_name)
                 .refine_paths(&self.block_visitor.bv.current_environment);

--- a/checker/tests/run-pass/model_field.rs
+++ b/checker/tests/run-pass/model_field.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Tests for get_model_field!
+
+#[macro_use]
+extern crate mirai_annotations;
+
+struct Foo {}
+
+fn func(foo: &Foo) {
+    precondition!(get_model_field!(foo, value, 0) == 99991);
+}
+
+pub fn main() {
+    let foo = Foo {};
+    set_model_field!(&foo, value, 99991);
+    func(&foo);
+    //todo: fix problem with refining post condition containing unknown model field
+    verify!(get_model_field!(&foo, value, 0) == 99991); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+}


### PR DESCRIPTION
## Description

Tweak the implementation of get_model_field and set_model_field to strip explicit deref from the paths that end up in Expression::UnknownModelField.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
