### PR TITLE
Update the tutorial for tag analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "contracts"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730b7cefe8f7e0826d0efb633ab373b85d0fb97c7d83942a0e70911a0e62f505"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +365,7 @@ version = "1.0.5"
 dependencies = [
  "bincode",
  "clap",
- "contracts",
+ "contracts 0.4.0",
  "env_logger",
  "fs2",
  "itertools",
@@ -596,7 +607,7 @@ dependencies = [
 name = "shopping_cart"
 version = "0.1.0"
 dependencies = [
- "contracts",
+ "contracts 0.4.0",
  "mirai-annotations",
 ]
 
@@ -722,6 +733,14 @@ dependencies = [
 name = "timing_channels"
 version = "0.1.0"
 dependencies = [
+ "mirai-annotations",
+]
+
+[[package]]
+name = "trait_methods"
+version = "0.1.0"
+dependencies = [
+ "contracts 0.5.1",
  "mirai-annotations",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "examples/shopping_cart",
     "examples/tag_analysis/timing_channels",
     "examples/tag_analysis/untrustworthy_inputs",
-    "examples/tag_analysis/verification_status"
+    "examples/tag_analysis/verification_status",
+    "examples/tag_analysis/trait_methods",
 ]
 
 [profile.release]

--- a/examples/tag_analysis/timing_channels/src/lib.rs
+++ b/examples/tag_analysis/timing_channels/src/lib.rs
@@ -7,16 +7,18 @@
 // Use the following flag of MIRAI to enable constant-time verification:
 // MIRAI_FLAGS --constant_time SecretTaintKind
 
-#![feature(const_generics)]
-#![allow(incomplete_features)]
+#![cfg_attr(mirai, allow(incomplete_features), feature(const_generics))]
 
 #[macro_use]
 extern crate mirai_annotations;
 
+#[cfg(mirai)]
 use mirai_annotations::{TagPropagation, TagPropagationSet};
 
+#[cfg(mirai)]
 struct SecretTaintKind<const MASK: TagPropagationSet> {}
 
+#[cfg(mirai)]
 const SECRET_TAINT_MASK: TagPropagationSet = tag_propagation_set!(
     TagPropagation::Equals,
     TagPropagation::GreaterThan,
@@ -26,7 +28,10 @@ const SECRET_TAINT_MASK: TagPropagationSet = tag_propagation_set!(
     TagPropagation::Ne
 );
 
+#[cfg(mirai)]
 type SecretTaint = SecretTaintKind<SECRET_TAINT_MASK>;
+#[cfg(not(mirai))]
+type SecretTaint = ();
 
 const KEY_LENGTH: usize = 1024;
 

--- a/examples/tag_analysis/trait_methods/Cargo.toml
+++ b/examples/tag_analysis/trait_methods/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "trait_methods"
+version = "0.1.0"
+authors = ["Di Wang <diwang95@fb.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+test = false # we have no unit tests
+doctest = false # and no doc tests
+
+[dependencies]
+contracts = { version = "*", features = [ "mirai_assertions" ]}
+mirai-annotations = { path = "../../../annotations" }

--- a/examples/tag_analysis/trait_methods/src/lib.rs
+++ b/examples/tag_analysis/trait_methods/src/lib.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+// This is an example of adding tag-related annotations to trait methods.
+
+#![cfg_attr(mirai, allow(incomplete_features), feature(const_generics))]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+#[cfg(mirai)]
+use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+#[cfg(mirai)]
+struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+#[cfg(mirai)]
+const SECRET_TAINT_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+#[cfg(mirai)]
+type SecretTaint = SecretTaintKind<SECRET_TAINT_MASK>;
+#[cfg(not(mirai))]
+type SecretTaint = ();
+
+use contracts::*;
+
+#[allow(clippy::inline_fn_without_body)]
+#[contract_trait]
+trait ProcessWithoutTaint {
+    #[pre(does_not_have_tag!(self, SecretTaint))]
+    fn process(&mut self, incr: i32);
+}
+
+struct Block {
+    content: i32,
+}
+
+#[contract_trait]
+impl ProcessWithoutTaint for Block {
+    fn process(&mut self, incr: i32) {
+        self.content += incr;
+    }
+}
+
+pub fn main() {
+    let mut block = Block { content: 99991 };
+    verify!(does_not_have_tag!(&block, SecretTaint));
+    block.process(12345);
+    add_tag!(&block, SecretTaint);
+    verify!(has_tag!(&block, SecretTaint));
+    block.process(54321); //~ unsatisfied precondition
+}

--- a/examples/tag_analysis/untrustworthy_inputs/src/lib.rs
+++ b/examples/tag_analysis/untrustworthy_inputs/src/lib.rs
@@ -6,26 +6,36 @@
 // This is an example of using tag analysis to track untrustworthy inputs.
 // The code is extracted from a crate for public-key cryptography.
 
-#![feature(const_generics)]
-#![allow(incomplete_features)]
+#![cfg_attr(mirai, allow(incomplete_features), feature(const_generics))]
 
 #[macro_use]
 extern crate mirai_annotations;
 
 use core::convert::TryFrom;
+#[cfg(mirai)]
 use mirai_annotations::{TagPropagation, TagPropagationSet};
 
+#[cfg(mirai)]
 struct TaintedKind<const MASK: TagPropagationSet> {}
 
+#[cfg(mirai)]
 const TAINTED_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
 
+#[cfg(mirai)]
 type Tainted = TaintedKind<TAINTED_MASK>;
+#[cfg(not(mirai))]
+type Tainted = ();
 
+#[cfg(mirai)]
 struct SanitizedKind<const MASK: TagPropagationSet> {}
 
+#[cfg(mirai)]
 const SANITIZED_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
 
+#[cfg(mirai)]
 type Sanitized = SanitizedKind<SANITIZED_MASK>;
+#[cfg(not(mirai))]
+type Sanitized = ();
 
 /// A structure for public keys.
 pub struct PublicKey(u32);

--- a/examples/tag_analysis/verification_status/src/lib.rs
+++ b/examples/tag_analysis/verification_status/src/lib.rs
@@ -6,19 +6,24 @@
 // This is an example of using tag analysis to record verification status of objects.
 // The code is extracted from a blockchain codebase.
 
-#![feature(const_generics)]
-#![allow(incomplete_features)]
+#![cfg_attr(mirai, allow(incomplete_features), feature(const_generics))]
 
 #[macro_use]
 extern crate mirai_annotations;
 
+#[cfg(mirai)]
 use mirai_annotations::{TagPropagation, TagPropagationSet};
 
+#[cfg(mirai)]
 struct VerifiedKind<const MASK: TagPropagationSet> {}
 
+#[cfg(mirai)]
 const VERIFIED_MASK: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
 
+#[cfg(mirai)]
 type Verified = VerifiedKind<VERIFIED_MASK>;
+#[cfg(not(mirai))]
+type Verified = ();
 
 /// VoteMsg is the structure sent by the voter in response for receiving a proposal.
 pub struct VoteMsg {


### PR DESCRIPTION
## Description

This commit updates the tutorial for tag analysis with the changes below:
- Describe a mechanism to safely use the incomplete `const_generics` feature (required by tag analysis) in a project.
- Add a section and an example on adding tag-related annotations to trait methods.
- Clarify the pros & cons of using tag analysis to record verification status.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

None of the above: documentation change with a new example.

## How Has This Been Tested?

./validate.sh (can't run MIRAI on itself right now)