### PR TITLE
Reduce exclusion list and filter out more diagnostics in relaxed mode

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,57 +139,21 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(file_name: &str) -> bool {
-        file_name.contains("client/libra-dev/src") // takes too long
-            || file_name.contains("config/management/src") // false positives
-            || file_name.contains("config/management/genesis") // takes too long
-            || file_name.contains("consensus/src") // resolve error
-            || file_name.contains("consensus/safety-rules/src") // false positives
-            || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
-            || file_name.contains("common/bitvec/src") // false positives
-            || file_name.contains("common/datatest-stable/src") // takes too long
-            || file_name.contains("common/debug-interface") // resolve error
-            || file_name.contains("common/logger/src") // resolve error
-            || file_name.contains("common/metrics/src") // stack overflow
-            || file_name.contains("common/trace/src") // stack overflow
-            || file_name.contains("config/config-builder/src") // false positives
-            || file_name.contains("execution/executor/src") // false positives
-            || file_name.contains("execution/execution-correctness/src") // takes too long
-            || file_name.contains("json-rpc/src") // compiler panic
-            || file_name.contains("language/bytecode-verifier/src") // resolve error
-            || file_name.contains("language/compiler/src") // takes too long
-            || file_name.contains("language/compiler/bytecode-source-map/src") // false positives
-            || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // false positives
-            || file_name.contains("language/move-prover/errmapgen/src") // stack overflow
-            || file_name.contains("language/move-lang/src") // resolve error
-            || file_name.contains("language/move-vm/runtime/src") // resolve error
-            || file_name.contains("language/move-prover/src") // false positives
-            || file_name.contains("language/move-prover/bytecode/src") // stack overflow
-            || file_name.contains("language/move-prover/spec-lang/src") // false positives
-            || file_name.contains("language/resource-viewer/src") // false positives
-            || file_name.contains("language/move-prover/docgen/src") // takes too long 
-            || file_name.contains("language/move-prover/stackless-bytecode-generator/src") // resolve error
-            || file_name.contains("language/stdlib/src") // z3 encoding
-            || file_name.contains("language/transaction-builder/generator/src") // z3 encoding
-            || file_name.contains("language/tools/move-coverage/src") // stack overflow
-            || file_name.contains("language/tools/transaction-replay/src") // z3 encoding
-            || file_name.contains("language/tools/vm-genesis/src") // resolve error
-            || file_name.contains("language/tools/genesis-viewer/src") // false positives
-            || file_name.contains("language/vm/src") // false positives
-            || file_name.contains("mempool/src") // stack overflow
-            || file_name.contains("network/src") // resolve error
-            || file_name.contains("network/builder") // takes too long
-            || file_name.contains("secure/net/src") // false positives
-            || file_name.contains("secure/storage/src") // false positives
-            || file_name.contains("secure/storage/vault/src") // resolve error
-            || file_name.contains("state-synchronizer/src") // false positives
-            || file_name.contains("storage/backup/backup-service/src") // resolve error
-            || file_name.contains("storage/jellyfish-merkle/src") // unreachable code
-            || file_name.contains("storage/backup/backup-cli/src") // panics
-            || file_name.contains("storage/libradb/src") // resolve error
-            || file_name.contains("storage/schemadb/src") // crash
-            || file_name.contains("testsuite/cli/src") // false positives
-            || file_name.contains("testsuite/cli/libra-wallet/src") // takes too long
-            || file_name.contains("types/src") // resolve error
+        file_name.contains("client/libra-dev/src") // panic
+        || file_name.contains("consensus/src") // panic
+        || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
+        || file_name.contains("json-rpc/src") // compiler panic
+        || file_name.contains("language/bytecode-verifier/src") // Z3 encoding
+        || file_name.contains("language/move-lang/src") // Z3 encoding
+        || file_name.contains("language/move-prover/src") // resolve error
+        || file_name.contains("language/move-prover/bytecode/src") // Z3 encoding
+        || file_name.contains("language/move-prover/spec-lang/src") // takes too long
+        || file_name.contains("language/transaction-builder/generator/src") // takes too long
+        || file_name.contains("mempool/src") // stack overflow
+        || file_name.contains("secure/storage/vault/src") // stack overflow
+        || file_name.contains("storage/backup/backup-cli/src") // panics
+        || file_name.contains("storage/schemadb/src") // crash 
+        || file_name.contains("types/src") // stack overflow
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -707,6 +707,94 @@ impl Expression {
         }
     }
 
+    /// Returns true if any part of the expression is a parameter.
+    /// Use this to weed out diagnostics that would need preconditions to silence them.
+    #[logfn_inputs(TRACE)]
+    pub fn contains_parameter(&self) -> bool {
+        match &self {
+            Expression::Add { left, right }
+            | Expression::AddOverflows { left, right, .. }
+            | Expression::And { left, right }
+            | Expression::BitAnd { left, right }
+            | Expression::BitOr { left, right }
+            | Expression::BitXor { left, right }
+            | Expression::Div { left, right }
+            | Expression::Equals { left, right }
+            | Expression::GreaterOrEqual { left, right }
+            | Expression::GreaterThan { left, right }
+            | Expression::IntrinsicBinary { left, right, .. }
+            | Expression::LessOrEqual { left, right }
+            | Expression::LessThan { left, right }
+            | Expression::Mul { left, right }
+            | Expression::MulOverflows { left, right, .. }
+            | Expression::Ne { left, right }
+            | Expression::Offset { left, right }
+            | Expression::Or { left, right }
+            | Expression::Rem { left, right }
+            | Expression::Shl { left, right }
+            | Expression::ShlOverflows { left, right, .. }
+            | Expression::Shr { left, right, .. }
+            | Expression::ShrOverflows { left, right, .. }
+            | Expression::Sub { left, right }
+            | Expression::SubOverflows { left, right, .. } => {
+                left.expression.contains_parameter() || right.expression.contains_parameter()
+            }
+            Expression::BitNot { operand, .. }
+            | Expression::Cast { operand, .. }
+            | Expression::IntrinsicBitVectorUnary { operand, .. }
+            | Expression::IntrinsicFloatingPointUnary { operand, .. }
+            | Expression::TaggedExpression { operand, .. } => {
+                operand.expression.contains_parameter()
+            }
+            Expression::Bottom => true,
+
+            Expression::CompileTimeConstant(..) => false,
+            Expression::ConditionalExpression {
+                condition,
+                consequent,
+                alternate,
+            } => {
+                condition.expression.contains_parameter()
+                    || consequent.expression.contains_parameter()
+                    || alternate.expression.contains_parameter()
+            }
+            Expression::HeapBlock { .. } => true,
+            Expression::HeapBlockLayout {
+                length, alignment, ..
+            } => {
+                length.expression.contains_parameter() || alignment.expression.contains_parameter()
+            }
+            Expression::Join { left, right, .. } => {
+                left.expression.contains_parameter() || right.expression.contains_parameter()
+            }
+            Expression::Neg { operand }
+            | Expression::LogicalNot { operand }
+            | Expression::UnknownTagCheck { operand, .. } => {
+                operand.expression.contains_parameter()
+            }
+            Expression::Reference(path) => path.contains_parameter(),
+            Expression::InitialParameterValue { .. } => true,
+            Expression::Switch {
+                discriminator,
+                cases,
+                default,
+            } => {
+                discriminator.expression.contains_parameter()
+                    || default.expression.contains_parameter()
+                    || cases.iter().any(|(_, v)| v.expression.contains_parameter())
+            }
+            Expression::Top => true,
+            Expression::UninterpretedCall { .. } => true,
+            Expression::UnknownModelField { path, default } => {
+                path.contains_parameter() || default.expression.contains_parameter()
+            }
+            Expression::UnknownTagField { path } | Expression::Variable { path, .. } => {
+                path.contains_parameter()
+            }
+            Expression::WidenedJoin { .. } => true,
+        }
+    }
+
     /// Returns a value from the enum `TagPropagation` which reflects the expression kind.
     /// If the tag propagation behavior for the expression is not controllable, e.g., for
     /// control-flow expressions such as Conditional or Switch, returns None.

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -233,6 +233,35 @@ impl Path {
         }
     }
 
+    /// Returns true if the path contains a value whose expression contains a parameter.
+    #[logfn_inputs(TRACE)]
+    pub fn contains_parameter(&self) -> bool {
+        match &self.value {
+            PathEnum::Alias { value } => value.expression.contains_parameter(),
+            PathEnum::HeapBlock { .. } => false,
+            PathEnum::LocalVariable { .. } => false,
+            PathEnum::Offset { value } => value.expression.contains_parameter(),
+            PathEnum::Parameter { .. } => true,
+            PathEnum::Result => false,
+            PathEnum::StaticVariable { .. } => true,
+            PathEnum::PhantomData => false,
+            PathEnum::PromotedConstant { .. } => false,
+            PathEnum::QualifiedPath {
+                qualifier,
+                selector,
+                ..
+            } => {
+                qualifier.contains_parameter() || {
+                    if let PathSelector::Index(value) = selector.as_ref() {
+                        value.expression.contains_parameter()
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
+    }
+
     /// Returns the index value of the index path qualifed by qualifier.
     #[logfn_inputs(TRACE)]
     pub fn get_index_value_qualified_by(&self, root: &Rc<Path>) -> Option<Rc<AbstractValue>> {

--- a/checker/tests/run-pass/array_literal_out_of_bounds.rs
+++ b/checker/tests/run-pass/array_literal_out_of_bounds.rs
@@ -6,7 +6,7 @@
 
 // A test that calls visit_aggregate
 
-// MIRAI_FLAGS -- -Z mir-opt-level=0
+// MIRAI_FLAGS --diag=paranoid -- -Z mir-opt-level=0
 
 #[allow(const_err)]
 #[allow(unconditional_panic)]


### PR DESCRIPTION
## Description

Most false positives arise when the analysis entry point has parameters which are not constrained by explicit precondition annotations. While adding such annotations is desirable, it is not going to happen any time soon and meanwhile the related diagnostics drown out everything else. Consequently, in relaxed mode, MIRAI now does not issue diagnostics for undischarged  proof obligations when their conditions involve parameter values.

This PR also updates the exclusion list to remove crates that can now be analyzed without crashing and without generating reams of false positives.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
