### PR TITLE
Restore test code that now works

### DIFF
--- a/checker/tests/run-pass/bit_vector_and_vec_push.rs
+++ b/checker/tests/run-pass/bit_vector_and_vec_push.rs
@@ -32,6 +32,5 @@ pub fn main() {
     let mut buf = Vec::<u8>::new();
     write_u32_as_uleb128(&mut buf, 129);
     verify!(buf.len() == 2);
-    //todo: fix this
-    //verify!(buf.len() == 1); // ~ provably false verification condition
+    verify!(buf.len() == 1); //~ provably false verification condition
 }

--- a/checker/tests/run-pass/contract_annotations.rs
+++ b/checker/tests/run-pass/contract_annotations.rs
@@ -6,89 +6,87 @@
 
 // Tests for annotations from the contracts crate.
 
-//todo: fix this
-
 // MIRAI_FLAGS --test_only
 
-// use contracts::*;
-// use mirai_annotations::*;
-//
-// pub fn main() {
-//     use_pre_post();
-//     use_trait();
-//     use_invariant();
-// }
-//
-// // Simple pre/post
-// // ---------------
-//
-// #[pre(x > 0)]
-// #[post(ret >= x)]
-// fn pre_post(x: i32) -> i32 {
-//     return x;
-// }
-//
-// #[test]
-// fn use_pre_post() {
-//     checked_verify!(pre_post(1) >= 1);
-// }
-//
-// // Trait pre/post
-//
-// #[contract_trait]
-// trait Adder {
-//     fn get(&self) -> i32;
-//
-//     #[pre(x > 0)]
-//     #[pre(self.get() <= std::i32::MAX - x)]
-//     #[post(ret == old(self.get()) && self.get() > old(self.get()))]
-//     fn get_and_add(&mut self, x: i32) -> i32;
-// }
-//
-// struct MyAdder {
-//     x: i32,
-// }
-//
-// #[contract_trait]
-// impl Adder for MyAdder {
-//     fn get(&self) -> i32 {
-//         self.x
-//     }
-//     fn get_and_add(&mut self, x: i32) -> i32 {
-//         let c = self.x;
-//         self.x = self.x + x;
-//         return c;
-//     }
-// }
-//
-// #[test]
-// fn use_trait() {
-//     let mut a = MyAdder { x: 1 };
-//     checked_verify!(a.get() == 1);
-//     checked_verify!(a.get_and_add(2) == 1);
-//     checked_verify!(a.get() == 3);
-// }
-//
-// // Invariants
-// // ==========
-//
-// struct S {
-//     x: i32,
-// }
-//
-// #[debug_invariant(self.x > 0)]
-// impl S {
-//     #[pre(self.x < std::i32::MAX)]
-//     #[post(ret == old(self.x))]
-//     fn get_and_decrement(&mut self) -> i32 {
-//         let c = self.x;
-//         self.x = self.x + 1;
-//         return c;
-//     }
-// }
-//
-// #[test]
-// fn use_invariant() {
-//     let mut s = S { x: 1 };
-//     checked_verify!(s.get_and_decrement() == 1);
-// }
+use contracts::*;
+use mirai_annotations::*;
+
+pub fn main() {
+    use_pre_post();
+    use_trait();
+    use_invariant();
+}
+
+// Simple pre/post
+// ---------------
+
+#[pre(x > 0)]
+#[post(ret >= x)]
+fn pre_post(x: i32) -> i32 {
+    return x;
+}
+
+#[test]
+fn use_pre_post() {
+    checked_verify!(pre_post(1) >= 1);
+}
+
+// Trait pre/post
+
+#[contract_trait]
+trait Adder {
+    fn get(&self) -> i32;
+
+    #[pre(x > 0)]
+    #[pre(self.get() <= std::i32::MAX - x)]
+    #[post(ret == old(self.get()) && self.get() > old(self.get()))]
+    fn get_and_add(&mut self, x: i32) -> i32;
+}
+
+struct MyAdder {
+    x: i32,
+}
+
+#[contract_trait]
+impl Adder for MyAdder {
+    fn get(&self) -> i32 {
+        self.x
+    }
+    fn get_and_add(&mut self, x: i32) -> i32 {
+        let c = self.x;
+        self.x = self.x + x;
+        return c;
+    }
+}
+
+#[test]
+fn use_trait() {
+    let mut a = MyAdder { x: 1 };
+    checked_verify!(a.get() == 1);
+    checked_verify!(a.get_and_add(2) == 1);
+    checked_verify!(a.get() == 3);
+}
+
+// Invariants
+// ==========
+
+struct S {
+    x: i32,
+}
+
+#[debug_invariant(self.x > 0)]
+impl S {
+    #[pre(self.x < std::i32::MAX)]
+    #[post(ret == old(self.x))]
+    fn get_and_decrement(&mut self) -> i32 {
+        let c = self.x;
+        self.x = self.x + 1;
+        return c;
+    }
+}
+
+#[test]
+fn use_invariant() {
+    let mut s = S { x: 1 };
+    checked_verify!(s.get_and_decrement() == 1);
+}

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -6,15 +6,15 @@
 
 // A test that uses a widened summary.
 
-use mirai_annotations::*;
+//use mirai_annotations::*;
 
 fn fact(n: u8) -> u128 {
     if n == 0 {
         1
     } else {
         let n1fac = fact(n - 1);
-        assume!(n1fac <= std::u128::MAX / (n as u128));
-        (n as u128) * n1fac
+        //assume!(n1fac <= std::u128::MAX / (n as u128));
+        (n as u128) * n1fac //~ possible attempt to multiply with overflow
     }
 }
 

--- a/checker/tests/run-pass/func_call_return_struct.rs
+++ b/checker/tests/run-pass/func_call_return_struct.rs
@@ -6,9 +6,6 @@
 
 // A test that uses a function summary where the return value is a structure.
 
-// MIRAI_FLAGS -- -Z mir-opt-level=0
-//todo: implement deserialization of constant structs
-
 use mirai_annotations::*;
 
 struct Foo {

--- a/checker/tests/run-pass/trait_contracts.rs
+++ b/checker/tests/run-pass/trait_contracts.rs
@@ -42,11 +42,10 @@ impl Adder for MyAdder {
 
 #[test]
 pub fn test() {
-    //todo: fix this
-    // let mut a = MyAdder(3);
-    // a.decrement();
-    // checked_verify!(a.current() < 3);
-    // verify!(a.current() == 1); // ~ provably false verification condition
+    let mut a = MyAdder(3);
+    a.decrement();
+    checked_verify!(a.current() < 3);
+    verify!(a.current() == 1); //~ provably false verification condition
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Re-enable some temporarily disabled test code.
Hobble factorial.rs so that it never fails because of Z3 flakiness.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
