### PR TITLE
Distribute deref to conditional branches

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1298,7 +1298,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 .join(right.dereference(target_type), path),
             Expression::Offset { .. } => {
                 let path = Path::get_as_path(self.clone());
-                let deref_path = Path::new_deref(path);
+                let deref_path = Path::new_deref(path, target_type.clone());
                 if let PathEnum::Computed { value } = &deref_path.value {
                     value.clone()
                 } else {

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2907,7 +2907,8 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                             .type_visitor
                             .get_path_rustc_type(&thin_pointer_path, self.bv.current_span);
                         ty = type_visitor::get_target_type(thin_ptr_type);
-                        let deref_path = Path::new_deref(thin_pointer_path);
+                        let deref_path =
+                            Path::new_deref(thin_pointer_path, ExpressionType::from(ty.kind()));
                         self.bv
                             .type_visitor
                             .path_ty_cache


### PR DESCRIPTION
## Description

Distribute the deref selector to the branches of a conditional expression inside of a PathEnum::Computed qualifier. This unlocks simplifications and help path normalization.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
