### PR TITLE
Deal with unevaluated enum variant constants

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2290,9 +2290,14 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         literal: &rustc_middle::ty::Const<'tcx>,
         ty: Ty<'tcx>,
     ) -> Rc<AbstractValue> {
+        let mut val = literal.val;
+        if let rustc_middle::ty::ConstKind::Unevaluated(..) = &val {
+            val = val.eval(self.bv.tcx, self.bv.type_visitor.get_param_env());
+        }
+
         if let rustc_middle::ty::ConstKind::Value(ConstValue::Scalar(Scalar::Raw {
             data, ..
-        })) = &literal.val
+        })) = &val
         {
             let param_env = self.bv.type_visitor.get_param_env();
             if let Ok(ty_and_layout) = self.bv.tcx.layout_of(param_env.and(ty)) {

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1462,10 +1462,9 @@ impl Z3Solver {
         operand: &Rc<AbstractValue>,
     ) -> (bool, z3_sys::Z3_ast) {
         use self::ExpressionType::*;
-        let expr_type = operand.expression.infer_type();
-        let expr_type = match expr_type {
-            Bool | ThinPointer | NonPrimitive => ExpressionType::I128,
-            _ => expr_type,
+        let expr_type = match operand.expression.infer_type() {
+            Bool | Function | ThinPointer | NonPrimitive => ExpressionType::I128,
+            val => val,
         };
         let is_float = expr_type.is_floating_point_number();
         let ast = self.get_ast_for_widened(path, operand, expr_type);

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -1972,6 +1972,13 @@ pub mod core {
         pub fn slice_index_overflow_fail() {
             panic!("attempted to index slice up to maximum usize");
         }
+
+        fn slice_start_index_len_fail(index: usize, len: usize) -> ! {
+            panic!(
+                "range start index {} out of range for slice of length {}",
+                index, len
+            );
+        }
     }
 
     pub mod usize {


### PR DESCRIPTION
## Description

Deal with unevaluated enum variant constants that show up as a result of recent changes to rustc.

Work around what seems to be a rustc bug in a type inference step in z3_solver.

Add a contract for a standard function that does not have MIR included in the distribution.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
