### PR TITLE
Allow recursive calls after devirtualization

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1563,8 +1563,8 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                         {
                             (*len) - u128::from(offset)
                         } else {
-                            debug!("PathSelector::ConstantIndex implies the length of the value is known");
-                            assume_unreachable!();
+                            // can't expand the pattern because the length is not known at this point
+                            return false;
                         }
                     } else {
                         u128::from(offset)

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,8 +139,7 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(file_name: &str) -> bool {
-        file_name.contains("client/libra-dev/src") // illegal down cast
-            || file_name.contains("config/management/src") // false positives
+        file_name.contains("config/management/src") // false positives
             || file_name.contains("consensus/src") // resolve error
             || file_name.contains("consensus/safety-rules/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
@@ -158,12 +157,14 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-vm/runtime/src") // resolve error
             || file_name.contains("language/move-prover/src") // false positives
             || file_name.contains("language/move-prover/spec-lang/src") // false positives
-            || file_name.contains("language/resource-viewer/src") // illegal down cast
+            || file_name.contains("language/resource-viewer/src") // false positives
+            || file_name.contains("language/move-prover/docgen/src") // takes too long 
             || file_name.contains("language/move-prover/stackless-bytecode-generator/src") // resolve error
             || file_name.contains("language/tools/vm-genesis/src") // resolve error
             || file_name.contains("language/tools/genesis-viewer/src") // false positives
             || file_name.contains("language/vm/src") // false positives
             || file_name.contains("network/src") // resolve error
+            || file_name.contains("network/builder") // takes too long
             || file_name.contains("secure/net/src") // false positives
             || file_name.contains("secure/storage/src") // false positives
             || file_name.contains("secure/storage/vault/src") // resolve error
@@ -173,6 +174,7 @@ impl MiraiCallbacks {
             || file_name.contains("storage/backup/backup-cli/src") // panics
             || file_name.contains("storage/libradb/src") // resolve error
             || file_name.contains("testsuite/cli/src") // false positives
+            || file_name.contains("testsuite/cli/libra-wallet/src") // takes too long
             || file_name.contains("types/src") // resolve error
     }
 

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -12,7 +12,7 @@ use crate::path::Path;
 use crate::utils;
 
 use log_derive::{logfn, logfn_inputs};
-use mirai_annotations::{assume, assume_unreachable};
+use mirai_annotations::*;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
 use serde::{Deserialize, Serialize};
@@ -249,7 +249,6 @@ fn add_provenance(preconditions: &[Precondition], tcx: TyCtxt<'_>) -> Vec<Precon
             let mut precond = precondition.clone();
             if !precondition.spans.is_empty() {
                 let last_span = precondition.spans.last();
-                assume!(last_span.is_some());
                 let span = last_span.unwrap().source_callsite();
                 precond.provenance = Some(Rc::new(tcx.sess.source_map().span_to_string(span)));
             }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -307,12 +307,11 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                         if let TyKind::Adt(def, substs) = &t.kind {
                             use rustc_index::vec::Idx;
                             if *ordinal >= def.variants.len() {
-                                assume_unreachable!(
+                                info!(
                                     "illegally down casting to index {} of {:?} at {:?}",
-                                    *ordinal,
-                                    t,
-                                    current_span
+                                    *ordinal, t, current_span
                                 );
+                                return self.tcx.types.never;
                             }
                             let variant = &def.variants[VariantIdx::new(*ordinal)];
                             let field_tys = variant.fields.iter().map(|fd| fd.ty(self.tcx, substs));

--- a/checker/tests/run-pass/generic_recursive.rs
+++ b/checker/tests/run-pass/generic_recursive.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Check that self recursive calls happening via trait methods are detected.
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub trait X {
+    fn foo() -> usize;
+}
+
+pub struct Y<U> {
+    pub a: U,
+}
+
+impl<U: X> X for Y<U> {
+    fn foo() -> usize {
+        U::foo() + 1
+    }
+}
+
+pub struct Z {
+    pub b: u8,
+}
+
+impl X for Z {
+    fn foo() -> usize {
+        1
+    }
+}
+
+pub fn main() {
+    verify!(Z::foo() == 1);
+    verify!(Y::<Z>::foo() == 2);
+    verify!(Y::<Y<Z>>::foo() == 3);
+    verify!(Y::<Y<Y<Z>>>::foo() == 4);
+    verify!(Y::<Y<Y<Y<Z>>>>::foo() == 5);
+    verify!(Y::<Y<Y<Y<Y<Z>>>>>::foo() == 6);
+}


### PR DESCRIPTION
## Description

Reorganize code so that devirtualization happens before the check for recursion.

Work around some hard to repro bugs that get uncovered by the additional analysis. Fix the way Z3 expressions are generated for switch statements with discriminator values that are bit vectors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
