### PR TITLE
Deal with non-standard enum encoding

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -358,7 +358,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 local_val
             }
         };
-        let result = if refined_val.is_bottom() {
+        let result = if refined_val.is_bottom() || refined_val.is_top() {
             if self.imported_root_static(&path) {
                 return self.lookup_path_and_refine_result(path, result_rustc_type);
             }
@@ -409,7 +409,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                             }
                             AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
                         }
-                        PathEnum::LocalVariable { .. } => refined_val,
+                        PathEnum::LocalVariable { .. } if !refined_val.is_top() => refined_val,
                         _ => AbstractValue::make_typed_unknown(
                             result_type.clone(),
                             path.replace_parameter_root_with_copy(),

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -312,7 +312,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     /// If this call is to an implementation of the std::clone::Clone::clone trait method
     /// then make sure any model fields and tag fields are copied to the result as well.
     /// If there is no MIR implementation available for the clone method, then fall back to a
-    /// deep copy (after calling deal_with_missing_summary).   
+    /// deep copy (after calling deal_with_missing_summary).
     #[logfn_inputs(DEBUG)]
     pub fn handle_clone(&mut self, summary: &Summary) {
         if let Some((place, _)) = &self.destination {

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -58,7 +58,7 @@ impl Environment {
     /// Updates the path to value map so that the given path now points to the given value.
     #[logfn_inputs(TRACE)]
     pub fn update_value_at(&mut self, path: Rc<Path>, value: Rc<AbstractValue>) {
-        if value.is_bottom() || value.is_top() {
+        if value.is_bottom() {
             self.value_map = self.value_map.remove(&path);
             return;
         }

--- a/checker/tests/run-pass/enum_fieldless.rs
+++ b/checker/tests/run-pass/enum_fieldless.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test that fieldless enums can have explicitly defined values for discriminants
+
+#[macro_use]
+extern crate mirai_annotations;
+enum SomeEnumA {
+    VariantN33 = -33,
+    VariantN11 = -11,
+    Variant22 = 22,
+    Variant44 = 44,
+    Variant45,
+}
+
+enum SomeEnumB {
+    None,
+    Some(char),
+    Leaf,
+}
+
+enum SomeEnumC {
+    Only(char),
+}
+
+enum SomeEnumD {
+    Only = -123,
+}
+
+fn foo(n: u32) -> SomeEnumA {
+    match n {
+        0 => SomeEnumA::VariantN33,
+        1 => SomeEnumA::VariantN11,
+        2 => SomeEnumA::Variant22,
+        3 => SomeEnumA::Variant44,
+        _ => SomeEnumA::Variant45,
+    }
+}
+
+fn bar(n: u32) -> SomeEnumB {
+    match n {
+        0 => SomeEnumB::Leaf,
+        1 => SomeEnumB::Some('a'),
+        2 => SomeEnumB::Some('/'),
+        3 => SomeEnumB::Some('A'),
+        _ => SomeEnumB::None,
+    }
+}
+
+fn baz(n: u32) -> SomeEnumC {
+    match n {
+        0 => SomeEnumC::Only('4'),
+        1 => SomeEnumC::Only('$'),
+        _ => SomeEnumC::Only('\0'),
+    }
+}
+
+fn fun() -> SomeEnumD {
+    SomeEnumD::Only
+}
+
+pub fn main() {
+    verify!(matches!(foo(0), SomeEnumA::VariantN33));
+    verify!(matches!(foo(1), SomeEnumA::VariantN11));
+    verify!(matches!(foo(2), SomeEnumA::Variant22));
+    verify!(matches!(foo(3), SomeEnumA::Variant44));
+    verify!(matches!(foo(12345), SomeEnumA::Variant45));
+    verify!(matches!(foo(54321), SomeEnumA::Variant45));
+
+    verify!(matches!(bar(0), SomeEnumB::Leaf));
+    verify!(matches!(bar(1), SomeEnumB::Some('a')));
+    verify!(matches!(bar(2), SomeEnumB::Some('/')));
+    verify!(matches!(bar(3), SomeEnumB::Some('A')));
+    verify!(matches!(bar(12345), SomeEnumB::None));
+    verify!(matches!(bar(54321), SomeEnumB::None));
+
+    verify!(matches!(baz(0), SomeEnumC::Only('4')));
+    verify!(matches!(baz(1), SomeEnumC::Only('$')));
+    verify!(matches!(baz(2), SomeEnumC::Only('\0')));
+
+    verify!(matches!(fun(), SomeEnumD::Only));
+}

--- a/checker/tests/run-pass/iterator.rs
+++ b/checker/tests/run-pass/iterator.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test that uses ranges mutated via iterators in a loop.
+
+#![feature(range_is_empty)]
+#![feature(unchecked_math)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+// pub fn test1() {
+//     let mut it = std::ops::Range {
+//         start: 0usize,
+//         end: 10usize,
+//     };
+
+//     while let Some(_) = it.next() {
+//         verify!(it.start <= 10);
+//     }
+//     verify!(it.start >= 10);
+// }
+
+// todo: sizes of expressions are too large. Simplify them on the fly.
+// pub fn test2() {
+//     let mut it = std::ops::RangeInclusive::new(0usize, 10usize);
+//     while let Some(_) = it.next() {
+//         verify!(*it.start() <= 10);
+//     }
+//     verify!(it.is_empty());
+// }
+
+struct UsizeRangeInclusive {
+    start: usize,
+    end: usize,
+    exhausted: bool,
+}
+
+impl UsizeRangeInclusive {
+    fn new(start: usize, end: usize) -> UsizeRangeInclusive {
+        UsizeRangeInclusive {
+            start,
+            end,
+            exhausted: false,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.exhausted || !(self.start <= self.end)
+    }
+
+    fn next(&mut self) -> Option<usize> {
+        if self.is_empty() {
+            return None;
+        }
+        let is_iterating = self.start < self.end;
+        Some(if is_iterating {
+            let n = unsafe { std::iter::Step::forward_unchecked(self.start.clone(), 1) };
+            std::mem::replace(&mut self.start, n)
+        } else {
+            self.exhausted = true;
+            self.start.clone()
+        })
+    }
+}
+
+pub fn test3() {
+    let mut it = UsizeRangeInclusive::new(0usize, 10usize);
+    while let Some(_) = it.next() {
+        verify!(it.start <= 10);
+    }
+    verify!(it.is_empty());
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Fieldless enums can have discriminants with explicitly defined tag values. For example, `std::cmp::Ordering` is defined as `{ Less = -1, Equal = 0, Greater = 1 }`. This commit implements a routine to extract consistent discriminant tags for fieldless enums.

Some enums have non-standard encoding. For example, a value of `Option<char>` is encoded as a 32-bit integer, where `Some(c)` is represented by the value of `c`, and `None` is represented by `0x110000`. This commit also takes care of such special encoding of enums.

This commit also fixes a few issues:
- `switchInt` instructions can have multiple branches with the same target.
- The treatment of `TOP` should be slightly different from `BOTTOM`. Currently, when the size of an expression becomes too large, it is then abstracted by `TOP`, which really means an existing but unknown value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh
ran MIRAI over Libra