### PR TITLE
Directly implement core::ptr::mut_ptr::write_bytes

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1922,9 +1922,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
         } else {
             warn!(
-                "unhandled call to write_bytes<{:?}>({:?}: {:?}, {:?}, {:?})",
-                elem_type, self.actual_args[0], dest_type, self.actual_args[1], self.actual_args[2]
+                "unhandled call to write_bytes at {:?}",
+                self.block_visitor.bv.current_span
             );
+            info!("elem_type {:?}", elem_type);
+            info!("dest {:?}", self.actual_args[0]);
+            info!("dest_type {:?}", dest_type);
+            info!("val {:?}", self.actual_args[1]);
+            info!("count {:?}", self.actual_args[2]);
         }
         self.use_entry_condition_as_exit_condition();
     }

--- a/checker/src/known_names.rs
+++ b/checker/src/known_names.rs
@@ -331,10 +331,24 @@ impl KnownNamesCache {
                 .unwrap_or(KnownNames::None)
         };
 
+        let get_known_name_for_ptr_mut_ptr_namespace =
+            |mut def_path_data_iter: Iter<'_>| match path_data_elem_as_disambiguator(
+                def_path_data_iter.next(),
+            ) {
+                Some(0) => get_path_data_elem_name(def_path_data_iter.next())
+                    .map(|n| match n.as_str().deref() {
+                        "write_bytes" => KnownNames::StdIntrinsicsWriteBytes,
+                        _ => KnownNames::None,
+                    })
+                    .unwrap_or(KnownNames::None),
+                _ => KnownNames::None,
+            };
+
         let get_known_name_for_ptr_namespace = |mut def_path_data_iter: Iter<'_>| {
             get_path_data_elem_name(def_path_data_iter.next())
                 .map(|n| match n.as_str().deref() {
                     "swap_nonoverlapping" => KnownNames::StdPtrSwapNonOverlapping,
+                    "mut_ptr" => get_known_name_for_ptr_mut_ptr_namespace(def_path_data_iter),
                     _ => KnownNames::None,
                 })
                 .unwrap_or(KnownNames::None)


### PR DESCRIPTION
## Description

core::ptr::mut_ptr::write_bytes amounts to an alias (trivial wrapper) for std::instrinsics::write_bytes. It is awkward to handle calls without constant arguments and all known calls have constant arguments. Handling this alias directly avoids the need to summarize the trivial wrapper, which is a problem because summaries are not specialized for constant arguments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
