### PR TITLE
Provide built-in support for std::sync::Once::call_once

### DIFF
--- a/checker/src/known_names.rs
+++ b/checker/src/known_names.rs
@@ -105,6 +105,7 @@ pub enum KnownNames {
     StdPanickingBeginPanicFmt,
     StdPtrSwapNonOverlapping,
     StdSliceCmpMemcmp,
+    StdSyncOnceCallOnce,
 }
 
 /// An analysis lifetime cache that contains a map from def ids to known names.
@@ -383,6 +384,28 @@ impl KnownNamesCache {
                 .unwrap_or(KnownNames::None)
         };
 
+        let get_known_name_for_sync_once_namespace =
+            |mut def_path_data_iter: Iter<'_>| match path_data_elem_as_disambiguator(
+                def_path_data_iter.next(),
+            ) {
+                Some(2) => get_path_data_elem_name(def_path_data_iter.next())
+                    .map(|n| match n.as_str().deref() {
+                        "call_once" => KnownNames::StdSyncOnceCallOnce,
+                        _ => KnownNames::None,
+                    })
+                    .unwrap_or(KnownNames::None),
+                _ => KnownNames::None,
+            };
+
+        let get_known_name_for_sync_namespace = |mut def_path_data_iter: Iter<'_>| {
+            get_path_data_elem_name(def_path_data_iter.next())
+                .map(|n| match n.as_str().deref() {
+                    "once" => get_known_name_for_sync_once_namespace(def_path_data_iter),
+                    _ => KnownNames::None,
+                })
+                .unwrap_or(KnownNames::None)
+        };
+
         let get_known_name_for_known_crate = |mut def_path_data_iter: Iter<'_>| {
             get_path_data_elem_name(def_path_data_iter.next())
                 .map(|n| match n.as_str().deref() {
@@ -409,6 +432,7 @@ impl KnownNamesCache {
                     "mirai_set_model_field" => KnownNames::MiraiSetModelField,
                     "mirai_verify" => KnownNames::MiraiVerify,
                     "slice" => get_known_name_for_slice_namespace(def_path_data_iter),
+                    "sync" => get_known_name_for_sync_namespace(def_path_data_iter),
                     _ => KnownNames::None,
                 })
                 .unwrap_or(KnownNames::None)


### PR DESCRIPTION
## Description

Provide built-in support for std::sync::Once::call_once.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI on Libra
