### PR TITLE
Improve SMT encoding for numeric casts

### DIFF
--- a/checker/tests/run-pass/cast.rs
+++ b/checker/tests/run-pass/cast.rs
@@ -15,6 +15,18 @@ fn foo(i: u16) {
     }
 }
 
-pub fn main() {
-    foo(17);
+pub fn test1(i: u16) {
+    foo(i);
 }
+
+fn bar(i: usize) {
+    if i < 16 {
+        verify!((i as u16) < 16);
+    }
+}
+
+pub fn test2(i: usize) {
+    bar(i);
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -17,8 +17,7 @@ fn fact(n: u8) -> u128 {
     } else {
         let n1fac = fact(n - 1);
         verify!(n1fac <= std::u128::MAX / (n as u128));
-        // todo: figure out why Z3 times out on this query
-        (n as u128) * n1fac //~ possible attempt to multiply with overflow
+        (n as u128) * n1fac
     }
 }
 


### PR DESCRIPTION
## Description

Some casts between two integer types of different bit lengths (e.g., `16u16 as usize` or `16usize as u16`) preserve the value being casted. The Z3 encoding for numeric casts uses bit-vectors, which may make constraints hard to solve and lead to false positives. This commit refines the Z3 encoding for numeric casts to avoid bit-vectors when possible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra