### PR TITLE
Include static variables in summaries that reference them

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1965,7 +1965,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         let index = promoted.index();
                         Rc::new(PathEnum::PromotedConstant { ordinal: index }.into())
                     }
-                    None => Path::new_static(self.bv.tcx, def_id),
+                    None => self.bv.import_static(Path::new_static(self.bv.tcx, def_id)),
                 };
                 self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
                 let val_at_path = self.bv.lookup_path_and_refine_result(path, ty);
@@ -2197,7 +2197,9 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 if let Some(rustc_middle::mir::interpret::GlobalAlloc::Static(def_id)) =
                     self.bv.tcx.get_global_alloc(p.alloc_id)
                 {
-                    return AbstractValue::make_reference(Path::new_static(self.bv.tcx, def_id));
+                    return AbstractValue::make_reference(
+                        self.bv.import_static(Path::new_static(self.bv.tcx, def_id)),
+                    );
                 }
                 debug!("span: {:?}", self.bv.current_span);
                 debug!("type kind {:?}", ty.kind());
@@ -2564,10 +2566,9 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     if let Some(rustc_middle::mir::interpret::GlobalAlloc::Static(def_id)) =
                         self.bv.tcx.get_global_alloc(ptr.alloc_id)
                     {
-                        return AbstractValue::make_reference(Path::new_static(
-                            self.bv.tcx,
-                            def_id,
-                        ));
+                        return AbstractValue::make_reference(
+                            self.bv.import_static(Path::new_static(self.bv.tcx, def_id)),
+                        );
                     }
                     let alloc = self.bv.tcx.global_alloc(ptr.alloc_id).unwrap_memory();
                     let alloc_len = alloc.len() as u64;

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -226,6 +226,7 @@ impl Summary {
 /// Constructs a summary of a function body by processing state information gathered during
 /// abstract interpretation of the body.
 #[allow(clippy::too_many_arguments)]
+#[logfn(TRACE)]
 pub fn summarize(
     argument_count: usize,
     exit_environment: Option<&Environment>,

--- a/checker/tests/run-pass/other_constants.rs
+++ b/checker/tests/run-pass/other_constants.rs
@@ -26,7 +26,7 @@ pub fn main() {
     verify!(A == true);
     verify!(B == false);
     verify!(C == 'A');
-    verify!(D == "foo"); //~ possible false verification condition
+    verify!(D == "foo");
     verify!(if let Foo::Bar = get_bar() {
         true
     } else {


### PR DESCRIPTION
## Description

Make sure that (structured) statics are fully imported into the environment as soon as a StaticVariable path is created and also make sure that all of this structure is included in summaries that references such statics.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
