### PR TITLE
Add simplification pattern and fix small bug

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -876,8 +876,8 @@ pub fn is_thin_pointer(ty_kind: &TyKind<'_>) -> bool {
 /// tracking a slice of the underlying collection.
 pub fn is_slice_pointer(ty_kind: &TyKind<'_>) -> bool {
     if let TyKind::RawPtr(TypeAndMut { ty: target, .. }) | TyKind::Ref(_, target, _) = ty_kind {
-        // Pointers to sized arrays are thin pointers.
-        matches!(target.kind(), TyKind::Slice(..) | TyKind::Str) || is_slice_pointer(target.kind())
+        // Pointers to sized arrays and slice pointers are thin pointers.
+        matches!(target.kind(), TyKind::Slice(..) | TyKind::Str)
     } else {
         false
     }

--- a/checker/tests/run-pass/for_iterator.rs
+++ b/checker/tests/run-pass/for_iterator.rs
@@ -4,72 +4,77 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//todo: fix this
+use mirai_annotations::*;
 
-//use std::collections::{HashMap, HashSet};
-//
-//pub struct AbstractValue {}
-//
-//impl AbstractValue {
-//    pub fn record_heap_addresses(&self, _result: &mut HashSet<usize>) {}
-//}
-//
-//#[derive(Eq, PartialEq)]
-//pub enum Path {
-//    AbstractHeapAddress { ordinal: usize },
-//    LocalVariable { ordinal: usize },
-//}
-//
-//impl Path {
-//    pub fn is_rooted_by(&self, _root: &Path) -> bool {
-//        true
-//    }
-//    pub fn record_heap_addresses(&self, _result: &mut HashSet<usize>) {}
-//}
-//
-//pub struct Environment {
-//    pub value_map: HashMap<Path, AbstractValue>,
-//}
-//
-//pub fn extract_side_effects(
-//    env: &Environment,
-//    argument_count: usize,
-//) -> Vec<(&Path, &AbstractValue)> {
-//    let mut heap_roots: HashSet<usize> = HashSet::new();
-//    let mut result = Vec::new();
-//    for ordinal in 0..=argument_count {
-//        // remember that 0 is the result
-//        let root = Path::LocalVariable { ordinal };
-//        for (path, value) in env
-//            .value_map
-//            .iter()
-//            .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
-//        {
-//            path.record_heap_addresses(&mut heap_roots);
-//            value.record_heap_addresses(&mut heap_roots);
-//            result.push((path.clone(), value.clone()));
-//        }
-//    }
-//    let mut visited_heap_roots: HashSet<usize> = HashSet::new();
-//    while heap_roots.len() > visited_heap_roots.len() {
-//        let mut new_roots: HashSet<usize> = HashSet::new();
-//        for ordinal in heap_roots.iter() {
-//            if visited_heap_roots.insert(*ordinal) {
-//                let root = Path::AbstractHeapAddress { ordinal: *ordinal };
-//                for (path, value) in env
-//                    .value_map
-//                    .iter()
-//                    .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
-//                {
-//                    path.record_heap_addresses(&mut new_roots);
-//                    value.record_heap_addresses(&mut new_roots);
-//                    result.push((path.clone(), value.clone()));
-//                }
-//            }
-//        }
-//        heap_roots.extend(new_roots.into_iter());
-//    }
-//    result
-//}
+use std::collections::{HashMap, HashSet};
+
+pub struct AbstractValue {}
+
+impl AbstractValue {
+    pub fn record_heap_addresses(&self, _result: &mut HashSet<usize>) {}
+}
+
+#[derive(Eq, PartialEq)]
+pub enum Path {
+    AbstractHeapAddress { ordinal: usize },
+    LocalVariable { ordinal: usize },
+}
+
+impl Path {
+    pub fn is_rooted_by(&self, _root: &Path) -> bool {
+        true
+    }
+    pub fn record_heap_addresses(&self, result: &mut HashSet<usize>) {
+        result.insert(0);
+    }
+}
+
+pub struct Environment {
+    pub value_map: HashMap<Path, AbstractValue>,
+}
+
+pub fn extract_side_effects(
+    env: &Environment,
+    argument_count: usize,
+) -> Vec<(&Path, &AbstractValue)> {
+    let mut heap_roots: HashSet<usize> = HashSet::new();
+    let mut result = Vec::new();
+    for ordinal in 0..=argument_count {
+        // remember that 0 is the result
+        let root = Path::LocalVariable { ordinal };
+        for (path, value) in env
+            .value_map
+            .iter()
+            .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
+        {
+            path.record_heap_addresses(&mut heap_roots);
+            value.record_heap_addresses(&mut heap_roots);
+            result.push((path.clone(), value.clone()));
+        }
+    }
+    let mut visited_heap_roots: HashSet<usize> = HashSet::new();
+    while heap_roots.len() > visited_heap_roots.len() {
+        let mut new_roots: HashSet<usize> = HashSet::new();
+        for ordinal in heap_roots.iter() {
+            if visited_heap_roots.insert(*ordinal) {
+                let root = Path::AbstractHeapAddress { ordinal: *ordinal };
+                for (path, value) in env
+                    .value_map
+                    .iter()
+                    .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
+                {
+                    path.record_heap_addresses(&mut new_roots);
+                    value.record_heap_addresses(&mut new_roots);
+                    result.push((path.clone(), value.clone()));
+                }
+            }
+        }
+        let it = new_roots.into_iter();
+        // todo: provide a better way of assuming that heaps_roots won't grow out of bounds
+        assume_preconditions!();
+        heap_roots.extend(it);
+    }
+    result
+}
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Add a simplification rule. Fix is_slice_pointer is not report a reference to a slice pointer as being a slice pointer itself. Uncomment a test case that works (because of previous fixes).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
