### PR TITLE
Simplify pointer equality

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1491,6 +1491,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             ) if *z == other => {
                 return x.logical_not().or(y.equals(z.clone()));
             }
+            (Expression::Reference { .. }, Expression::Cast { .. })
+            | (Expression::Cast { .. }, Expression::Reference { .. }) => {
+                return Rc::new(FALSE);
+            }
             (x, y) => {
                 // If self and other are the same expression and the expression could not result in
                 // NaN we can simplify this to true.

--- a/checker/tests/run-pass/vecdeque_pop_back.rs
+++ b/checker/tests/run-pass/vecdeque_pop_back.rs
@@ -15,8 +15,7 @@ pub fn main() {
     let old_len = v.len();
     verify!(old_len == 0);
     v.push_back(1);
-    //todo: fix these
-    //verify!(v.len() == old_len + 1);
+    verify!(v.len() == old_len + 1);
     v.pop_back();
-    //verify!(v.len() == old_len);
+    verify!(v.len() == old_len);
 }

--- a/checker/tests/run-pass/vecdeque_pop_front.rs
+++ b/checker/tests/run-pass/vecdeque_pop_front.rs
@@ -15,8 +15,7 @@ pub fn main() {
     let old_len = v.len();
     verify!(old_len == 0);
     v.push_back(1);
-    //todo: fix these
-    //verify!(v.len() == old_len + 1);
+    verify!(v.len() == old_len + 1);
     v.pop_front();
-    //verify!(v.len() == old_len);
+    verify!(v.len() == old_len);
 }

--- a/checker/tests/run-pass/vecdeque_push_back.rs
+++ b/checker/tests/run-pass/vecdeque_push_back.rs
@@ -15,6 +15,5 @@ pub fn main() {
     let old_len = v.len();
     verify!(old_len == 0);
     v.push_back(0);
-    //todo: fix this
-    //verify!(v.len() == old_len + 1);
+    verify!(v.len() == old_len + 1);
 }

--- a/checker/tests/run-pass/vecdeque_push_front.rs
+++ b/checker/tests/run-pass/vecdeque_push_front.rs
@@ -15,6 +15,5 @@ pub fn main() {
     let old_len = v.len();
     verify!(old_len == 0);
     v.push_front(0);
-    //todo: fix this
-    //verify!(v.len() == old_len + 1);
+    verify!(v.len() == old_len + 1);
 }


### PR DESCRIPTION
## Description

Comparing pointers that are known to be good to dummy pointers, like constants 0 or 4 cast to pointers, can be simplified to false during expression construction, whereas the Z3 translation of such pointer comparisons is too general for it to come to a definite conclusion.

Also fix the Z3 translation to better avoid mixing bit vector and numeric operands.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
