### PR TITLE
Use `env` in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #Copyright (c) Facebook, Inc. and its affiliates.
 
 # This source code is licensed under the MIT license found in the


### PR DESCRIPTION
## Description

The hashbang assumes bash is present in `/bin/bash`, but on distros such as NixOS, it isn't. `/usr/bin/env` is more likely to be present, and will find bash in more cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes.
- [ ] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

