### PR TITLE
Make the widen operation simpler

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1086,10 +1086,6 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     self.current_environment.update_value_at(tpath, rvalue);
                     continue;
                 }
-                Expression::Join { left, right, .. } => {
-                    // Refinement did not update the path since it is not known to it
-                    rvalue = left.join(right.clone(), &tpath);
-                }
                 Expression::Offset { .. } => {
                     if self.check_for_errors && self.function_being_analyzed_is_root() {
                         self.check_offset(&rvalue);
@@ -1191,10 +1187,6 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     } else if rtype == ExpressionType::NonPrimitive {
                         self.copy_or_move_elements(tpath.clone(), path.clone(), target_type, false);
                     }
-                }
-                Expression::WidenedJoin { operand, .. } => {
-                    // Refinement did not update the path since it is not known to it
-                    rvalue = operand.widen(&tpath);
                 }
                 _ => {}
             }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -158,6 +158,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/compiler/src") // takes too long
             || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
+            || file_name.contains("language/move-prover/errmapgen/src") // stack overflow
             || file_name.contains("language/move-lang/src") // resolve error
             || file_name.contains("language/move-vm/runtime/src") // resolve error
             || file_name.contains("language/move-prover/src") // false positives

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -412,6 +412,8 @@ pub enum Expression {
     /// body.
     WidenedJoin {
         /// The path of the location where an indeterminate number of flows join together.
+        /// This is the same as the path in operand, and is repeated here for convenience in
+        /// pattern matches.
         path: Rc<Path>,
         /// The join of some of the flows to come together at this path.
         /// The first few iterations do joins. Once widening happens, further iterations


### PR DESCRIPTION
## Description

Only widen joins. Loop variables should always get joined (and this will actually be true in a future PR) and only loop variables should get widened.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
