### PR TITLE
Make it easier to spot when a k-limit came into play

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -295,6 +295,7 @@ impl AbstractValue {
     #[logfn_inputs(TRACE)]
     pub fn make_from(expression: Expression, expression_size: u64) -> Rc<AbstractValue> {
         if expression_size > k_limits::MAX_EXPRESSION_SIZE {
+            info!("Maximum expression size exceeded");
             // If the expression gets too large, refining it gets expensive and composing it
             // into other expressions leads to exponential growth. We therefore need to abstract
             // (go up in the lattice). We do that by making the expression a typed variable and
@@ -1069,6 +1070,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
 
         // if self { consequent } else { alternate } implies self in the consequent and !self in the alternate
         if consequent.expression_size <= (k_limits::MAX_REFINE_DEPTH as u64) {
+            //todo: don't abuse depth for size
             consequent = consequent.refine_with(self, 5);
         }
         if alternate.expression_size < (k_limits::MAX_REFINE_DEPTH as u64) {
@@ -2956,6 +2958,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     #[logfn_inputs(TRACE)]
     fn get_as_interval(&self) -> IntervalDomain {
         if self.expression_size > k_limits::MAX_EXPRESSION_SIZE / 10 {
+            info!("maximum expression size exceeded from getting an interval domain");
             return interval_domain::BOTTOM;
         }
         match &self.expression {
@@ -3937,6 +3940,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         //do not use false path conditions to refine things
         checked_precondition!(path_condition.as_bool_if_known().is_none());
         if depth >= k_limits::MAX_REFINE_DEPTH {
+            info!("max refine depth exceeded during refine_with");
             //todo: perhaps this should go away.
             // right now it deals with the situation where some large expressions have sizes
             // that are not accurately tracked. These really should get fixed.

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2632,6 +2632,12 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 let index_value = self.get_u128_const_val(last_index);
                 let index_path = Path::new_index(array_path.clone(), index_value);
                 value_map.insert_mut(index_path, operand);
+            } else {
+                info!(
+                    "constant array has {} elements, but maximum tracked is {}",
+                    i,
+                    k_limits::MAX_BYTE_ARRAY_LENGTH
+                );
             }
         }
         let length_path = Path::new_length(array_path.clone());

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -447,6 +447,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     result
                 })
             } else {
+                info!("max path length exceeded in refined value");
                 let result = match path.value {
                     PathEnum::LocalVariable { .. } => refined_val,
                     PathEnum::Parameter { .. } => AbstractValue::make_initial_parameter_value(

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -837,6 +837,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                                 spans: vec![self.block_visitor.bv.current_span],
                             };
                             self.block_visitor.bv.preconditions.push(precondition);
+                        } else {
+                            let warning = self.block_visitor.bv.cv.session.struct_span_warn(
+                                self.block_visitor.bv.current_span,
+                                warning.as_ref(),
+                            );
+                            self.block_visitor.bv.emit_diagnostic(warning);
                         }
                     }
                 }

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -10,7 +10,7 @@
 pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 70;
 
 /// The maximum number of elements in a byte array that will be individually tracked.
-pub const MAX_BYTE_ARRAY_LENGTH: usize = 10;
+pub const MAX_BYTE_ARRAY_LENGTH: usize = 100;
 
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -626,7 +626,7 @@ impl Path {
         }
         let qualifier_length = qualifier.path_length();
         if qualifier_length >= k_limits::MAX_PATH_LENGTH {
-            debug!("max path length exceeded {:?}.{:?}", qualifier, selector);
+            info!("max path length exceeded {:?}.{:?}", qualifier, selector);
         }
         assume!(qualifier_length < 1_000_000_000); // We'll run out of memory long before this happens
         Rc::new(
@@ -789,7 +789,7 @@ impl PathRefinement for Rc<Path> {
             }
         };
         if depth > k_limits::MAX_REFINE_DEPTH {
-            info!("refine depth exceeded for path {:?}", self);
+            info!("refine_paths depth exceeded for path {:?}", self);
             return self.clone();
         }
         // self is a path that is not a key in the environment. This could be because it is not


### PR DESCRIPTION
## Description

Provide logging for every place where a k-limit is exceeded (diagnostics are already given when exceeding a k-limit will lead to unsoundness). Also increase a limit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
