### PR TITLE
Increase precision

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -900,7 +900,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             } else {
                 "possible unsatisfied postcondition"
             };
-            let error = self.bv.cv.session.struct_span_err(span, msg);
+            let error = self.bv.cv.session.struct_span_warn(span, msg);
             self.bv.emit_diagnostic(error);
             // Don't add the post condition to the summary
             return None;

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -25,4 +25,4 @@ pub const MAX_FIXPOINT_ITERATIONS: usize = 10;
 pub const MAX_PATH_LENGTH: usize = 30;
 
 /// Refining values with a path condition that is a really deep expression leads to exponential blow up.
-pub const MAX_REFINE_DEPTH: usize = 9;
+pub const MAX_REFINE_DEPTH: usize = 40;


### PR DESCRIPTION
## Description

When a binary expression is too large, make only the larger of the two operands more abstract. Likewise, when a conditional gets too large, try to keep one or more of the operands precise.

Also increase a k-limit for refinement depth and remove the limit for the size of an expression from which an interval domain can be obtained.

This spends all of the recent performance gains on more precision, and then some.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

