### PR TITLE
Fix nested loop fix point computation

### DIFF
--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -1057,7 +1057,7 @@ macro_rules! verify_unreachable {
     };
 }
 
-// Helper function for MIRAI. Should only be called via the result! macro.
+// Helper function for MIRAI. Should only be called via the abstract_value! macro.
 #[doc(hidden)]
 pub fn mirai_abstract_value<T>(x: T) -> T {
     x

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -394,6 +394,7 @@ pub trait AbstractValueTrait: Sized {
     fn is_compile_time_constant(&self) -> bool;
     fn is_contained_in_zeroed_heap_block(&self) -> bool;
     fn is_top(&self) -> bool;
+    fn is_widened(&self) -> bool;
     fn join(&self, other: Self, path: &Rc<Path>) -> Self;
     fn less_or_equal(&self, other: Self) -> Self;
     fn less_than(&self, other: Self) -> Self;
@@ -1665,6 +1666,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     fn is_top(&self) -> bool {
         match self.expression {
             Expression::Top => true,
+            _ => false,
+        }
+    }
+
+    /// True if this a widened value.
+    #[logfn_inputs(TRACE)]
+    fn is_widened(&self) -> bool {
+        match self.expression {
+            Expression::Widen { .. } => true,
             _ => false,
         }
     }

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1017,6 +1017,12 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 )
                 .replace_root(&refined_dummy_root, target_path.clone())
                 .refine_paths(pre_environment);
+            let pre_state_value = self.current_environment.value_at(&tpath);
+            if matches!(pre_state_value, Some(v) if v.is_widened()) {
+                // If the value is self referential, i.e. if its new value refers to its old
+                // value, widening may not converge. So just stick with the already widened value.
+                continue;
+            }
             let uncanonicalized_rvalue = value.refine_parameters(
                 arguments,
                 result_path,


### PR DESCRIPTION
## Description

When checking if a nested loop body has reached a fixed point, use the out_state of the last block of the nested loop body. More importantly, make a copy of out_state before processing the current block/body because doing so will (nowadays) update out_state. This had the perverse effect of always terminating (non nested loop) fixed point iterations after 4 iterations. Fixing this uncovered diverging behavior with widening when widened values are updated via refinement of summaries.

The non convergence of widened values obtained from summaries has been fixed by not transferring summary side effects when the side effect will replace one widened value with another.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
