### PR TITLE
Simplify pointer subtraction

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -171,7 +171,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
 
         // The entry block has no predecessors and the function parameters are its initial state
         // (which we omit here so that we can lazily provision them with additional context)
-        // as well any promoted constants.
+        // as well as any promoted constants.
         let mut first_state = self.promote_constants();
 
         // Add parameter values that are function constants.
@@ -1105,11 +1105,6 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     }
                     self.current_environment.update_value_at(tpath, rvalue);
                     continue;
-                }
-                Expression::Offset { .. } => {
-                    if self.check_for_errors && self.function_being_analyzed_is_root() {
-                        self.check_offset(&rvalue);
-                    }
                 }
                 Expression::Reference(path) => {
                     let deref_type = self

--- a/checker/tests/run-pass/unzip.rs
+++ b/checker/tests/run-pass/unzip.rs
@@ -6,16 +6,15 @@
 
 // A test that calls Iterator::unzip
 
-//todo: fix this
+use mirai_annotations::*;
 
-// use mirai_annotations::*;
-//
-// pub fn test() {
-//     let a = [(1, 2), (3, 4)];
-//
-//     let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
-//     verify!(left == [1, 3]);
-//     verify!(right == [2, 4]);
-// }
+pub fn test() {
+    let a = [(1, 2), (3, 4)];
+
+    let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
+    //todo: fix the false messages below (implement core.slice.cmp.memcmp)
+    verify!(left == [1, 3]); //~ provably false verification condition
+    verify!(right == [2, 4]); //~ provably false verification condition
+}
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Add a simplification rule for ((pointer + offset) as usize) - (pointer as usize).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
