### PR TITLE
Rename PathEnum::Alias to PathEnum::Computed

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2644,9 +2644,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     /// this value is always a string literal.
     #[logfn_inputs(TRACE)]
     fn coerce_to_string(&mut self, path: &Rc<Path>) -> Rc<str> {
-        if let PathEnum::Alias { value } = &path.value {
+        if let PathEnum::Computed { value } = &path.value {
             if let Expression::Reference(path) = &value.expression {
-                if let PathEnum::Alias { value } = &path.value {
+                if let PathEnum::Computed { value } = &path.value {
                     if let Expression::CompileTimeConstant(ConstantDomain::Str(s)) =
                         &value.expression
                     {
@@ -2656,7 +2656,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             }
         } else if let Some(value) = self.block_visitor.bv.current_environment.value_at(path) {
             if let Expression::Reference(path) = &value.expression {
-                if let PathEnum::Alias { value } = &path.value {
+                if let PathEnum::Computed { value } = &path.value {
                     if let Expression::CompileTimeConstant(ConstantDomain::Str(s)) =
                         &value.expression
                     {

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -72,7 +72,7 @@ impl Environment {
         path: &Rc<Path>,
     ) -> Option<(Rc<AbstractValue>, Rc<Path>, Rc<Path>)> {
         match &path.value {
-            PathEnum::Alias { value } => {
+            PathEnum::Computed { value } => {
                 if let Expression::ConditionalExpression {
                     condition,
                     consequent,
@@ -84,8 +84,8 @@ impl Environment {
                     {
                         return Some((
                             condition.clone(),
-                            Path::new_alias(consequent.refine_with(condition, 0)),
-                            Path::new_alias(alternate.refine_with(&condition.logical_not(), 0)),
+                            Path::get_as_path(consequent.refine_with(condition, 0)),
+                            Path::get_as_path(alternate.refine_with(&condition.logical_not(), 0)),
                         ));
                     }
                 }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -154,7 +154,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
             return ty;
         }
         match &path.value {
-            PathEnum::Alias { value } => match &value.expression {
+            PathEnum::Computed { value } => match &value.expression {
                 Expression::ConditionalExpression { consequent, .. } => {
                     self.get_path_rustc_type(&Path::get_as_path(consequent.clone()), current_span)
                 }
@@ -222,7 +222,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                 match t.kind() {
                     TyKind::Infer(..) => {
                         // The qualifier does not resolve to a useful rustc type.
-                        // This can happen when the qualifier is a PathEnum::Alias where the value
+                        // This can happen when the qualifier is a PathEnum::Computed where the value
                         // is TOP, or BOTTOM or a heap layout.
                         return self.tcx.types.never;
                     }


### PR DESCRIPTION
## Description

Rename PathEnum::Alias to PathEnum::Computed. The old name is no longer an accurate description of how it is used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
