### PR TITLE
Avoid creating environment entries for unkown values

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1151,6 +1151,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     if matches!(&path.value, PathEnum::PhantomData) {
                         continue;
                     }
+                    if tpath.eq(path) {
+                        // amounts to "x = unknown_value_at(x)"
+                        self.current_environment.value_map.remove_mut(path);
+                        continue;
+                    }
                     let mut target_type = self
                         .type_visitor
                         .get_path_rustc_type(&tpath, self.current_span);


### PR DESCRIPTION
## Description

When transferring a side effect from a callee summary to the call side, avoid creating environment entries that add no information. This (potentially) saves a bit of computation and makes debugging a bit easier.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
