### PR TITLE
Keep separate track of the pre-state during side-effect transfer

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -495,6 +495,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             callee_def_id,
             Some(callee_generic_arguments),
             callee_generic_argument_map.clone(),
+            self.bv.current_environment.clone(),
             func_const,
         );
         call_visitor.actual_args = &actual_args;

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -253,10 +253,8 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                             TyKind::Closure(def_id, subs) => {
                                 let _ = def_id;
                                 return subs.types().nth(*ordinal).unwrap_or_else(|| {
-                                    unrecoverable!(format!(
-                                        "closure field not found {:?} {:?}",
-                                        def_id, ordinal
-                                    ))
+                                    info!("closure field not found {:?} {:?}", def_id, ordinal);
+                                    self.tcx.types.never
                                 });
                             }
                             TyKind::Opaque(def_id, subs) => {

--- a/checker/tests/run-pass/for_in.rs
+++ b/checker/tests/run-pass/for_in.rs
@@ -11,7 +11,8 @@ extern crate mirai_annotations;
 
 pub fn foo(n: usize) {
     for ordinal in 2..=n {
-        verify!(ordinal - 1 >= 1);
+        verify!(ordinal - 1 >= 1); //~ possible attempt to subtract with overflow
+                                   //~ possible false verification condition
     }
 }
 


### PR DESCRIPTION
## Description

When refining a function summary with the call site environment, paths in the pre-conditions and side-effects should be refined in the call site environment as it was before the call. In particular, a later side-effect should not depend on an earlier
side-effect being applied to the environment in which it is refined.

Note that post conditions relate pre-state to post-state, so the current code breaks the for_in test which only worked accidentally. This will be addressed in a future PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
