### PR TITLE
Look inside computed paths that wrap initial parameter values

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -408,6 +408,12 @@ impl Path {
     #[logfn_inputs(TRACE)]
     pub fn is_rooted_by(&self, root: &Rc<Path>) -> bool {
         match &self.value {
+            PathEnum::Computed { value } => {
+                if let Expression::InitialParameterValue { path, .. } = &value.expression {
+                    return *path == *root || path.is_rooted_by(root);
+                }
+                false
+            }
             PathEnum::QualifiedPath { qualifier, .. } => {
                 *qualifier == *root || qualifier.is_rooted_by(root)
             }
@@ -474,6 +480,9 @@ impl Path {
     #[logfn_inputs(TRACE)]
     pub fn is_rooted_by_parameter(&self) -> bool {
         match &self.value {
+            PathEnum::Computed { value } => {
+                matches!(&value.expression, Expression::InitialParameterValue{..})
+            }
             PathEnum::QualifiedPath { qualifier, .. } => qualifier.is_rooted_by_parameter(),
             PathEnum::Parameter { .. } => true,
             _ => false,


### PR DESCRIPTION
## Description

Look inside computed paths that wrap initial parameter values when checking for a root

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra

