### PR TITLE
std::clone::Clone::clone() must copy tags and model fields

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -488,6 +488,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             &actual_argument_types,
         );
 
+        let known_name = func_ref_to_call.known_name;
         let func_const = ConstantDomain::Function(func_ref_to_call);
         let func_const_args = &self.get_function_constant_args(&actual_args);
         let mut call_visitor = CallVisitor::new(
@@ -511,6 +512,10 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         let function_summary = call_visitor
             .get_function_summary()
             .unwrap_or_else(Summary::default);
+        if known_name == KnownNames::StdCloneClone {
+            call_visitor.handle_clone(&function_summary);
+            return;
+        }
         if call_visitor.block_visitor.bv.check_for_errors
             && (!function_summary.is_computed || function_summary.is_angelic)
         {

--- a/checker/src/known_names.rs
+++ b/checker/src/known_names.rs
@@ -26,12 +26,12 @@ pub enum KnownNames {
     MiraiPreconditionStart,
     MiraiResult,
     MiraiSetModelField,
-    MiraiShallowClone,
     MiraiVerify,
     RustAlloc,
     RustAllocZeroed,
     RustDealloc,
     RustRealloc,
+    StdCloneClone,
     StdFutureFromGenerator,
     StdIntrinsicsArithOffset,
     StdIntrinsicsBitreverse,
@@ -173,6 +173,24 @@ impl KnownNamesCache {
                 }
                 _ => KnownNames::None,
             };
+
+        let get_known_name_for_clone_trait = |mut def_path_data_iter: Iter<'_>| {
+            get_path_data_elem_name(def_path_data_iter.next())
+                .map(|n| match n.as_str().deref() {
+                    "clone" => KnownNames::StdCloneClone,
+                    _ => KnownNames::None,
+                })
+                .unwrap_or(KnownNames::None)
+        };
+
+        let get_known_name_for_clone_namespace = |mut def_path_data_iter: Iter<'_>| {
+            get_path_data_elem_name(def_path_data_iter.next())
+                .map(|n| match n.as_str().deref() {
+                    "Clone" => get_known_name_for_clone_trait(def_path_data_iter),
+                    _ => KnownNames::None,
+                })
+                .unwrap_or(KnownNames::None)
+        };
 
         let get_known_name_for_future_namespace = |mut def_path_data_iter: Iter<'_>| {
             get_path_data_elem_name(def_path_data_iter.next())
@@ -326,6 +344,7 @@ impl KnownNamesCache {
             get_path_data_elem_name(def_path_data_iter.next())
                 .map(|n| match n.as_str().deref() {
                     "alloc" => get_known_name_for_alloc_namespace(def_path_data_iter),
+                    "clone" => get_known_name_for_clone_namespace(def_path_data_iter),
                     "future" => get_known_name_for_future_namespace(def_path_data_iter),
                     "intrinsics" => get_known_name_for_intrinsics_namespace(def_path_data_iter),
                     "marker" => get_known_name_for_marker_namespace(def_path_data_iter),
@@ -345,7 +364,6 @@ impl KnownNamesCache {
                     "mirai_precondition" => KnownNames::MiraiPrecondition,
                     "mirai_result" => KnownNames::MiraiResult,
                     "mirai_set_model_field" => KnownNames::MiraiSetModelField,
-                    "mirai_shallow_clone" => KnownNames::MiraiShallowClone,
                     "mirai_verify" => KnownNames::MiraiVerify,
                     _ => KnownNames::None,
                 })

--- a/checker/tests/run-pass/tag_cloning.rs
+++ b/checker/tests/run-pass/tag_cloning.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test for cloning of tags
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+use mirai_annotations::TagPropagationSet;
+
+#[derive(Clone)]
+struct Block {
+    content: i32,
+}
+
+struct TaintTagKind<const MASK: TagPropagationSet> {}
+
+const TAINT_TAG_MASK: TagPropagationSet = tag_propagation_set!();
+
+type TaintTag = TaintTagKind<TAINT_TAG_MASK>;
+
+pub fn main() {
+    let a = Block { content: 0 };
+    add_tag!(&a, TaintTag);
+    let b = a.clone();
+    verify!(has_tag!(&b, TaintTag));
+}


### PR DESCRIPTION
## Description

When a call to an implementation of std::clone::Clone::clone(&self) is encountered, do the usual things and then also copy any tags and model fields to the target. If the implementation has already done this, it will just amount to a no-op. 

Fixes #611 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
