### PR TITLE
Joining x and y at p, where x or y contains a widened value at p

### DIFF
--- a/checker/tests/run-pass/for.rs
+++ b/checker/tests/run-pass/for.rs
@@ -9,7 +9,7 @@
 pub fn to_be(dst: &mut [u16]) {
     for v in dst.iter_mut() {
         *v = v.to_be();
-    }
+    } //~ Fixed point loop took 51 iterations
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/offset.rs
+++ b/checker/tests/run-pass/offset.rs
@@ -7,6 +7,8 @@
 // A test that creates and checks pointer offsets
 #![feature(core_intrinsics)]
 
+use mirai_annotations::*;
+
 pub fn t1() {
     unsafe {
         let a = std::alloc::alloc(std::alloc::Layout::from_size_align(4, 2).unwrap());
@@ -49,6 +51,23 @@ pub fn t6() {
         let a1 = std::alloc::alloc(std::alloc::Layout::from_size_align(4, 2).unwrap());
         let a2 = std::alloc::realloc(a1, std::alloc::Layout::from_size_align(4, 2).unwrap(), 6);
         let _ = std::intrinsics::offset(a2, 6);
+    }
+}
+
+pub fn t7() {
+    unsafe {
+        let a1 = std::alloc::alloc(std::alloc::Layout::from_size_align(4, 2).unwrap()) as *mut u8;
+        *a1 = 111;
+        let mut a2 = a1;
+        let mut i: isize = 1;
+        while i < 2 {
+            a2 = std::intrinsics::offset(a1, i) as *mut u8;
+            *a2 = 222;
+            i += 1;
+        }
+        verify!(*a1 == 111);
+        //todo: figure out how to verify this
+        verify!(*a2 == 222); //~ possible false verification condition
     }
 }
 


### PR DESCRIPTION
## Description

When joining x and y at path p, if either x or y is or includes an expression which is a widening at path p, then use that expression as the result so that fix points converge.

Also add a diagnostic so that tests can fail if fixed points do not converge.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
