### PR TITLE
Check tags on the prefixes of a qualified path

### DIFF
--- a/checker/tests/run-pass/tag_non_scalar.rs
+++ b/checker/tests/run-pass/tag_non_scalar.rs
@@ -57,7 +57,6 @@ pub mod intra_procedure {
     }
 }
 
-// todo: deal with unknown paths rooted at parameters
 pub mod inter_procedure {
     use crate::SecretTaint;
 
@@ -68,7 +67,7 @@ pub mod inter_procedure {
                 && has_tag!(&tuple.1, SecretTaint)
                 && has_tag!(&tuple.2, SecretTaint)
                 && has_tag!(&tuple.3, SecretTaint)
-        ); //~ possible false verification condition
+        );
     }
 
     pub fn test_array(array: &[i32; 4]) {
@@ -78,7 +77,7 @@ pub mod inter_procedure {
                 && has_tag!(&array[1], SecretTaint)
                 && has_tag!(&array[2], SecretTaint)
                 && has_tag!(&array[3], SecretTaint)
-        ); //~ possible false verification condition
+        );
     }
 
     pub fn test_slice(slice: &[i32]) {
@@ -89,6 +88,6 @@ pub mod inter_procedure {
                 && has_tag!(&slice[1], SecretTaint)
                 && has_tag!(&slice[2], SecretTaint)
                 && has_tag!(&slice[3], SecretTaint)
-        ); //~ possible false verification condition
+        );
     }
 }

--- a/checker/tests/run-pass/tag_struct.rs
+++ b/checker/tests/run-pass/tag_struct.rs
@@ -92,9 +92,7 @@ pub mod with_propagation_to_sub_components {
         }
         add_tag!(join, SecretTaint);
         verify!(has_tag!(&foo, SecretTaint) || has_tag!(&bar, SecretTaint));
-        // todo: deal with unknown paths rooted at parameters
         verify!(has_tag!(&foo.content, SecretTaint) || has_tag!(&bar.content, SecretTaint));
-        //~ possible false verification condition
     }
 }
 


### PR DESCRIPTION
## Description

When a function parameter has a non-scalar type (e.g., struct), MIRAI does not have enough information about possible paths rooted by the parameter. Thus, when we add a tag to the function parameter, and the tag can be propagated to sub-components, we need a mechanism to propagate the tag to possible paths rooted by the parameter.

This commit focuses on intra-procedural verification. When the program adds and checks a tag on a qualified path (rooted by a parameter) inside the same function, at the checking site we iterate over all the prefixes of the path to see whether it can be tagged or not. Tag propagation during refinements will be addressed in a future PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra