### PR TITLE
Provide a direct way to invert SMT conditions.

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1414,7 +1414,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
     /// Only call this when doing actual error checking, since this is expensive.
     #[logfn_inputs(TRACE)]
     #[logfn(TRACE)]
-    fn check_condition_value_and_reachability(
+    pub fn check_condition_value_and_reachability(
         &mut self,
         cond_val: &Rc<AbstractValue>,
     ) -> (Option<bool>, Option<bool>) {

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -568,6 +568,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 let (_, cond) = &self.actual_args[0];
                 let (cond_as_bool, entry_cond_as_bool) = self
                     .block_visitor
+                    .bv
                     .check_condition_value_and_reachability(cond);
 
                 // If we never get here, rather call unreachable!()
@@ -1996,6 +1997,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
             let (refined_precondition_as_bool, entry_cond_as_bool) = self
                 .block_visitor
+                .bv
                 .check_condition_value_and_reachability(&refined_condition);
 
             if refined_precondition_as_bool.unwrap_or(false) {

--- a/checker/src/smt_solver.rs
+++ b/checker/src/smt_solver.rs
@@ -43,6 +43,9 @@ pub trait SmtSolver<SmtExpressionType> {
     /// have been added to the solver.
     fn get_solver_state_as_string(&self) -> String;
 
+    /// Returns an expression that is the logical inverse of the given expression.
+    fn invert_predicate(&self, expression: &SmtExpressionType) -> SmtExpressionType;
+
     /// Create a nested context. When a matching backtrack is called, the current context (state)
     /// of the solver will be restored to what it was when this was called.
     fn set_backtrack_position(&self) {
@@ -90,6 +93,8 @@ impl SmtSolver<()> for SolverStub {
     fn get_solver_state_as_string(&self) -> String {
         String::from("not implemented")
     }
+
+    fn invert_predicate(&self, _: &()) {}
 
     fn set_backtrack_position(&self) {}
 


### PR DESCRIPTION
## Description

When checking that x is satisfiable and !x is not, don't translate x and !x independently to SMT expressions. Just translate x and then negate the translation.

Also add a special case to avoid generating complicated range conditions when translating (x as u128) and (x as i128) since these casts will not lose information and hence the underlying Z3 integer does not have to be qualified.

Finally, remove redundant SMT solver related functions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
