### PR TITLE
Refine deref of local that contains a reference to a parameter copy.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -82,6 +82,8 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 location.statement_index += 1;
             }
             terminator_state.insert(bb, self.bv.current_environment.clone());
+        } else {
+            location.statement_index = terminator_index;
         }
 
         if let Some(mir::Terminator {
@@ -2658,7 +2660,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                             .type_visitor
                             .get_path_rustc_type(&thin_pointer_path, self.bv.current_span);
                         ty = type_visitor::get_target_type(thin_ptr_type);
-                        let deref_path = Path::new_qualified(thin_pointer_path, Rc::new(selector));
+                        let deref_path = Path::new_deref(thin_pointer_path);
                         self.bv
                             .type_visitor
                             .path_ty_cache

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -836,6 +836,12 @@ impl PathRefinement for Rc<Path> {
                                 );
                             }
                         }
+                        Expression::RefinedParameterCopy { .. } => {
+                            return Path::new_qualified(
+                                Path::get_as_path(val.clone()),
+                                refined_selector,
+                            );
+                        }
                         Expression::Variable { path, .. } => {
                             // This is not ideal, but without some kind of check this can overflow the stack.
                             // Investigate this some more in the future. (It involves joins.)


### PR DESCRIPTION
## Description

Fix refine_paths to deal with a deref of a local that contains a reference to a parameter copy.

Tweak visit_basic_block to properly track the location of a terminator when in check errors mode (which does not visit statements).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
