### PR TITLE
Do not promote verify! conditions to preconditions

### DIFF
--- a/checker/tests/run-pass/assume.rs
+++ b/checker/tests/run-pass/assume.rs
@@ -13,8 +13,8 @@ pub fn main() {
             // It is not checked by Mirai, because of the assumption.
             // Unlike this test case, in real life assumptions are made for complicated reasons that are
             // hard to encode in checked preconditions.
-    foo2(2); //~ possible false verification condition
-             // This gives a diagnostic because foo2 verifies i == 3 by promoting it to a precondition
+    foo2(2); //~ assertion failed: `(left == right)`
+             // This gives a diagnostic because foo2 asserts i == 3 which gets promoted to a precondition
 }
 
 pub fn foo(i: i32) {
@@ -27,7 +27,7 @@ pub fn foo(i: i32) {
 
 fn foo2(i: i32) {
     // this becomes an inferred precondition
-    verify!(i == 3); //~ related location
+    assert_eq!(i, 3); //~ related location
     let x = if i == 3 { 1 } else { 2 };
     verify!(x == 1); // This is neither true, nor checked at runtime, but it can only fail if
                      // the first verify fails, so the problem is already pointed out and we need not repeat ourselves.

--- a/checker/tests/run-pass/bit_vectors.rs
+++ b/checker/tests/run-pass/bit_vectors.rs
@@ -6,24 +6,22 @@
 
 // A test that uses bit vectors in the SMT solver
 
-use mirai_annotations::*;
-
 fn write_u32_as_uleb128(value: u32) {
     let mut val = value;
     let v1: u8 = (val & 0x7f) as u8;
-    verify!(v1 == 1);
+    assert!(v1 == 1);
     val >>= 7;
     let v2: u8 = (val & 0x7f) as u8;
-    verify!(v2 == 1);
+    assert!(v2 == 1);
 }
 
 fn write_i32_as_uleb128(value: i32) {
     let mut val = value;
     let v1: u8 = (val & (-127)) as u8;
-    verify!(v1 == 1);
+    assert!(v1 == 1);
     val >>= 7;
     let v2: u8 = (val & (-127)) as u8;
-    verify!(v2 == 128);
+    assert!(v2 == 128);
 }
 
 pub fn main() {

--- a/checker/tests/run-pass/closure_precond_inference.rs
+++ b/checker/tests/run-pass/closure_precond_inference.rs
@@ -15,7 +15,7 @@ pub fn main() {
 fn call(x: i32) {
     checked_assume!(x > 0);
     let f = || {
-        checked_verify!(x > 0);
+        assert!(x > 0);
     };
     f()
 }

--- a/checker/tests/run-pass/invalid_post_condition.rs
+++ b/checker/tests/run-pass/invalid_post_condition.rs
@@ -11,15 +11,15 @@ pub struct Block {
 }
 
 impl Block {
-    pub fn round(&self) -> u64 {
+    fn round(&self) -> u64 {
         postcondition!(self.round < std::u64::MAX - 2); //~ possible unsatisfied postcondition
         self.round
     }
-}
 
-pub fn voting_rule(proposed_block: Block) -> () {
-    let _ret = proposed_block.round();
-    verify!(_ret < std::u64::MAX); // verifies because the post condition is assumed here.
+    pub fn voting_rule(proposed_block: Block) -> () {
+        let _ret = proposed_block.round();
+        verify!(_ret < std::u64::MAX); // verifies because the post condition is assumed here.
+    }
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/precondition_local.rs
+++ b/checker/tests/run-pass/precondition_local.rs
@@ -11,14 +11,14 @@ fn test(v: &[i32]) {
     let mut i = 0;
     let n = v.len();
     while i < n {
-        verify!(v[i] >= 0); //~ related location
+        precondition!(v[i] >= 0); //~ related location
         i += 1;
     }
 }
 
 pub fn main() {
-    let a = [-1, 2, 3]; //~ possible false verification condition
+    let a = [-1, 2, 3];
     let b = [1, 2, 3];
-    test(&a);
+    test(&a); //~ possible unsatisfied precondition
     test(&b);
 }


### PR DESCRIPTION
## Description

Unlike assert!, which is ambiguously used to check that preconditions hold at runtime, verify! is meant to be a local annotation that requires the static checker to verify that a condition holds given only the explicit preconditions of the containing function (as well as the summaries of any called functions). Hence a verify! that cannot be proved statically should generate a diagnostic regardless of how it is called.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
