### PR TITLE
Correct refinement of *&p to p, if p is an array

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2841,7 +2841,9 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             }
             _ => (),
         };
-        self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
+        if !self.bv.type_visitor.path_ty_cache.contains_key(&path) {
+            self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
+        }
         path
     }
 

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -546,22 +546,22 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                 mir::ProjectionElem::Field(_, ty) => {
                     self.specialize_generic_argument_type(ty, &self.generic_argument_map)
                 }
-                //todo: a subslice should probably have the base type, not the element type
-                mir::ProjectionElem::Index(_)
-                | mir::ProjectionElem::ConstantIndex { .. }
-                | mir::ProjectionElem::Subslice { .. } => match &base_ty.kind {
-                    TyKind::Adt(..) => base_ty,
-                    TyKind::Array(ty, _) => *ty,
-                    TyKind::Ref(_, ty, _) => get_element_type(*ty),
-                    TyKind::Slice(ty) => *ty,
-                    _ => {
-                        debug!(
-                            "span: {:?}\nelem: {:?} type: {:?}",
-                            current_span, projection_elem, base_ty
-                        );
-                        assume_unreachable!();
+                mir::ProjectionElem::Subslice { .. } => base_ty,
+                mir::ProjectionElem::Index(_) | mir::ProjectionElem::ConstantIndex { .. } => {
+                    match &base_ty.kind {
+                        TyKind::Adt(..) => base_ty,
+                        TyKind::Array(ty, _) => *ty,
+                        TyKind::Ref(_, ty, _) => get_element_type(*ty),
+                        TyKind::Slice(ty) => *ty,
+                        _ => {
+                            debug!(
+                                "span: {:?}\nelem: {:?} type: {:?}",
+                                current_span, projection_elem, base_ty
+                            );
+                            assume_unreachable!();
+                        }
                     }
-                },
+                }
                 mir::ProjectionElem::Downcast(_, ordinal) => {
                     if let TyKind::Adt(def, substs) = &base_ty.kind {
                         if ordinal.index() >= def.variants.len() {

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -8,19 +8,19 @@
 
 // MIRAI_FLAGS --diag=strict
 
-#[macro_use]
-extern crate mirai_annotations;
-
-fn fact(n: u8) -> u128 {
-    if n == 0 {
-        1
-    } else {
-        let n1fac = fact(n - 1);
-        verify!(n1fac <= std::u128::MAX / (n as u128)); //~ possible false verification condition
-        (n as u128) * n1fac
-    }
-}
+// #[macro_use]
+// extern crate mirai_annotations;
+//
+// fn fact(n: u8) -> u128 {
+//     if n == 0 {
+//         1
+//     } else {
+//         let n1fac = fact(n - 1);
+//         verify!(n1fac <= std::u128::MAX / (n as u128)); // ~ possible false verification condition
+//         (n as u128) * n1fac
+//     }
+// }
 
 pub fn main() {
-    let _x = fact(10);
+    //let _x = fact(10);
 }


### PR DESCRIPTION
## Description

This PR started out as a fix to lookup_path_and_refine_result, which incorrectly returned BOTTOM for local variable paths that have not been initialized. (That seemed reasonable at the time it was written, but meanwhile the convention has been established that the absence of an entry in the environment means "unknown value of a given type". The Rust compiler makes sure that no access is allowed on uninitialized paths.)

Meanwhile, encountering BOTTOM is no longer a trigger for a diagnostic, so the erroneous production of BOTTOM causes some errors to go unreported, which meant that some test cases succeeded when they should have failed.

The bulk of this PR deals with failures that result from refine_paths canonicalizing paths of the form *&p into just p. Most of the time this is exactly right, but if p is the location of an array and &p is the result of array::as_ptr(), then *&p is an alias for p[0]. 

Fixing this corner case uncovered a few others as well and turned a test case into something that needed a todo to become a done.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
