### PR TITLE
Report preconditions that cannot be promoted

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -812,6 +812,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         // We might get here, or not, and the condition might be false, or not.
         // Give a warning if we don't know all of the callers, or if we run into a k-limit
         if self.bv.function_being_analyzed_is_root()
+            || cond.expression.contains_local_variable()
             || self.bv.preconditions.len() >= k_limits::MAX_INFERRED_PRECONDITIONS
         {
             // We expect public functions to have programmer supplied preconditions

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -16,7 +16,7 @@ fn fact(n: u8) -> u128 {
         1
     } else {
         let n1fac = fact(n - 1);
-        verify!(n1fac <= std::u128::MAX / (n as u128));
+        verify!(n1fac <= std::u128::MAX / (n as u128)); //~ possible false verification condition
         (n as u128) * n1fac
     }
 }

--- a/checker/tests/run-pass/precondition_local.rs
+++ b/checker/tests/run-pass/precondition_local.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test that infers preconditions that contain local variables and thus emit diagnostics
+
+#[macro_use]
+extern crate mirai_annotations;
+
+fn test(v: &[i32]) {
+    let mut i = 0;
+    let n = v.len();
+    while i < n {
+        verify!(v[i] >= 0); //~ possible false verification condition
+                            // todo: improve precondition promotion by e.g., supporting quantification
+        i += 1;
+    }
+}
+
+pub fn main() {
+    let a = [-1, 2, 3];
+    let b = [1, 2, 3];
+    test(&a);
+    test(&b);
+}


### PR DESCRIPTION
## Description

Previously only inferred preconditions of public methods were reported regardless of the callers. Because preconditions that contain local variables cannot be promoted (at least for now), these preconditions should also be reported.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra
