### PR TITLE
Guard against stack overflow when refining paths

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -337,7 +337,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         if let Some((place, _)) = &self.destination {
             checked_assume!(self.actual_args.len() == 1);
             let source_path = Path::new_deref(self.actual_args[0].0.clone())
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             let target_type = self
                 .block_visitor
                 .bv
@@ -717,14 +717,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 } else {
                     let arguments_struct_path = self.actual_args[0]
                         .0
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     let pieces_path_fat = Path::new_field(arguments_struct_path, 0)
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     let pieces_path_thin = Path::new_field(pieces_path_fat, 0)
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     let index = Rc::new(0u128.into());
                     let piece0_path_fat = Path::new_index(pieces_path_thin, index)
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     self.coerce_to_string(&piece0_path_fat)
                 };
                 if msg.contains("entered unreachable code")
@@ -950,7 +950,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             .enumerate()
             .map(|(i, t)| {
                 let arg_path = Path::new_field(callee_arg_array_path.clone(), i)
-                    .refine_paths(&self.block_visitor.bv.current_environment);
+                    .refine_paths(&self.block_visitor.bv.current_environment, 0);
                 let arg_val = self
                     .block_visitor
                     .bv
@@ -1088,7 +1088,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             )
             .unwrap_or(source_pointer_path);
             let source_path = Path::new_deref(source_thin_pointer_path)
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             trace!("MiraiAddTag: tagging {:?} with {:?}", tag, source_path);
 
             // Check if the tagged value has a pointer type (e.g., a reference).
@@ -1173,7 +1173,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             )
             .unwrap_or(source_pointer_path);
             let source_path = Path::new_deref(source_thin_pointer_path)
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             trace!(
                 "MiraiCheckTag: checking if {:?} has {}been tagged with {:?}",
                 source_path,
@@ -1318,7 +1318,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
             let field_name = self.coerce_to_string(&self.actual_args[1].0);
             let source_path = Path::new_model_field(qualifier, field_name)
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
 
             let target_path = self.block_visitor.visit_place(place);
             if self
@@ -1470,7 +1470,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
             let field_name = self.coerce_to_string(&self.actual_args[1].0);
             let target_path = Path::new_model_field(qualifier, field_name)
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             let source_path = self.actual_args[2].0.clone();
             let target_type = self.actual_argument_types[2];
             self.block_visitor.bv.copy_or_move_elements(
@@ -1523,7 +1523,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
         // Get a layout path and update the environment
         let layout_path = Path::new_layout(heap_block_path)
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         self.block_visitor
             .bv
             .current_environment
@@ -1541,7 +1541,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         let target_root = self.actual_args[1].0.clone();
         let count = self.actual_args[2].1.clone();
         let target_path = Path::new_slice(target_root, count)
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         let collection_type = self.actual_argument_types[0];
         self.block_visitor.bv.copy_or_move_elements(
             target_path,
@@ -1560,7 +1560,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         if let Some((place, _)) = &self.destination {
             let discriminant_path =
                 Path::new_discriminant(Path::new_deref(self.actual_args[0].0.clone()))
-                    .refine_paths(&self.block_visitor.bv.current_environment);
+                    .refine_paths(&self.block_visitor.bv.current_environment, 0);
             let mut discriminant_value = self.block_visitor.bv.lookup_path_and_refine_result(
                 discriminant_path,
                 self.block_visitor.bv.tcx.types.u128,
@@ -1607,9 +1607,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         let source_root = self.actual_args[1].0.clone();
         let count = self.actual_args[2].1.clone();
         let source_slice = Path::new_slice(source_root.clone(), count.clone())
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         let target_slice = Path::new_slice(target_root.clone(), count.clone())
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         let temp_root = Path::new_local(999_999);
         let temp_slice = Path::new_slice(temp_root.clone(), count);
         self.block_visitor
@@ -1690,7 +1690,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
         // Get a layout path and update the environment
         let layout_path = Path::new_layout(heap_block_path)
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         self.block_visitor
             .bv
             .current_environment
@@ -1727,9 +1727,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             };
             let target_path = self.block_visitor.visit_place(target_place);
             let path0 = Path::new_field(target_path.clone(), 0)
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             let path1 = Path::new_field(target_path.clone(), 1)
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             let target_type = self
                 .block_visitor
                 .bv
@@ -1798,7 +1798,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     fn handle_mem_replace(&mut self) {
         checked_assume!(self.actual_args.len() == 2);
         let dest_path = Path::new_deref(self.actual_args[0].0.clone())
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         let source_path = &self.actual_args[1].0;
         if let Some((place, _)) = &self.destination {
             let target_path = self.block_visitor.visit_place(place);
@@ -1901,7 +1901,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     let elem_size_val: Rc<AbstractValue> =
                         Rc::new((ty_and_layout.layout.size.bytes() as u128).into());
                     let length_path = Path::new_length(self.actual_args[0].0.clone())
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     let len_val = self.block_visitor.bv.lookup_path_and_refine_result(
                         length_path,
                         ExpressionType::Usize.as_rustc_type(self.block_visitor.bv.tcx),
@@ -2049,7 +2049,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 assume_unreachable!("transmute called on types with different bit lengths");
             }
             let (source_path, source_type) = &source_fields[source_field_index];
-            let source_path = source_path.refine_paths(&self.block_visitor.bv.current_environment);
+            let source_path =
+                source_path.refine_paths(&self.block_visitor.bv.current_environment, 0);
             let mut val = self
                 .block_visitor
                 .bv
@@ -2090,7 +2091,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     }
                     let (source_path, source_type) = &source_fields[source_field_index];
                     let source_path =
-                        source_path.refine_paths(&self.block_visitor.bv.current_environment);
+                        source_path.refine_paths(&self.block_visitor.bv.current_environment, 0);
                     let source_bits = ExpressionType::from(source_type.kind()).bit_length();
                     let mut next_val = self
                         .block_visitor
@@ -2127,7 +2128,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     fn handle_write_bytes(&mut self) {
         checked_assume!(self.actual_args.len() == 3);
         let dest_path = Path::new_deref(self.actual_args[0].0.clone())
-            .refine_paths(&self.block_visitor.bv.current_environment);
+            .refine_paths(&self.block_visitor.bv.current_environment, 0);
         let dest_type = self.actual_argument_types[0];
         let source_path = self.actual_args[1].0.clone();
         let byte_value = &self.actual_args[1].1;
@@ -2290,7 +2291,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     &self.environment_before_call,
                     self.block_visitor.bv.fresh_variable_offset,
                 )
-                .refine_paths(&self.block_visitor.bv.current_environment);
+                .refine_paths(&self.block_visitor.bv.current_environment, 0);
             if self
                 .block_visitor
                 .bv
@@ -2419,7 +2420,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                                 &self.environment_before_call,
                                 self.block_visitor.bv.fresh_variable_offset,
                             )
-                            .refine_paths(&self.block_visitor.bv.current_environment);
+                            .refine_paths(&self.block_visitor.bv.current_environment, 0);
                         self.block_visitor.bv.current_environment.update_value_at(
                             path.refine_parameters(
                                 self.actual_args,
@@ -2503,7 +2504,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                             &self.environment_before_call,
                             self.block_visitor.bv.fresh_variable_offset,
                         )
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     exit_condition = exit_condition.and(unwind_condition.logical_not());
                 }
             }
@@ -2520,7 +2521,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                         refined_post_condition
                     );
                     let refined_post_condition = refined_post_condition
-                        .refine_paths(&self.block_visitor.bv.current_environment);
+                        .refine_paths(&self.block_visitor.bv.current_environment, 0);
                     trace!("refined post condition {:?}", refined_post_condition);
                     exit_condition = exit_condition.and(refined_post_condition);
                     trace!("post exit conditions {:?}", exit_condition);

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -140,20 +140,17 @@ impl MiraiCallbacks {
 
     fn is_excluded(file_name: &str) -> bool {
         file_name.contains("client/libra-dev/src") // panic
-        || file_name.contains("consensus/src") // panic
-        || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
-        || file_name.contains("json-rpc/src") // compiler panic
-        || file_name.contains("language/bytecode-verifier/src") // Z3 encoding
-        || file_name.contains("language/move-lang/src") // Z3 encoding
-        || file_name.contains("language/move-prover/src") // resolve error
-        || file_name.contains("language/move-prover/bytecode/src") // Z3 encoding
-        || file_name.contains("language/move-prover/spec-lang/src") // takes too long
-        || file_name.contains("language/transaction-builder/generator/src") // takes too long
-        || file_name.contains("mempool/src") // stack overflow
-        || file_name.contains("secure/storage/vault/src") // stack overflow
-        || file_name.contains("storage/backup/backup-cli/src") // panics
-        || file_name.contains("storage/schemadb/src") // crash 
-        || file_name.contains("types/src") // stack overflow
+            || file_name.contains("consensus/src") // panic
+            || file_name.contains("crypto/crypto-derive/src") //  `(left == right)`  left: `Type`, right: `Fn`
+            || file_name.contains("json-rpc/src") // panic
+            || file_name.contains("language/bytecode-verifier/src") // Z3 encoding
+            || file_name.contains("language/move-lang/src") // Z3 encoding
+            || file_name.contains("language/move-prover/src") // resolve error
+            || file_name.contains("language/move-prover/bytecode/src") // Z3 encoding
+            || file_name.contains("language/move-prover/spec-lang/src") // takes too long
+            || file_name.contains("language/transaction-builder/generator/src") // takes too long
+            || file_name.contains("storage/backup/backup-cli/src") // panic
+            || file_name.contains("storage/schemadb/src") // panic
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -84,7 +84,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                     for (i, ty) in substs.as_closure().upvar_tys().enumerate() {
                         let var_type: ExpressionType = ty.kind().into();
                         let closure_field_path =
-                            Path::new_field(path.clone(), i).refine_paths(environment);
+                            Path::new_field(path.clone(), i).refine_paths(environment, 0);
                         self.path_ty_cache.insert(closure_field_path.clone(), ty);
                         let closure_field_val =
                             AbstractValue::make_typed_unknown(var_type, closure_field_path.clone());


### PR DESCRIPTION
## Description

Paths can be self referential so some kind of recursion stop is needed to prevent stack overflow. An occurs check is too expensive in practice, so a depth counter is used instead.

Also in this PR, a tweak to always evaluate constant generic parameters with the compiler's eval function so that a code path that causes a compiler crash can be avoided.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
