### PR TITLE
Rename refers_to_unknown_location to might_benefit_from_refinement

### DIFF
--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -79,8 +79,8 @@ impl Environment {
                     alternate,
                 } = &value.expression
                 {
-                    if consequent.refers_to_unknown_location()
-                        && alternate.refers_to_unknown_location()
+                    if consequent.might_benefit_from_refinement()
+                        && alternate.might_benefit_from_refinement()
                     {
                         return Some((
                             condition.clone(),

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -878,11 +878,9 @@ impl PathRefinement for Rc<Path> {
                             }
                         }
                         _ => {
-                            if val.refers_to_unknown_location() {
-                                return Path::new_qualified(
-                                    Path::get_as_path(val.clone()),
-                                    refined_selector,
-                                );
+                            let val_as_path = Path::get_as_path(val.clone());
+                            if !matches!(val_as_path.value, PathEnum::Computed {..}) {
+                                return Path::new_qualified(val_as_path, refined_selector);
                             }
                         }
                     }
@@ -911,7 +909,7 @@ impl PathRefinement for Rc<Path> {
     #[logfn_inputs(TRACE)]
     fn refine_paths(&self, environment: &Environment, depth: usize) -> Rc<Path> {
         if let Some(val) = environment.value_at(&self) {
-            if val.refers_to_unknown_location() {
+            if val.might_benefit_from_refinement() {
                 // self is an alias for val
                 return Path::get_as_path(val.clone());
             }
@@ -924,7 +922,7 @@ impl PathRefinement for Rc<Path> {
         // canonical.
         match &self.value {
             PathEnum::Computed { value } => {
-                if value.refers_to_unknown_location() {
+                if value.might_benefit_from_refinement() {
                     Path::get_as_path(value.clone())
                 } else {
                     self.clone()
@@ -1026,7 +1024,7 @@ impl PathRefinement for Rc<Path> {
                             }
                         }
                         _ => {
-                            if val.refers_to_unknown_location() {
+                            if val.might_benefit_from_refinement() {
                                 return Path::new_qualified(
                                     Path::get_as_path(val.clone()),
                                     refined_selector,


### PR DESCRIPTION
## Description

Rename refers_to_unknown_location to might_benefit_from_refinement. The old name is no longer accurate and makes the code harder to understand.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra