### PR TITLE
Fix subset operator

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2764,6 +2764,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     /// Note: !x.subset(y) does not imply y.subset(x).
     #[logfn_inputs(TRACE)]
     fn subset(&self, other: &Rc<AbstractValue>) -> bool {
+        if self.expression.eq(&other.expression) {
+            return true;
+        }
         match (&self.expression, &other.expression) {
             // The empty set is a subset of every other set.
             (Expression::Bottom, _) => true,
@@ -2814,7 +2817,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 // This is a conservative answer. False does not imply other.subset(self).
                 self.subset(&left) || self.subset(&right)
             }
-            (e1, e2) => e1.eq(e2),
+            _ => false,
         }
     }
 


### PR DESCRIPTION
## Description

If expression A is equal to B, it should aways be the case that A.subset(B). This fix seems to take care of all currently known failures to reach a fixed point.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
Ran MIRAI over Libra
