### PR TITLE
Add warning if assumption is provably false (resolve #393)

### DIFF
--- a/checker/tests/run-pass/assume_provably_false.rs
+++ b/checker/tests/run-pass/assume_provably_false.rs
@@ -1,0 +1,5 @@
+pub fn main() {
+    let a = 5;
+    assume!(a < 5); //this assumption is provably false and it will be ignored
+    verify!(a == 5);
+}

--- a/checker/tests/run-pass/assume_provably_false.rs
+++ b/checker/tests/run-pass/assume_provably_false.rs
@@ -1,5 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that a provably false assumption is ignored in the assertion.
+
+
+#[macro_use]
+extern crate mirai_annotations;
+
 pub fn main() {
     let a = 5;
-    assume!(a < 5); //this assumption is provably false and it will be ignored
+    assume!(a < 5); //~ assumption is provably false and it will be ignored in the assertion
     verify!(a == 5);
 }


### PR DESCRIPTION
## Description

Fixes #393 

I'm not sure though that these changes are enough because initially, I thought that the solution should also address the problem described in #389, but according to the discussion, in the current implementation of the `result!`, it is not possible. 

If I'm missing something, I will be glad to hear feedback. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
also, added an example to checker/run-pass tests