### PR TITLE
Unify post conditions path refinement

### DIFF
--- a/checker/tests/run-pass/model_field_refinement.rs
+++ b/checker/tests/run-pass/model_field_refinement.rs
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 // A test where function preconditions involve model/tag fields of parameters
-// todo: deal with refinement of unknown model/tag fields (issue #577)
 
 #![feature(const_generics)]
 #![allow(incomplete_features)]
@@ -24,7 +23,7 @@ pub fn test1() {
     let foo = Foo {};
     set_model_field!(&foo, value, 99991);
     func1(&foo);
-    verify!(get_model_field!(&foo, value, 0) == 99991); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+    verify!(get_model_field!(&foo, value, 0) == 99991);
 }
 
 struct TaintKind<const MASK: TagPropagationSet> {}
@@ -41,7 +40,7 @@ pub fn test2() {
     let foo = Foo {};
     add_tag!(&foo, Taint);
     func2(&foo);
-    verify!(has_tag!(&foo, Taint)); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+    verify!(has_tag!(&foo, Taint));
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Remove refinement that became redundant a while ago and also causes problems with unknown model fields and unknown tag fields.

Fixes #577 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
