### PR TITLE
Avoid rustc crashes

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -155,6 +155,12 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             .get_rustc_place_type(place, self.bv.current_span);
         match ty.kind() {
             TyKind::Adt(..) | TyKind::Generator(..) => {
+                if let Some(gen_args) = self.bv.type_visitor.generic_arguments {
+                    if !utils::are_concrete(gen_args) {
+                        info!("failed to infer generic arguments of {:?}", self.bv.def_id);
+                        return;
+                    }
+                }
                 let param_env = self.bv.type_visitor.get_param_env();
                 if let Ok(ty_and_layout) = self.bv.tcx.layout_of(param_env.and(ty)) {
                     let discr_ty = ty_and_layout.ty.discriminant_ty(self.bv.tcx);

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -585,12 +585,15 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                 mir::ProjectionElem::Downcast(_, ordinal) => {
                     if let TyKind::Adt(def, substs) = base_ty.kind() {
                         if ordinal.index() >= def.variants.len() {
-                            assume_unreachable!(
+                            info!(
                                 "illegally down casting to index {} of {:?} at {:?}",
                                 ordinal.index(),
                                 base_ty,
                                 current_span
                             );
+                            let variant = &def.variants.iter().last().unwrap();
+                            let field_tys = variant.fields.iter().map(|fd| fd.ty(self.tcx, substs));
+                            return self.tcx.mk_tup(field_tys);
                         }
                         let variant = &def.variants[*ordinal];
                         let field_tys = variant.fields.iter().map(|fd| fd.ty(self.tcx, substs));


### PR DESCRIPTION
## Description

Do some checks to avoid crashing when things don't quite work as expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
