### PR TITLE
Set enum discriminant value even when enum type is not concrete.

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -373,6 +373,10 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                     _ => {}
                 }
                 info!("current span is {:?}", current_span);
+                info!(
+                    "cache key is {:?}",
+                    utils::summary_key_str(self.tcx, self.def_id)
+                );
                 info!("path is {:?}", path);
                 info!("t is {:?}", t);
                 info!("qualifier is {:?}", qualifier);


### PR DESCRIPTION
## Description

Set enum discriminant value even when enum type is not concrete.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
