### PR TITLE
Tweak handling of promoted constants inside unreachable blocks

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1985,10 +1985,6 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         let mut val = literal.val;
         let ty = literal.ty;
         if let rustc_middle::ty::ConstKind::Unevaluated(def_ty, substs, promoted) = &literal.val {
-            // Do this to get MIR into the cache
-            val = literal
-                .val
-                .eval(self.bv.tcx, self.bv.type_visitor.get_param_env());
             let def_id = def_ty.def_id_for_type_of();
             let substs = self
                 .bv
@@ -2003,9 +1999,27 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 None => Path::new_static(self.bv.tcx, def_id),
             };
             self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
+            // Note that this might not find the promoted constant in the current environment,
+            // even though it was imported at the beginning of visit_body. This happens
+            // when the current environment starts of empty because we are visiting an
+            // unreachable block for error reporting purposes.
+            //todo: keep track of the first state containing the promoted constants and use that
+            // to lookup PromotedConstant paths.
             let static_val = self.bv.lookup_path_and_refine_result(path, ty);
             if let Expression::Variable { .. } = &static_val.expression {
-                debug!("literal {:?} has no MIR, evaluates to {:?}", literal, val);
+                // Try getting the value from val.eval
+                val = val.eval(self.bv.tcx, self.bv.type_visitor.get_param_env());
+                match &val {
+                    rustc_middle::ty::ConstKind::Unevaluated(..) => {
+                        // val.eval did not manage to evaluate this, go with unknown.
+                        return static_val;
+                    }
+                    rustc_middle::ty::ConstKind::Value(ConstValue::ByRef { .. }) => {
+                        // Don't currently know how to deal with such a result, go with unknown.
+                        return static_val;
+                    }
+                    _ => {}
+                }
             } else {
                 return static_val;
             }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -141,6 +141,7 @@ impl MiraiCallbacks {
     fn is_excluded(file_name: &str) -> bool {
         file_name.contains("client/libra-dev/src") // takes too long
             || file_name.contains("config/management/src") // false positives
+            || file_name.contains("config/management/genesis") // takes too long
             || file_name.contains("consensus/src") // resolve error
             || file_name.contains("consensus/safety-rules/src") // false positives
             || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
@@ -164,9 +165,14 @@ impl MiraiCallbacks {
             || file_name.contains("language/resource-viewer/src") // false positives
             || file_name.contains("language/move-prover/docgen/src") // takes too long 
             || file_name.contains("language/move-prover/stackless-bytecode-generator/src") // resolve error
+            || file_name.contains("language/stdlib/src") // z3 encoding
+            || file_name.contains("language/transaction-builder/generator/src") // z3 encoding
+            || file_name.contains("language/tools/move-coverage/src") // stack overflow
+            || file_name.contains("language/tools/transaction-replay/src") // z3 encoding
             || file_name.contains("language/tools/vm-genesis/src") // resolve error
             || file_name.contains("language/tools/genesis-viewer/src") // false positives
             || file_name.contains("language/vm/src") // false positives
+            || file_name.contains("mempool/src") // stack overflow
             || file_name.contains("network/src") // resolve error
             || file_name.contains("network/builder") // takes too long
             || file_name.contains("secure/net/src") // false positives
@@ -177,6 +183,7 @@ impl MiraiCallbacks {
             || file_name.contains("storage/jellyfish-merkle/src") // unreachable code
             || file_name.contains("storage/backup/backup-cli/src") // panics
             || file_name.contains("storage/libradb/src") // resolve error
+            || file_name.contains("storage/schemadb/src") // crash
             || file_name.contains("testsuite/cli/src") // false positives
             || file_name.contains("testsuite/cli/libra-wallet/src") // takes too long
             || file_name.contains("types/src") // resolve error


### PR DESCRIPTION
## Description

Recent changes in rustc means more constants come to MIRAI in unevaluated form. Evaluating these via the eval method helps, but produces useless and unexpected results for some promoted constants.

Normally this is not a problem because these have already been evaluated and entered into the initial environment, but when a block is not reachable, it has no predecessors and can end up with an empty environment, which means that unexpected constant values resulting from eval spilled over into the subsequent code and caused crashes.

Work around this for now by adding special case logic to prevent spilling these. Added a todo to come up with a proper solution (more bookkeeping work is needed for that).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh (MIRAI on MIRAI still does not work)
ran MIRAI over Libra (now works, but more crates are excluded)
