### PR TITLE
Add a tutorial for using tag analysis with MIRAI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "timing_channels"
+version = "0.1.0"
+dependencies = [
+ "mirai-annotations 1.10.0",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,9 +665,23 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "untrustworthy_inputs"
+version = "0.1.0"
+dependencies = [
+ "mirai-annotations 1.10.0",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "verification_status"
+version = "0.1.0"
+dependencies = [
+ "mirai-annotations 1.10.0",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ members = [
     "checker",
     "standard_contracts",
     "examples/taint",
-    "examples/shopping_cart"
+    "examples/shopping_cart",
+    "examples/tag_analysis/timing_channels",
+    "examples/tag_analysis/untrustworthy_inputs",
+    "examples/tag_analysis/verification_status"
 ]
 
 [profile.release]

--- a/documentation/TagAnalysis.md
+++ b/documentation/TagAnalysis.md
@@ -1,0 +1,227 @@
+# Tag Analysis
+
+## Overview
+
+Tag analysis is a compile-time static analysis that keeps track of information flows in programs. Information flows
+from variable X to variable Y, whenever information stored in X is transferred to Y. Tag analysis attaches different
+kinds of tags to values in a program to keep track of data flows for these tags. For example, taint analysis is a
+special form of tag analysis that reasons about sensitive information, such as private user data in social network
+service, or private keys in crypto code. Using tag analysis, a static analyzer can verify that tainted values (i.e.,
+values attached with special taint tags) will never flow to specific program locations that may leak the information,
+e.g., a method writing the tainted values to a public channel. Because the analysis is carried out at compile time,
+the analyzer can verify non-trivial information-flow properties without any runtime overheads.
+
+MIRAI supports a context-, field-, flow-, and path-sensitive tag analysis. Context-sensitivity and field-sensitivity
+come from MIRAI's summary-based inter-procedural analysis and precise abstract heap model, respectively.
+We implement the tag analysis as a data-flow analysis with a tag domain that over-approximates present and absent tags
+on values simultaneously. When the data-flow analysis is not precise enough to answer queries, MIRAI generates a
+propositional formula that encodes both the query and the path condition that guards the query, and uses an
+off-the-shelf constraint solver such as [Z3](https://github.com/Z3Prover/z3) to answer the query.
+
+Tag analysis is in general an undecidable problem, so MIRAI might not get sufficiently precise information to verify
+information-flow properties. MIRAI's tag analysis is developed to be consistent with MIRAI's design, which avoids false
+negatives (not flagging real errors), and reduces the number of false positives (flagging false errors). When the
+analysis result is not precise enough, or MIRAI timeouts because the analyzed program has very complex control or data
+flow, MIRAI will produce a conservative approximation of the program states and report possible errors, some of which
+may be false positives. As in other static analysis, developer-provided annotations, such as loop invariants, or
+simplification of the control flow in the analyzed program, could help MIRAI improve analysis precision.
+
+## Declaring tags
+
+MIRAI supports developer-defined tags and customizable tag propagation behavior. Tag-related types and macros are
+provided by the [MIRAI Annotations](https://crates.io/crates/mirai-annotations) crate.
+
+In MIRAI, tags are just Rust types, except that they are assumed to have at least one generic argument, the first of
+which should be a const parameter of type `TagPropagationSet`. The code below declares a tag kind named
+`SecretTaintKind`.
+
+``` rust
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+struct SecretTaintKind<const MASK: TagPropagationSet> {}
+```
+
+`MASK` is used to specify propagation behavior of different program operations for the tag. For example, if bitwise-xor
+can be used to “sanitize” tainted data, it will then block the taint tag. MIRAI provides a macro `tag_propagation_set!`
+to create a tag-propagation set by specifying all the operations that can propagate the tag. The code below defines a
+tag named `SecretTaint` that can only be propagated by equality checks.
+
+``` rust
+const SECRET_TAINT_MASK = tag_propagation_set!(TagPropagation::Equals, TagPropagation::Ne);
+
+type SecretTaint = SecretTaintKind<SECRET_TAINT_MASK>;
+```
+
+## Attaching and checking tags on values
+
+In MIRAI, tags are attached to values via the `add_tag!` macro, whose first parameter is a reference to the value
+that is being tagged, and second parameter is a well-defined tag type. The code below attaches the `SecretTaint` tag we
+just defined to a value.
+
+``` rust
+add_tag!(&value_to_be_tagged, SecretTaint);
+```
+
+To check if a value has (respectively, does not have) a tag attached to it, we can use the `has_tag!` macro
+(respectively, the `does_not_have_tag!` macro). Both macros take a reference to the checked value and a tag type as
+arguments, and return a Boolean value indicating the check result. A common usage is to combine them with MIRAI's
+specification mechanisms such as verification conditions, pre-conditions, and post-conditions. The code below
+illustrates the three mechanisms.
+
+``` rust
+// as a verification condition
+verify!(does_not_have_tag!(&value_without_tag, SecretTaint));
+
+// as a pre-condition
+fn argument_must_be_tainted(msg: Message) {
+    precondition!(has_tag!(&msg, SecretTaint));
+    ...
+}
+
+// as a post-condition
+fn result_must_be_tainted() -> Message {
+    ...
+    postcondition!(has_tag!(&result, SecretTaint));
+    result
+}
+```
+
+These annotations are equivalent to no-ops when the code is compiled by an unmodified Rust compiler. When compiled with
+MIRAI, these annotations cause MIRAI to check the conditions and emit diagnostic messages if MIRAI cannot prove the
+conditions to be true.
+
+## Scenario I: Detect timing side-channels
+
+Constant-time programming is a well-known discipline to protect programs---especially crypto code---against timing
+attacks. A common practice is to avoid branchings to be controlled by sensitive information, because attackers could
+use side-channel attacks that measure different execution times of a program to infer the sensitive information.
+
+For example, the code below implements a compare function that is **not** constant-time, because the running time of it
+depends on the length of the longest common prefix of `secret` and `public`. An attacker could construct different
+values as `public` and measure the running times to infer the content of `secret`.
+
+``` rust
+// The compare function is **not** constant-time.
+fn compare(secret: &[i32], public: &[i32], len: usize) -> bool {
+    for i in 0..len {
+        if secret[i] != public[i] {
+            return false;
+        }
+    }
+    true
+}
+```
+
+The code below implements a constant-time compare function, by iterating all the integers in `secret` and `public`. The
+implementation is constant-time because it avoids the early-return behavior that leaks information about `secret`.
+
+``` rust
+// The compare function is constant-time.
+fn compare(secret: &[i32], public: &[i32], len: usize) -> bool {
+    let mut result = true;
+    for i in 0..len {
+        result = result & (secret[i] == public[i]);
+    }
+    result
+}
+```
+
+MIRAI's constant-time verification is enabled by a command-line option `--constant_time Name`, where `Name` is the tag
+kind type identifying sensitive information that should not influence running time, e.g., the type `SecretTaintKind`
+defined above. MIRAI reports every branch condition that has the tag used for constant-time verification. If MIRAI
+timeouts or the analysis result is not precise enough, MIRAI will report all possible errors, which may contain false
+positives, i.e., some branch conditions are reported to possibly have the constant-time tag, but during any real
+execution of the program, these branch conditions would not have the constant-time verification tag. Providing
+annotations (such as loop invariants) or simplifying the program's control flow can help MIRAI reduce the number of
+false positives.
+
+See the [timing-channels crate](../examples/tag_analysis/timing_channels) for a complete example.
+
+## Scenario II: Track untrustworthy inputs
+
+In public-key cryptography, the source of a public key might be untrustworthy. Also, public keys obtained from the
+the outside environment might suffer from non-trivial vulnerabilities, e.g., public keys for Ed25519 might not be safe
+against small subgroup attacks.
+
+The code below illustrates a scenario, where we want to make sure that every public key used in the system is either a
+key that we already know is valid, or a user-input key that goes through the `try_from` method, which checks for key
+validity. We can verify this property using tag analysis: when a public key is used, we check if it does not have a
+`Tainted` tag, or it has a special `Sanitized` tag that can only be attached to values via `try_from`. In practice, the
+`Sanitized` type can usually be defined as a private type in the module containing `try_from`, so that developers using
+this module are not able to attach the `Sanitized` tag to values, except by calling the `try_from` method.
+
+``` rust
+// A public key that we already know is valid.
+// This key is defined in a way that it does not have the Tainted tag.
+const A_VALID_PUBLIC_KEY: PublicKey = ...;
+
+// Deserialize a public key without any validity checks.
+fn from_bytes_unchecked(bytes: &[u8]) -> PublicKey {
+    let public_key = ...;
+    add_tag!(&public_key, Tainted);
+    public_key
+}
+
+// Deserialize a public key. This method checks for key validity.
+fn try_from(bytes: &[u8]) -> Result<PublicKey> {
+    let public_key = from_bytes_unchecked(bytes);
+
+    // Perform validity checks. Return Err if the key is invalid.
+    ...
+
+    add_tag!(&public_key, Sanitized);
+    Ok(public_key)
+}
+
+// Check that `sig` is valid for `message` using `public_key`.
+fn verify_msg(sig: &Signature, message: &Message, public_key: &PublicKey) -> Result<()> {
+    precondition!(does_not_have_tag!(public_key, Tainted) || has_tag!(public_key, Sanitized));
+    ...
+}
+```
+
+MIRAI reports every verification condition that is provably false. If MIRAI
+timeouts or the analysis result is not precise enough, MIRAI will report all possible errors, which may contain false
+positives, i.e., some verification conditions are reported to be possibly false, but during any real execution of the
+program, these verification conditions would be actually true. Providing annotations (such as loop invariants) or
+simplifying the program's control flow can help MIRAI reduce the number of false positives.
+
+See the [untrustworthy-inputs crate](../examples/tag_analysis/untrustworthy_inputs) for a complete example.
+
+## Scenario III: Record verification status
+
+In a blockchain codebase, there are many verification routines that check the validity of different values, including
+blocks, messages, keys, etc. As pointed out by this [issue](https://github.com/libra/libra/issues/1602), it would add
+clarity to record verification status in the values.
+
+We can implement this mechanism using tag analysis as illustrated below: after a value has gone through a
+verification routine, we attach a `Verified` tag to it. For other code, where a verified value is required, we add a
+condition to enforce that the value has been attached with the `Verified` tag.
+
+``` rust
+// Make sure a VoteMsg makes sense.
+fn verify(msg: &VoteMsg, validator: &ValidatorVerifier) -> Result<()> {
+    ...
+    add_tag!(msg, Verified);
+    Ok(())
+}
+
+// Send the vote to the chosen recipients.
+fn send_vote(msg: &VoteMsg, recipients: Vec<Author>) {
+    precondition!(has_tag!(msg, Verified));
+    ...
+}
+```
+
+MIRAI reports every verification condition that is provably false. If MIRAI
+timeouts or the analysis result is not precise enough, MIRAI will report all possible errors, which may contain false
+positives. Providing annotations (such as loop invariants) or simplifying the program's control flow can help MIRAI
+reduce the number of false positives.
+
+See the [verification-status crate](../examples/tag_analysis/verification_status) for a complete example.

--- a/examples/tag_analysis/timing_channels/Cargo.toml
+++ b/examples/tag_analysis/timing_channels/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "timing_channels"
+version = "0.1.0"
+authors = ["Di Wang <diwang95@fb.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+test = false # we have no unit tests
+doctest = false # and no doc tests
+
+[dependencies]
+mirai-annotations = { path = "../../../annotations" }

--- a/examples/tag_analysis/timing_channels/src/lib.rs
+++ b/examples/tag_analysis/timing_channels/src/lib.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+// This is an example of using tag analysis to verify constant-time security.
+// Use the following flag of MIRAI to enable constant-time verification:
+// MIRAI_FLAGS --constant_time SecretTaintKind
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+const SECRET_TAINT_MASK: TagPropagationSet = tag_propagation_set!(
+    TagPropagation::Equals,
+    TagPropagation::GreaterThan,
+    TagPropagation::GreaterOrEqual,
+    TagPropagation::LessThan,
+    TagPropagation::LessOrEqual,
+    TagPropagation::Ne
+);
+
+type SecretTaint = SecretTaintKind<SECRET_TAINT_MASK>;
+
+const KEY_LENGTH: usize = 1024;
+
+pub mod non_constant_time {
+    /// A compare function that is **not** constant-time.
+    pub fn compare(secret: &[i32; crate::KEY_LENGTH], public: &[i32; crate::KEY_LENGTH]) -> bool {
+        precondition!(has_tag!(secret, crate::SecretTaint));
+
+        let mut i = 0;
+        while i < crate::KEY_LENGTH {
+            if secret[i] != public[i] {
+                return false;
+            }
+            //~ the branch condition may have a SecretTaintKind tag
+            i += 1;
+        }
+        true
+    }
+}
+
+pub mod constant_time {
+    /// A compare function that is constant-time.
+    pub fn compare(secret: &[i32; crate::KEY_LENGTH], public: &[i32; crate::KEY_LENGTH]) -> bool {
+        precondition!(has_tag!(secret, crate::SecretTaint));
+
+        let mut result = true;
+        let mut i = 0;
+        while i < crate::KEY_LENGTH {
+            result &= secret[i] == public[i];
+            i += 1;
+        }
+        result
+    }
+}

--- a/examples/tag_analysis/untrustworthy_inputs/Cargo.toml
+++ b/examples/tag_analysis/untrustworthy_inputs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "untrustworthy_inputs"
+version = "0.1.0"
+authors = ["Di Wang <diwang95@fb.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+test = false # we have no unit tests
+doctest = false # and no doc tests
+
+[dependencies]
+mirai-annotations = { path = "../../../annotations" }

--- a/examples/tag_analysis/untrustworthy_inputs/src/lib.rs
+++ b/examples/tag_analysis/untrustworthy_inputs/src/lib.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+// This is an example of using tag analysis to track untrustworthy inputs.
+// The code is extracted from a crate for public-key cryptography.
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use core::convert::TryFrom;
+use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+struct TaintedKind<const MASK: TagPropagationSet> {}
+
+const TAINTED_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+type Tainted = TaintedKind<TAINTED_MASK>;
+
+struct SanitizedKind<const MASK: TagPropagationSet> {}
+
+const SANITIZED_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+type Sanitized = SanitizedKind<SANITIZED_MASK>;
+
+/// A structure for public keys.
+pub struct PublicKey(u32);
+
+/// A public key that we already know is valid. This key does not have the Tainted tag.
+pub const A_VALID_PUBLIC_KEY: PublicKey = PublicKey(999213123u32);
+
+impl PublicKey {
+    /// Deserialize a public key without any validation checks.
+    fn from_bytes_unchecked(bytes: &[u8]) -> Result<PublicKey, &'static str> {
+        if bytes.len() != 4 {
+            Err("wrong length")
+        } else {
+            let key = PublicKey(
+                u32::from(bytes[0])
+                    | u32::from(bytes[1]) << 8
+                    | u32::from(bytes[2]) << 16
+                    | u32::from(bytes[3]) << 24,
+            );
+            add_tag!(&key, Tainted);
+            Ok(key)
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = &'static str;
+
+    /// Deserialize a public key. This method will also check for key validity.
+    fn try_from(bytes: &[u8]) -> Result<PublicKey, Self::Error> {
+        match PublicKey::from_bytes_unchecked(bytes) {
+            Err(msg) => Err(msg),
+            Ok(key) => {
+                if bytes[0] == 213 || bytes[2] == 166 {
+                    return Err("small subgroup");
+                }
+
+                add_tag!(&key, Sanitized);
+                Ok(key)
+            }
+        }
+    }
+}
+
+pub mod untrustworthy_public_keys {
+    pub fn test_unchecked_public_key(bytes: &[u8]) {
+        if let Ok(key) = crate::PublicKey::from_bytes_unchecked(bytes) {
+            verify!(does_not_have_tag!(&key, crate::Tainted) || has_tag!(&key, crate::Sanitized));
+            //~ provably false verification condition
+        }
+    }
+}
+
+pub mod verified_public_keys {
+    use core::convert::TryFrom;
+
+    pub fn test_checked_public_key(bytes: &[u8]) {
+        let key = match crate::PublicKey::try_from(bytes) {
+            Err(..) => crate::A_VALID_PUBLIC_KEY,
+            Ok(key) => key,
+        };
+        verify!(does_not_have_tag!(&key, crate::Tainted) || has_tag!(&key, crate::Sanitized));
+    }
+}

--- a/examples/tag_analysis/verification_status/Cargo.toml
+++ b/examples/tag_analysis/verification_status/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "verification_status"
+version = "0.1.0"
+authors = ["Di Wang <diwang95@fb.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+test = false # we have no unit tests
+doctest = false # and no doc tests
+
+[dependencies]
+mirai-annotations = { path = "../../../annotations" }

--- a/examples/tag_analysis/verification_status/src/lib.rs
+++ b/examples/tag_analysis/verification_status/src/lib.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+// This is an example of using tag analysis to record verification status of objects.
+// The code is extracted from a blockchain codebase.
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+struct VerifiedKind<const MASK: TagPropagationSet> {}
+
+const VERIFIED_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+type Verified = VerifiedKind<VERIFIED_MASK>;
+
+/// VoteMsg is the structure sent by the voter in response for receiving a proposal.
+pub struct VoteMsg {
+    vote: i32,
+    sync_info: bool,
+}
+
+impl VoteMsg {
+    pub fn new(vote: i32, sync_info: bool) -> Self {
+        VoteMsg { vote, sync_info }
+    }
+
+    pub fn verify(&self) -> Option<()> {
+        let flag = self.vote % 2 == 0;
+        if flag == self.sync_info {
+            add_tag!(self, Verified);
+            Some(())
+        } else {
+            None
+        }
+    }
+}
+
+/// Networking support for all consensus messaging.
+pub struct NetworkSender {
+    author: String,
+}
+
+impl NetworkSender {
+    pub fn new(author: String) -> Self {
+        NetworkSender { author }
+    }
+
+    pub fn author(&self) -> &String {
+        &self.author
+    }
+
+    /// Send the vote to the chosen recipients.
+    pub fn send_vote(&self, vote_msg: VoteMsg, _recipients: Vec<String>) {
+        precondition!(has_tag!(&vote_msg, crate::Verified));
+    }
+}
+
+pub mod unverified_objects {
+    pub fn test_unverified_msg() {
+        let sender = crate::NetworkSender::new("Alice".to_owned());
+        let msg = crate::VoteMsg::new(123, true);
+        sender.send_vote(msg, vec!["Bob".to_owned()]); //~ unsatisfied precondition
+    }
+}
+
+pub mod verified_objects {
+    pub fn tes_verified_msg() {
+        let sender = crate::NetworkSender::new("Alice".to_owned());
+        let msg = crate::VoteMsg::new(122, true);
+        if let Some(()) = msg.verify() {
+            sender.send_vote(msg, vec!["Bob".to_owned()]);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This commit adds a tutorial for tag analysis, which includes an overview of tag analysis in MIRAI, the mechanisms for declaring and adding/checking tags, and three scenarios of using tag analysis. This commit also adds three examples that correspond to the three scenarios, respectively.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

None of the above: documentation change with some new examples.

## How Has This Been Tested?

./validate.sh