### PR TITLE
Update z3 build steps to z3's 4.8.9 release

### DIFF
--- a/documentation/Z3AndLinux.md
+++ b/documentation/Z3AndLinux.md
@@ -13,33 +13,11 @@ Clone the Z3 source repository (preferably into the directory containing the MIR
 git clone https://github.com/Z3Prover/z3.git
 ```
 
-Edit the CMakeLists.txt file to add this:
-```
-################################################################################
-# Position independent code
-################################################################################
-# This is required because code built in the components will end up in a shared
-# library. If not building a shared library ``-fPIC`` isn't needed and would add
-# unnecessary overhead.
-if (BUILD_LIBZ3_SHARED)
-  # Avoid adding -fPIC compiler switch if we compile with MSVC (which does not
-  # support the flag) or if we target Windows, which generally does not use
-  # position independent code for native code shared libraries (DLLs).
-  if (NOT (MSVC OR MINGW OR WIN32))
-    z3_add_cxx_flag("-fPIC" REQUIRED)
-  endif()
-+else()
-+  if (BUILD_PIC)
-+    z3_add_cxx_flag("-fPIC" REQUIRED)
-+  endif()
-endif()
-```
-
 Then do:
 ```
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBZ3_SHARED=FALSE -DBUILD_PIC=TRUE ../
+cmake -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_LIBZ3_SHARED=FALSE ../
 # use the number of jobs that makes sense for your machine
 make -j32
 ```


### PR DESCRIPTION
This PR updates the Z3AndLinux.md steps to be up to date with current z3 master branch (commit id: e5cc613) but also with z3's 4.8.9 release.

The Z3AndLinux.md steps required modifications to z3's CMakeList's "Position independent code" part, which are outdated.

The modifications are not needed anymore as z3 CMakeLists was changed so it will include PIC in non-shared builds [1].

This PR also changes the name of the passed flag to build z3 statically to `Z3_BUILD_LIBZ3_SHARED` as it was renamed in z3 [2][3].

[1] https://github.com/Z3Prover/z3/blob/z3-4.8.9/CMakeLists.txt#L377-L388
[2] https://github.com/Z3Prover/z3/commit/36695435535ec18dd194beb1def019351bcdcd59
[3] https://github.com/Z3Prover/z3/blob/z3-4.8.9/CMakeLists.txt#L353-L356

PS: Please double check if it works properly as I haven't tested it yet.