### PR TITLE
Add more refinements

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -136,7 +136,8 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         place: &mir::Place<'tcx>,
         variant_index: rustc_target::abi::VariantIdx,
     ) {
-        let target_path = Path::new_discriminant(self.visit_place(place));
+        let target_path = Path::new_discriminant(self.visit_place(place))
+            .refine_paths(&self.bv.current_environment);
         let index_val = self.get_u128_const_val(variant_index.as_usize() as u128);
         self.bv
             .current_environment
@@ -1441,8 +1442,12 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     // If the target is not a fat pointer, it must be a thin pointer since an
                     // address of operator can hardly result in anything else. So, in this case,
                     // &*source_thin_ptr should just be a non canonical alias for source_thin_ptr.
-                    self.bv
-                        .copy_or_move_elements(path, qualifier.clone(), target_type, false);
+                    self.bv.copy_or_move_elements(
+                        path,
+                        qualifier.refine_paths(&self.bv.current_environment),
+                        target_type,
+                        false,
+                    );
                     return;
                 }
             }

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -691,7 +691,7 @@ impl PathRefinement for Rc<Path> {
             }
             PathEnum::Result => {
                 if result.is_none() {
-                    warn!("A summary that references it result should have a path for the result");
+                    warn!("A summary that references its result should have a path for the result");
                     Path::new_local(fresh)
                 } else {
                     result.as_ref().unwrap().clone()
@@ -768,7 +768,8 @@ impl PathRefinement for Rc<Path> {
                     if let Expression::Reference(path) = &value.expression {
                         // since self is a qualified path we have to drop the reference operator
                         // since selectors implicitly dereference pointers.
-                        return Path::new_qualified(path.clone(), refined_selector);
+                        return Path::new_qualified(path.clone(), refined_selector)
+                            .refine_paths(environment);
                     }
                 }
                 if let PathSelector::Downcast(_, variant) = refined_selector.as_ref() {

--- a/checker/tests/run-pass/struct_param_local_copy.rs
+++ b/checker/tests/run-pass/struct_param_local_copy.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that takes the address of a local copy of a parameter of type struct
+
+#[macro_use]
+extern crate mirai_annotations;
+
+#[derive(Clone, Copy)]
+struct Foo {
+    bar: i32,
+}
+
+fn foo(f: Foo) -> i32 {
+    let g: Foo = f;
+    foo2(&g)
+}
+
+fn foo2(f: &Foo) -> i32 {
+    f.bar
+}
+
+pub fn test1() {
+    let f = Foo { bar: 1 };
+    let i = foo(f);
+    verify!(i == 1);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Deal with path aliasing that arises when a field of a copy of struct that is a parameter ends up in the summary of a method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
