### PR TITLE
Fix bug in silent promotion of preconditions in relaxed mode

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -774,12 +774,17 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     /// Emit a diagnostic to the effect that the current call might violate a the given precondition
     /// of the called function. Use the provenance and spans of the precondition to point out related locations.
     #[logfn_inputs(TRACE)]
-    pub fn emit_diagnostic_for_precondition(&mut self, precondition: &Precondition, warn: bool) {
+    pub fn emit_diagnostic_for_precondition(
+        &mut self,
+        precondition: &Precondition,
+        condition: &Rc<AbstractValue>,
+        warn: bool,
+    ) {
         precondition!(self.bv.check_for_errors);
         // In relaxed mode we don't want to complain if the condition or reachability depends on
         // a parameter, since it is assumed that an implicit precondition was intended by the author.
         if matches!(self.bv.cv.options.diag_level, DiagLevel::RELAXED)
-            && (precondition.condition.expression.contains_parameter()
+            && (condition.expression.contains_parameter()
                 || self
                     .bv
                     .current_environment

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2386,7 +2386,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 // The precondition is definitely false.
                 if entry_cond_as_bool.unwrap_or(false) {
                     // We always get to this call
-                    self.issue_diagnostic_for_call(precondition, false);
+                    self.issue_diagnostic_for_call(precondition, &refined_condition, false);
                     return;
                 } else {
                     // Promote the precondition, but be assertive.
@@ -2436,14 +2436,19 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
 
             // The precondition cannot be promoted, so the buck stops here.
-            self.issue_diagnostic_for_call(precondition, warn);
+            self.issue_diagnostic_for_call(precondition, &refined_condition, warn);
         }
     }
 
     // Issue a diagnostic, but only if there isn't already a diagnostic for this
     // function call.
     #[logfn_inputs(TRACE)]
-    fn issue_diagnostic_for_call(&mut self, precondition: &Precondition, warn: bool) {
+    fn issue_diagnostic_for_call(
+        &mut self,
+        precondition: &Precondition,
+        condition: &Rc<AbstractValue>,
+        warn: bool,
+    ) {
         if self.block_visitor.bv.check_for_errors
             && !self
                 .block_visitor
@@ -2452,7 +2457,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .contains(&self.callee_fun_val)
         {
             self.block_visitor
-                .emit_diagnostic_for_precondition(precondition, warn);
+                .emit_diagnostic_for_precondition(precondition, condition, warn);
             self.block_visitor
                 .bv
                 .already_reported_errors_for_call_to

--- a/checker/tests/run-pass/relaxed_precon.rs
+++ b/checker/tests/run-pass/relaxed_precon.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks relaxed mode preconditions
+
+// MIRAI_FLAGS --diag=relaxed
+
+use mirai_annotations::*;
+
+fn foo(i: i32) {
+    precondition!(i > 3); //~ related location
+}
+
+pub fn bar(i: i32) {
+    // No diagnostic here since relaxed mode silently promotes the precondition even though
+    // bar is an analysis root
+    foo(i);
+}
+
+pub fn main() {
+    // Diagnostic here since the unsatisfied precondition does not depend on a parameter
+    // of the analysis root.
+    foo(1); //~ unsatisfied precondition
+}


### PR DESCRIPTION
## Description

In relaxed mode, a precondition violation that occurs in an analysis root function will not result in a diagnostic if the precondition's condition (or path condition) depends on a parameter of the root function, since it can conceivably be expected that the root function expects its callers to not call it with arguments that will lead to runtime violations of the precondition.

The logic for doing this was buggy because it checked the unrefined precondition, which almost always contains a parameter, and thus suppressed almost all diagnostics about violated preconditions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh (with addition test case)
ran MIRAI over Libra (in relaxed mode), observed a number of diagnostics where previously there were none
