### PR TITLE
Tweak refinement of target paths

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2258,10 +2258,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 alternate,
                 ..
             } => consequent.refers_to_unknown_location() || alternate.refers_to_unknown_location(),
-            Expression::Join { left, right, .. } | Expression::Offset { left, right } => {
+            Expression::Join { left, right, .. } => {
                 left.refers_to_unknown_location() || right.refers_to_unknown_location()
             }
-            Expression::Reference(..) => true,
+            Expression::Offset { .. } | Expression::Reference(..) => true,
             Expression::Switch {
                 discriminator,
                 cases,

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1018,8 +1018,18 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     pre_environment,
                     self.fresh_variable_offset,
                 )
-                .replace_root(&refined_dummy_root, target_path.clone())
-                .refine_paths(pre_environment);
+                .replace_root(&refined_dummy_root, target_path.clone());
+            trace!("parameter refined tpath {:?}", tpath);
+            match &tpath.value {
+                PathEnum::PhantomData => {
+                    // No need to track this data
+                    return;
+                }
+                PathEnum::Alias { .. }
+                | PathEnum::Offset { .. }
+                | PathEnum::QualifiedPath { .. } => tpath = tpath.refine_paths(pre_environment),
+                _ => {}
+            }
             let pre_state_value = self.current_environment.value_at(&tpath);
             if matches!(pre_state_value, Some(v) if v.is_widened_join()) {
                 // If the value is self referential, i.e. if its new value refers to its old

--- a/checker/tests/run-pass/target_path_refinement.rs
+++ b/checker/tests/run-pass/target_path_refinement.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that a left hand path is not refined as aggressively as a right hand path.
+// In particular, if the left hand path is a local that binds to a reference, assignments
+// to the path should update the binding, not the target of the bound reference.
+
+use mirai_annotations::*;
+
+pub fn t1() {
+    let x = 1;
+    let mut y = &x;
+    verify!(*y == 1);
+    let px = &x;
+    let z = 2;
+    y = &z;
+    verify!(*px == 1);
+    verify!(*y == 2);
+}
+
+fn t2a<'a>(a: &mut &'a i32, b: &'a i32) -> i32 {
+    *a = b;
+    1
+}
+
+pub fn t2() -> i32 {
+    let x = 1;
+    let mut y = &x;
+    verify!(*y == 1);
+    let px = &x;
+    let z = 2;
+    t2a(&mut y, &z);
+    verify!(*px == 1);
+    verify!(*y == 2);
+    3
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Refining a path to a local that contains a reference to another local into being a reference to the other local is necessary for making paths canonical, but also problematic in some cases. The main problem being addressed here is that when a reference is being assigned to a local that is already initialized to a reference, then the target path of the assignment should not be refined to the previous value.

Fixing this required deferring refinement in some cases that still need them, so some more, seemingly unrelated changes, are included here to keep the tests working.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
