### PR TITLE
Fix enum encoding to make range iterators work

### DIFF
--- a/checker/tests/run-pass/iterator.rs
+++ b/checker/tests/run-pass/iterator.rs
@@ -23,13 +23,13 @@ pub fn test1() {
     verify!(it.start >= 10);
 }
 
-// pub fn test2() {
-//     let mut it = std::ops::RangeInclusive::new(0usize, 10usize);
-//     while let Some(_) = it.next() {
-//         verify!(*it.start() <= 10);
-//     }
-//     verify!(it.is_empty());
-// }
+pub fn test2() {
+    let mut it = std::ops::RangeInclusive::new(0usize, 10usize);
+    while let Some(_) = it.next() {
+        verify!(*it.start() <= 10);
+    }
+    verify!(it.is_empty());
+}
 
 struct UsizeRangeInclusive {
     start: usize,


### PR DESCRIPTION
## Description

This commit fixes issues on enum encoding to make range iterators work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

./validate.sh (can't run MIRAI on itself right now)
Not working for libra either