### PR TITLE
Remove some unnecessary work from an inner loop

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1691,9 +1691,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 let target_index_val = self.get_u128_const_val(u128::try_from(i - from).unwrap());
                 let indexed_target = Path::new_index(target_path.clone(), target_index_val)
                     .refine_paths(&self.current_environment);
-                debug!(
+                trace!(
                     "indexed_target {:?} indexed_source {:?} elem_ty {:?}",
-                    indexed_target, indexed_source, elem_ty
+                    indexed_target,
+                    indexed_source,
+                    elem_ty
                 );
                 update(self, indexed_target, indexed_source, elem_ty);
             }
@@ -1894,12 +1896,8 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 } else {
                     trace!("copying child {:?} to {:?}", value, qualified_path);
                 };
-                let rustc_type = self
-                    .type_visitor
-                    .get_path_rustc_type(&qualified_path, self.current_span);
-                let old_value =
-                    self.lookup_path_and_refine_result(qualified_path.clone(), rustc_type);
-                update(self, qualified_path, old_value, value.clone());
+                let old_value = value_map.get(&qualified_path).unwrap_or(&value);
+                update(self, qualified_path, old_value.clone(), value.clone());
                 no_children = false;
             }
             if let Expression::RefinedParameterCopy { path, .. }

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -7,7 +7,7 @@
 // take too long or use too much memory.
 
 /// The maximum number of seconds that MIRAI is willing to analyze a function body for.
-pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 5;
+pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 11;
 
 /// The maximum number of elements in a byte array that will be individually tracked.
 pub const MAX_BYTE_ARRAY_LENGTH: usize = 10;


### PR DESCRIPTION
## Description

Remove some unnecessary work from the inner loop of non_patterned_copy_or_move_elements, which is a performance critical function. Also increase the time-out for analyzing a single function body to allow analysis of huge functions that initialize matrices in the crypto code we are focusing on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
