### PR TITLE
Tweak --test_only mode

### DIFF
--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -21,6 +21,7 @@ extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_session;
 
+use itertools::Itertools;
 use log::*;
 use mirai::callbacks;
 use mirai::options::Options;
@@ -105,6 +106,18 @@ fn main() {
         }
 
         if options.test_only {
+            let prefix: String = "mirai_annotations=".into();
+            let postfix: String = ".rmeta".into();
+
+            if let Some((_, s)) = rustc_command_line_arguments
+                .iter_mut()
+                .find_position(|arg| arg.starts_with(&prefix))
+            {
+                if s.ends_with(&postfix) {
+                    *s = s.replace(&postfix, ".rlib");
+                }
+            }
+
             let test: String = "--test".into();
             if !rustc_command_line_arguments
                 .iter()


### PR DESCRIPTION
## Description

In this mode, cargo supplies the mirai_annotations library as an .rmeta file whereas rustc requires an .rlib file. Go figure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
ran RUSTC_WRAPPER=mirai MIRAI_FLAGS="--test_only" cargo build on the smallvec crate.

