### PR TITLE
Fix typo in get_function_constant_args

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -599,7 +599,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                             | Expression::Variable { path: ipath, .. } => {
                                 if (*path) == *ipath || path.is_rooted_by(ipath) {
                                     let param_path_root = Path::new_parameter(i + 1);
-                                    let param_path = path.replace_root(arg_path, param_path_root);
+                                    let param_path = path.replace_root(ipath, param_path_root);
                                     result.push((param_path, value.clone()));
                                     break;
                                 }

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -918,6 +918,9 @@ impl PathRefinement for Rc<Path> {
     /// Returns a copy path with the root replaced by new_root.
     #[logfn_inputs(TRACE)]
     fn replace_root(&self, old_root: &Rc<Path>, new_root: Rc<Path>) -> Rc<Path> {
+        if *self == *old_root {
+            return new_root;
+        }
         match &self.value {
             PathEnum::QualifiedPath {
                 qualifier,


### PR DESCRIPTION
## Description

Fix logic for propagating function constant arguments to argument signatures used for computing specialized summaries.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
