### PR TITLE
Make refine_parameters do the right thing for PathEnum::Alias

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -671,6 +671,9 @@ impl PathRefinement for Rc<Path> {
         fresh: usize,
     ) -> Rc<Path> {
         match &self.value {
+            PathEnum::Alias { value } => {
+                Path::new_alias(value.refine_parameters(arguments, result, pre_environment, fresh))
+            }
             PathEnum::HeapBlock { value } => {
                 let refined_value =
                     value.refine_parameters(arguments, result, pre_environment, fresh);
@@ -716,7 +719,9 @@ impl PathRefinement for Rc<Path> {
                     selector.refine_parameters(arguments, result, pre_environment, fresh);
                 Path::new_qualified(refined_qualifier, refined_selector)
             }
-            _ => self.clone(),
+            PathEnum::StaticVariable { .. }
+            | PathEnum::PhantomData
+            | PathEnum::PromotedConstant { .. } => self.clone(),
         }
     }
 


### PR DESCRIPTION
## Description

Make refine_parameters actually refine PathEnum::Alias. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
