### PR TITLE
Use upvars to find the fields of a closure object

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -697,6 +697,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                             substs,
                         ));
                     }
+                    //todo: what about generators?
                     TyKind::Ref(_, ty, _) => {
                         let specialized_closure_ty =
                             self.bv.type_visitor.specialize_generic_argument_type(
@@ -2881,26 +2882,20 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         .current_environment
                         .update_value_at(len_path, len_val);
                 }
-                TyKind::Closure(def_id, generic_args) => {
-                    let func_const = self.visit_function_reference(
-                        *def_id,
-                        ty,
-                        generic_args.as_closure().substs,
-                    );
+                TyKind::Closure(def_id, generic_args)
+                | TyKind::Generator(def_id, generic_args, ..) => {
+                    let func_const = self.visit_function_reference(*def_id, ty, generic_args);
                     let func_val = Rc::new(func_const.clone().into());
                     self.bv
                         .current_environment
                         .update_value_at(base_path.clone(), func_val);
                 }
                 TyKind::Opaque(def_id, ..) => {
+                    //todo: what about generators?
                     if let TyKind::Closure(def_id, generic_args) =
                         &self.bv.tcx.type_of(*def_id).kind
                     {
-                        let func_const = self.visit_function_reference(
-                            *def_id,
-                            ty,
-                            generic_args.as_closure().substs,
-                        );
+                        let func_const = self.visit_function_reference(*def_id, ty, generic_args);
                         let func_val = Rc::new(func_const.clone().into());
                         self.bv
                             .current_environment
@@ -2912,17 +2907,6 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         *def_id,
                         ty,
                         generic_args.as_closure().substs,
-                    );
-                    let func_val = Rc::new(func_const.clone().into());
-                    self.bv
-                        .current_environment
-                        .update_value_at(base_path.clone(), func_val);
-                }
-                TyKind::Generator(def_id, generic_args, ..) => {
-                    let func_const = self.visit_function_reference(
-                        *def_id,
-                        ty,
-                        generic_args.as_generator().substs,
                     );
                     let func_val = Rc::new(func_const.clone().into());
                     self.bv

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -175,7 +175,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
         // Add parameter values that are function constants.
         // Also add entries for closure fields.
         for (path, val) in function_constant_args.iter() {
-            TypeVisitor::add_any_closure_fields_for(
+            self.type_visitor.add_any_closure_fields_for(
                 &mut self.current_environment,
                 parameter_types,
                 &mut first_state,
@@ -1147,9 +1147,13 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     if matches!(&path.value, PathEnum::PhantomData) {
                         continue;
                     }
-                    let target_type = self
+                    let mut target_type = self
                         .type_visitor
                         .get_path_rustc_type(&tpath, self.current_span);
+                    if target_type == self.tcx.types.never {
+                        //todo: figure out why this happens
+                        target_type = rtype.as_rustc_type(self.tcx);
+                    }
                     if let PathEnum::LocalVariable { ordinal } = &path.value {
                         if *ordinal >= self.fresh_variable_offset {
                             // A fresh variable from the callee adds no information that is not

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -943,12 +943,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         if type_visitor::get_def_id_from_closure(closure_ty).is_some() {
             actual_args.insert(0, self.actual_args[0].clone());
             actual_argument_types.insert(0, closure_ref_ty);
+            //todo: could this be a generator?
             if let TyKind::Closure(def_id, substs) = closure_ty.kind {
                 argument_map = self
                     .block_visitor
                     .bv
                     .type_visitor
-                    .get_generic_arguments_map(def_id, substs, &[]);
+                    .get_generic_arguments_map(def_id, substs.as_closure().substs, &[]);
             }
         }
 


### PR DESCRIPTION
## Description

Adapt to the new encoding of closure fields in the generic arguments. Add some todo comments for dealing with generators.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
