### PR TITLE
Treat char values as u32 when encoding expressions for Z3

### DIFF
--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1329,7 +1329,8 @@ impl Z3Solver {
                                 modulo_ast,
                                 unsigned_ast,
                             )
-                        } else if exp_type.is_unsigned_integer() {
+                        } else if exp_type.is_unsigned_integer() || exp_type == ExpressionType::Char
+                        {
                             let mut unsigned_ast = self.get_as_numeric_z3_ast(expression).1;
                             let modulo_constant = target_type.as_unsigned().modulo_constant();
                             let modulo_ast = if modulo_constant.is_bottom() {


### PR DESCRIPTION
## Description

Treat char values as u32 when encoding expressions for Z3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
