### PR TITLE
Tweak path to type inference.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1943,6 +1943,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     }
                     None => Path::new_static(self.bv.tcx, *def_id),
                 };
+                self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
                 self.bv.lookup_path_and_refine_result(path, ty)
             }
 

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -224,7 +224,10 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                 selector,
                 ..
             } => {
-                let t = self.get_path_rustc_type(qualifier, current_span);
+                let mut t = self.get_path_rustc_type(qualifier, current_span);
+                if let TyKind::Projection(..) = &t.kind {
+                    t = self.specialize_generic_argument_type(t, &self.generic_argument_map);
+                }
                 match &**selector {
                     PathSelector::ConstantSlice { .. } => {
                         return t;


### PR DESCRIPTION
## Description

Add more special cases to get_path_rustc_type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
