### PR TITLE
Propagate tags during refinements

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -332,6 +332,9 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                             self.tcx.mk_mut_ref(self.tcx.lifetimes.re_static, slice_ty)
                         };
                     }
+                    PathSelector::TagField => {
+                        return self.dummy_untagged_value_type;
+                    }
                     _ => {}
                 }
                 info!("current span is {:?}", current_span);

--- a/checker/tests/run-pass/tag_nested_struct.rs
+++ b/checker/tests/run-pass/tag_nested_struct.rs
@@ -97,14 +97,13 @@ pub fn test7() {
     };
     taint_argument_for_test7(&foo);
     verify!(has_tag!(&foo, SecretTaint));
-    // todo: propagate tags during refinements
-    verify!(has_tag!(&foo.bar.content, SecretTaint)); //~ provably false verification condition
-    verify!(has_tag!(&foo.bar, SecretTaint)); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+    verify!(has_tag!(&foo.bar.content, SecretTaint));
+    verify!(has_tag!(&foo.bar, SecretTaint));
 }
 
 fn taint_argument_for_test8(foo: &Foo) {
-    add_tag!(foo, SecretTaint);
-    add_tag!(&foo.bar, SecretSanitizer);
+    add_tag!(&foo.bar, SecretTaint);
+    add_tag!(foo, SecretSanitizer);
 }
 
 pub fn test8() {
@@ -112,11 +111,10 @@ pub fn test8() {
         bar: Bar { content: 99991 },
     };
     taint_argument_for_test8(&foo);
-    // todo: propagate tags during refinements
-    verify!(has_tag!(&foo.bar, SecretTaint)); //~ provably false verification condition
-    verify!(has_tag!(&foo.bar, SecretSanitizer)); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
-    verify!(does_not_have_tag!(&foo, SecretTaint)); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
-    verify!(has_tag!(&foo, SecretSanitizer)); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
+    verify!(has_tag!(&foo.bar, SecretTaint));
+    verify!(has_tag!(&foo.bar, SecretSanitizer));
+    verify!(has_tag!(&foo, SecretSanitizer));
+    verify!(does_not_have_tag!(&foo, SecretTaint));
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

This commit adds a routine to propagate tags during refinements. Tag propagation is not properly handled by the original `transfer_and_refine` method, because some tags can be propagated to sub-components, but sub-components rooted by a function parameter are unknown during the analysis of the function itself, so they might not be tracked in the summary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra