### PR TITLE
Promote the full &str value when importing a static ref to a &str

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -397,7 +397,7 @@ pub trait AbstractValueTrait: Sized {
     fn logical_not(&self) -> Self;
     fn offset(&self, other: Self) -> Self;
     fn or(&self, other: Self) -> Self;
-    fn record_heap_blocks(&self, result: &mut HashSet<Rc<AbstractValue>>);
+    fn record_heap_blocks_and_strings(&self, result: &mut HashSet<Rc<AbstractValue>>);
     fn refers_to_unknown_location(&self) -> bool;
     fn remainder(&self, other: Self) -> Self;
     fn remove_conjuncts_that_depend_on(&self, variables: &HashSet<Rc<Path>>) -> Self;
@@ -2406,10 +2406,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         }
     }
 
-    /// Adds any abstract heap addresses found in the associated expression to the given set.
+    /// Adds any abstract heap addresses and strings found in the associated expression to the given set.
     #[logfn_inputs(TRACE)]
-    fn record_heap_blocks(&self, result: &mut HashSet<Rc<AbstractValue>>) {
-        self.expression.record_heap_blocks(result);
+    fn record_heap_blocks_and_strings(&self, result: &mut HashSet<Rc<AbstractValue>>) {
+        self.expression.record_heap_blocks_and_strings(result);
     }
 
     /// True if the value is derived from one or more memory locations whose addresses were not known

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -627,7 +627,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
             );
             // Effects on the heap
             for (path, value) in side_effects.iter() {
-                if path.is_rooted_by_abstract_heap_block() {
+                if path.is_rooted_by_abstract_heap_block() || path.is_rooted_by_string() {
                     self.current_environment.update_value_at(
                         path.refine_parameters(
                             &[],

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -156,7 +156,8 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
         );
         // Analysis local foreign contracts are not summarized and cached on demand, so we need to do it here.
         let summary = body_visitor.visit_body(&[], &[]);
-        if utils::is_foreign_contract(self.tcx, def_id) {
+        let kind = self.tcx.def_kind(def_id);
+        if kind == rustc_hir::def::DefKind::Static || utils::is_foreign_contract(self.tcx, def_id) {
             self.summary_cache.set_summary_for(def_id, summary);
         }
         let old_diags = self.diagnostics_for.insert(def_id, diagnostics);

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -1031,7 +1031,7 @@ impl Expression {
 
     /// Adds any heap blocks found in the associated expression to the given set.
     #[logfn_inputs(TRACE)]
-    pub fn record_heap_blocks(&self, result: &mut HashSet<Rc<AbstractValue>>) {
+    pub fn record_heap_blocks_and_strings(&self, result: &mut HashSet<Rc<AbstractValue>>) {
         match &self {
             Expression::Add { left, right }
             | Expression::And { left, right }
@@ -1052,45 +1052,45 @@ impl Expression {
             | Expression::Shl { left, right }
             | Expression::Shr { left, right, .. }
             | Expression::Sub { left, right } => {
-                left.expression.record_heap_blocks(result);
-                right.expression.record_heap_blocks(result);
+                left.expression.record_heap_blocks_and_strings(result);
+                right.expression.record_heap_blocks_and_strings(result);
             }
             Expression::ConditionalExpression {
                 condition,
                 consequent,
                 alternate,
             } => {
-                condition.expression.record_heap_blocks(result);
-                consequent.expression.record_heap_blocks(result);
-                alternate.expression.record_heap_blocks(result);
+                condition.expression.record_heap_blocks_and_strings(result);
+                consequent.expression.record_heap_blocks_and_strings(result);
+                alternate.expression.record_heap_blocks_and_strings(result);
             }
             Expression::HeapBlock { .. } => {
                 result.insert(AbstractValue::make_from(self.clone(), 1));
             }
             Expression::Join { left, right, .. } => {
-                left.expression.record_heap_blocks(result);
-                right.expression.record_heap_blocks(result);
+                left.expression.record_heap_blocks_and_strings(result);
+                right.expression.record_heap_blocks_and_strings(result);
             }
             Expression::Neg { operand }
             | Expression::LogicalNot { operand }
             | Expression::TaggedExpression { operand, .. }
             | Expression::UnknownTagCheck { operand, .. } => {
-                operand.expression.record_heap_blocks(result);
+                operand.expression.record_heap_blocks_and_strings(result);
             }
-            Expression::Reference(path) => path.record_heap_blocks(result),
+            Expression::Reference(path) => path.record_heap_blocks_and_strings(result),
             Expression::Switch {
                 discriminator,
                 cases,
                 default,
             } => {
-                discriminator.record_heap_blocks(result);
+                discriminator.record_heap_blocks_and_strings(result);
                 for (case_val, case_result) in cases {
-                    case_val.record_heap_blocks(result);
-                    case_result.record_heap_blocks(result);
+                    case_val.record_heap_blocks_and_strings(result);
+                    case_result.record_heap_blocks_and_strings(result);
                 }
-                default.record_heap_blocks(result);
+                default.record_heap_blocks_and_strings(result);
             }
-            Expression::Variable { path, .. } => path.record_heap_blocks(result),
+            Expression::Variable { path, .. } => path.record_heap_blocks_and_strings(result),
             _ => (),
         }
     }

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -323,8 +323,8 @@ fn extract_side_effects(
                 }
             })
         {
-            path.record_heap_blocks(&mut heap_roots);
-            value.record_heap_blocks(&mut heap_roots);
+            path.record_heap_blocks_and_strings(&mut heap_roots);
+            value.record_heap_blocks_and_strings(&mut heap_roots);
             if let Expression::Variable { path: vpath, .. } | Expression::InitialParameterValue { path: vpath, ..} = &value.expression {
                 if ordinal > 0 && vpath.eq(path) {
                     // The value is not an update, but just what was there at function entry.
@@ -356,8 +356,8 @@ fn extract_reachable_heap_allocations(
                     .iter()
                     .filter(|(p, _)| (**p) == root || p.is_rooted_by(&root))
                 {
-                    path.record_heap_blocks(&mut new_roots);
-                    value.record_heap_blocks(&mut new_roots);
+                    path.record_heap_blocks_and_strings(&mut new_roots);
+                    value.record_heap_blocks_and_strings(&mut new_roots);
                     result.push((path.clone(), value.clone()));
                 }
             }

--- a/checker/tests/run-pass/other_constants.rs
+++ b/checker/tests/run-pass/other_constants.rs
@@ -26,7 +26,7 @@ pub fn main() {
     verify!(A == true);
     verify!(B == false);
     verify!(C == 'A');
-    //verify!(D == "foo"); //todo: #2 enable this when we have summaries for the standard library
+    verify!(D == "foo"); //~ possible false verification condition
     verify!(if let Foo::Bar = get_bar() {
         true
     } else {


### PR DESCRIPTION
## Description

Promote the full &str value when importing a static ref to a &str. &str values are treated specially in the heap model because it is generally unnecessary (and cumbersome) to deal with them as arrays of characters.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
