### PR TITLE
Fix Z3 encoding for switch expression and function consts

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2034,7 +2034,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     /// Assign abstract values to the target fields that are consistent with the concrete values
     /// that will arise at runtime if the sequential (packed) bytes of the source fields are copied to the
     /// target fields on a little endian machine.
-    #[logfn_inputs(INFO)]
+    #[logfn_inputs(TRACE)]
     fn copy_field_bits(
         &mut self,
         source_fields: Vec<(Rc<Path>, Ty<'tcx>)>,

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,10 +139,8 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(file_name: &str) -> bool {
-        file_name.contains("language/bytecode-verifier/src") // Z3 encoding
-            || file_name.contains("language/move-lang/src") // Z3 encoding
+        file_name.contains("language/move-lang/src") // takes too long
             || file_name.contains("language/move-prover/src") // takes too long
-            || file_name.contains("language/move-prover/bytecode/src") // Z3 encoding
             || file_name.contains("language/move-prover/spec-lang/src") // takes too long
             || file_name.contains("language/transaction-builder/generator/src") // takes too long
     }


### PR DESCRIPTION
## Description

When a function constant is used in a numeric context (i.e. after casting the function pointer to an integer), the Z3 encoding did not specialize the Z3 fresh constant value to be of sort int.

Likewise, a switch expression that is used in a numeric context should be translated to a Z3 expression with this goal in mind.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
