### PR TITLE
Make sure that promoted constants are always available

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -916,20 +916,23 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     ) -> Rc<AbstractValue> {
         if self.is_bottom() {
             // If the condition is impossible so is the expression.
-            return consequent;
-        }
-        if self.is_top() {
             return self.clone();
         }
+        // If either of the branches is impossible, it must be the other one.
         if consequent.is_bottom() {
             return alternate;
         }
         if alternate.is_bottom() {
             return consequent;
         }
+        // If the branches are the same, the condition does no matter.
         if consequent.expression == alternate.expression {
             // [c ? x : x] -> x
             return consequent;
+        }
+        // If the condition is unknown, the rules below won't fire.
+        if self.is_top() {
+            return self.clone();
         }
         if self.expression == consequent.expression {
             // [x ? x : y] -> x || y

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1951,20 +1951,13 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     None => Path::new_static(self.bv.tcx, def_id),
                 };
                 self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
-                // Note that this might not find the promoted constant in the current environment,
-                // even though it was imported at the beginning of visit_body. This happens
-                // when the current environment starts of empty because we are visiting an
-                // unreachable block for error reporting purposes.
-                //todo: keep track of the first state containing the promoted constants and use that
-                // to lookup PromotedConstant paths.
                 let val_at_path = self.bv.lookup_path_and_refine_result(path, ty);
                 if let Expression::Variable { .. } = &val_at_path.expression {
                     // Seems like there is nothing at the path, but...
                     if self.bv.tcx.is_mir_available(def_id) {
                         // The MIR body should have computed something. If that something is
                         // a structure, the value of the path will be unknown (only leaf paths have
-                        // known values). Alternatively, this could be a simple value that is not
-                        // in the environment as explained in the Note above.
+                        // known values).
                         return val_at_path;
                     }
                     // Seems like a lazily serialized constant. Force evaluation.

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,10 +139,14 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(file_name: &str) -> bool {
-        file_name.contains("language/move-lang/src") // takes too long
-            || file_name.contains("language/move-prover/src") // takes too long
-            || file_name.contains("language/move-prover/spec-lang/src") // takes too long
-            || file_name.contains("language/transaction-builder/generator/src") // takes too long
+        // these analyze too slowly to tolerate
+        file_name.contains("common/datatest-stable/src")
+            || file_name.contains("config/management/genesis/src")
+            || file_name.contains("language/move-lang/src")
+            || file_name.contains("language/move-prover/src")
+            || file_name.contains("language/move-prover/spec-lang/src")
+            || file_name.contains("language/tools/genesis-viewer/src")
+            || file_name.contains("language/transaction-builder/generator/src")
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.


### PR DESCRIPTION
## Description

Use the initial environment that contains promoted constants, as the initial environment of an unreachable block, rather than an empty environment.

Also allow the [c ? x : x] -> x simplification to kick in when c is TOP.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
