### PR TITLE
Fix importation of structured constants into environment

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1256,12 +1256,8 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 } = constant.borrow();
                 let rh_type = literal.ty;
                 let const_value = self.visit_constant(*user_ty, &literal);
-                if self
-                    .bv
-                    .type_visitor
-                    .starts_with_slice_pointer(rh_type.kind())
-                {
-                    // todo: visit_constant should probably always return a reference
+                if const_value.expression.infer_type() == ExpressionType::NonPrimitive {
+                    // Transfer children into the environment, discard const_value.
                     if let Expression::Reference(rpath) | Expression::Variable { path: rpath, .. } =
                         &const_value.expression
                     {

--- a/checker/tests/run-pass/unzip.rs
+++ b/checker/tests/run-pass/unzip.rs
@@ -12,7 +12,7 @@ pub fn test() {
     let a = [(1, 2), (3, 4)];
 
     let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
-    //todo: fix the false messages below
+    //todo: fix the false messages below (implement core.slice.cmp.memcmp)
     verify!(left == [1, 3]); //~ provably false verification condition
     verify!(right == [2, 4]); //~ provably false verification condition
 }


### PR DESCRIPTION
## Description

Fix importation of structured constants into environment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
