### PR TITLE
Generalize support for patterned transfers from summaries

### DIFF
--- a/annotations/README.md
+++ b/annotations/README.md
@@ -32,8 +32,8 @@ Additionally we also have:
 * assumed_postcondition! which is an assume at the definition site, rather than a verify.
 * assume_preconditions! which assumes that the caller has satisfied all (inferred) preconditions of the next call.
 * assume_unreachable! which assumes that it is unreachable for reasons beyond what MIRAI can reason about.
-* unrecoverable! which is the same as panic! but explicitly indicates that this is not a programming mistake.
-* verify_unreachable! which requires MIRAI to verify that it is not unreachable.
+* unrecoverable! which is the same as panic! but explicitly indicates that this is not a programming mistake to reach this.
+* verify_unreachable! which requires MIRAI to verify that it is not reachable.
 
 This crate also provides macros for describing and constraining abstract state that only has meaning to MIRAI. These are:
 * abstract_value!


### PR DESCRIPTION
## Description

Tweak transfer_and_refine to support target path patterns in more situations. Add some documentation and todos.

Unrelated tweaks to readme for annotations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
