### PR TITLE
Allow tags on values of unsized types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -339,13 +339,13 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.10.0"
+version = "1.10.1"
 
 [[package]]
 name = "mirai-standard-contracts"
 version = "0.0.1"
 dependencies = [
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
  "contracts 0.4.0 (git+https://gitlab.com/karroffel/contracts.git?branch=master)",
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ dependencies = [
 name = "taint-error"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ dependencies = [
 name = "timing_channels"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
 ]
 
 [[package]]
@@ -668,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "untrustworthy_inputs"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "verification_status"
 version = "0.1.0"
 dependencies = [
- "mirai-annotations 1.10.0",
+ "mirai-annotations 1.10.1",
 ]
 
 [[package]]

--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.10.0"
+version = "1.10.1"
 authors = ["Herman Venter <hermanv@fb.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -1065,17 +1065,17 @@ pub fn mirai_abstract_value<T>(x: T) -> T {
 
 // Helper function for MIRAI. Should only be called via the add_tag! macro.
 #[doc(hidden)]
-pub fn mirai_add_tag<V, T>(_v: &V) {}
+pub fn mirai_add_tag<V: ?Sized, T>(_v: &V) {}
 
 // Helper function for MIRAI. Should only be called via the has_tag! macro.
 #[doc(hidden)]
-pub fn mirai_has_tag<V, T>(_v: &V) -> bool {
+pub fn mirai_has_tag<V: ?Sized, T>(_v: &V) -> bool {
     false
 }
 
 // Helper function for MIRAI. Should only be called via the does_not_have_tag! macro.
 #[doc(hidden)]
-pub fn mirai_does_not_have_tag<V, T>(_v: &V) -> bool {
+pub fn mirai_does_not_have_tag<V: ?Sized, T>(_v: &V) -> bool {
     false
 }
 

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1007,7 +1007,16 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         precondition!(self.actual_args.len() == 1);
 
         if let Some(tag) = self.extract_tag_kind_and_propagation_set() {
-            let source_path = Path::new_deref(self.actual_args[0].0.clone())
+            let source_pointer_path = self.actual_args[0].0.clone();
+            let source_pointer_rustc_type = self.actual_argument_types[0];
+            let source_thin_pointer_path = Path::get_path_to_thin_pointer_at_offset_0(
+                self.block_visitor.bv.tcx,
+                &self.block_visitor.bv.current_environment,
+                &source_pointer_path,
+                source_pointer_rustc_type,
+            )
+            .unwrap_or(source_pointer_path);
+            let source_path = Path::new_deref(source_thin_pointer_path)
                 .refine_paths(&self.block_visitor.bv.current_environment);
             trace!("MiraiAddTag: tagging {:?} with {:?}", tag, source_path);
 
@@ -1074,7 +1083,16 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
         let result: Option<Rc<AbstractValue>>;
         if let Some(tag) = self.extract_tag_kind_and_propagation_set() {
-            let source_path = Path::new_deref(self.actual_args[0].0.clone())
+            let source_pointer_path = self.actual_args[0].0.clone();
+            let source_pointer_rustc_type = self.actual_argument_types[0];
+            let source_thin_pointer_path = Path::get_path_to_thin_pointer_at_offset_0(
+                self.block_visitor.bv.tcx,
+                &self.block_visitor.bv.current_environment,
+                &source_pointer_path,
+                source_pointer_rustc_type,
+            )
+            .unwrap_or(source_pointer_path);
+            let source_path = Path::new_deref(source_thin_pointer_path)
                 .refine_paths(&self.block_visitor.bv.current_environment);
             trace!(
                 "MiraiCheckTag: checking if {:?} has {}been tagged with {:?}",

--- a/checker/tests/run-pass/tag_non_scalar.rs
+++ b/checker/tests/run-pass/tag_non_scalar.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for adding tags to non-scalar values and checking tags on sub-components
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+const SECRET_TAINT: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+type SecretTaint = SecretTaintKind<SECRET_TAINT>;
+
+pub mod intra_procedure {
+    use crate::SecretTaint;
+
+    pub fn test_tuple() {
+        let tuple = (1, 2, 3, 4);
+        add_tag!(&tuple, SecretTaint);
+        verify!(
+            has_tag!(&tuple.0, SecretTaint)
+                && has_tag!(&tuple.1, SecretTaint)
+                && has_tag!(&tuple.2, SecretTaint)
+                && has_tag!(&tuple.3, SecretTaint)
+        );
+    }
+
+    pub fn test_array() {
+        let array = [1, 2, 3, 4];
+        add_tag!(&array, SecretTaint);
+        verify!(
+            has_tag!(&array[0], SecretTaint)
+                && has_tag!(&array[1], SecretTaint)
+                && has_tag!(&array[2], SecretTaint)
+                && has_tag!(&array[3], SecretTaint)
+        );
+    }
+
+    pub fn test_slice() {
+        let array = [1, 2, 3, 4];
+        let slice: &[i32] = &array;
+        add_tag!(slice, SecretTaint);
+        verify!(
+            has_tag!(&slice[0], SecretTaint)
+                && has_tag!(&slice[1], SecretTaint)
+                && has_tag!(&slice[2], SecretTaint)
+                && has_tag!(&slice[3], SecretTaint)
+        );
+    }
+}
+
+// todo: deal with unknown paths rooted at parameters
+pub mod inter_procedure {
+    use crate::SecretTaint;
+
+    pub fn test_tuple(tuple: &(i32, i32, i32, i32)) {
+        precondition!(has_tag!(tuple, SecretTaint));
+        verify!(
+            has_tag!(&tuple.0, SecretTaint)
+                && has_tag!(&tuple.1, SecretTaint)
+                && has_tag!(&tuple.2, SecretTaint)
+                && has_tag!(&tuple.3, SecretTaint)
+        ); //~ possible false verification condition
+    }
+
+    pub fn test_array(array: &[i32; 4]) {
+        precondition!(has_tag!(array, SecretTaint));
+        verify!(
+            has_tag!(&array[0], SecretTaint)
+                && has_tag!(&array[1], SecretTaint)
+                && has_tag!(&array[2], SecretTaint)
+                && has_tag!(&array[3], SecretTaint)
+        ); //~ possible false verification condition
+    }
+
+    pub fn test_slice(slice: &[i32]) {
+        precondition!(slice.len() == 4);
+        precondition!(has_tag!(slice, SecretTaint));
+        verify!(
+            has_tag!(&slice[0], SecretTaint)
+                && has_tag!(&slice[1], SecretTaint)
+                && has_tag!(&slice[2], SecretTaint)
+                && has_tag!(&slice[3], SecretTaint)
+        ); //~ possible false verification condition
+    }
+}


### PR DESCRIPTION
## Description

Rust's generic type parameters are implicitly bound by `Sized`. This commit explicitly annotates the generic type parameter of tag-related functions with `?Sized` to allow tags on values of unsized types.

This commit fixes a bug in the implementation of add_tag/check_tag: when the source address is a fat pointer (e.g., the value being tagged is a slice), we obtain the correct thin pointer before doing the actual dereference.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra

