### PR TITLE
Add simplifications and improve widening

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -765,7 +765,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     #[logfn_inputs(TRACE)]
     pub fn emit_diagnostic_for_precondition(&mut self, precondition: &Precondition, warn: bool) {
         precondition!(self.bv.check_for_errors);
-        let mut diagnostic = if warn {
+        let mut diagnostic = if warn && !precondition.message.starts_with("possible ") {
             Rc::new(format!("possible {}", precondition.message))
         } else {
             precondition.message.clone()

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -183,7 +183,13 @@ impl Environment {
         other: Environment,
         condition: &Rc<AbstractValue>,
     ) -> Environment {
-        self.join_or_widen(other, |x, y, _| {
+        self.join_or_widen(other, |x, y, p| {
+            if let Some(val) = y.get_widened_subexpression(p) {
+                return val;
+            }
+            if let Some(val) = x.get_widened_subexpression(p) {
+                return val;
+            }
             condition.conditional_expression(x.clone(), y.clone())
         })
     }

--- a/checker/tests/run-pass/precondition_local.rs
+++ b/checker/tests/run-pass/precondition_local.rs
@@ -5,8 +5,7 @@
 
 // A test that infers a precondition from a loop invariant
 
-#[macro_use]
-extern crate mirai_annotations;
+use mirai_annotations::*;
 
 fn test(v: &[i32]) {
     let mut i = 0;
@@ -18,8 +17,7 @@ fn test(v: &[i32]) {
 }
 
 pub fn main() {
-    //todo: avoid "possible possible"
-    let a = [-1, 2, 3]; //~ possible possible false verification condition
+    let a = [-1, 2, 3]; //~ possible false verification condition
     let b = [1, 2, 3];
     test(&a);
     test(&b);


### PR DESCRIPTION
## Description

Add more expression simplification rules, as well as more checks to prevent variables that are already widened from being complicated by further fixed point iterations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
