### PR TITLE
Use actual argument types for parameter local types

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2824,10 +2824,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             }
             base_path
         } else {
-            let ty = self.bv.type_visitor.specialize_generic_argument_type(
-                self.bv.mir.local_decls[place.local].ty,
-                &self.bv.type_visitor.generic_argument_map,
-            );
+            let ty = self.bv.type_visitor.get_loc_ty(place.local);
             self.visit_projection(base_path, ty, &place.projection)
         }
     }


### PR DESCRIPTION
## Description

Use the call-site argument types rather than the function declared parameters types for constructing type specific summaries. This is important to help with Trait method call resolution.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
