### PR TITLE
Fix transfer of array repeat values from summaries

### DIFF
--- a/checker/tests/run-pass/array_repeat.rs
+++ b/checker/tests/run-pass/array_repeat.rs
@@ -9,8 +9,46 @@
 #[macro_use]
 extern crate mirai_annotations;
 
-pub fn main() {
+pub fn test1() {
     let x = [1; 2];
     verify!(x[0] == 1);
     verify!(x[1] == 1);
 }
+
+fn foo() -> [i32; 2] {
+    [3; 2]
+}
+
+pub fn test2() {
+    let x = foo();
+    verify!(x[0] == 3);
+    verify!(x[1] == 3);
+}
+
+fn bar(a: &mut [i32; 2]) {
+    *a = [4; 2];
+}
+
+pub fn test3() {
+    let mut x = [1; 2];
+    bar(&mut x);
+    verify!(x[0] == 4);
+    verify!(x[1] == 4);
+}
+
+pub fn test4() {
+    let mut x = [1, 2];
+    bar(&mut x);
+    verify!(x[0] == 4);
+    verify!(x[1] == 4);
+}
+
+pub fn test5() {
+    let mut x = [1; 2];
+    x[0] = 3;
+    bar(&mut x);
+    verify!(x[0] == 4);
+    verify!(x[1] == 4);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Array repeat values are sparse and special care must be taken to update aliases. I.e. if we have the (refined) side effect `a[0..2] = 5` from a summary, then we can't just update path a[0..10], but also need to update any aliasing paths, such as a[0] and a[1].

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
