### PR TITLE
Tweak path type inference to deal with more Opaque types

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -227,6 +227,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                         );
                     }
                 }
+            } else {
+                info!(
+                    "could not resolve function {:?}, {:?}, {:?}",
+                    self.callee_def_id, param_env, gen_args,
+                )
             }
         }
     }

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -219,6 +219,7 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
     /// Emit any diagnostics or, if testing, check that they are as expected.
     #[logfn_inputs(TRACE)]
     fn emit_or_check_diagnostics(&mut self) {
+        self.session.diagnostic().reset_err_count();
         if self.test_run {
             let mut expected_errors = expected_errors::ExpectedErrors::new(self.file_name);
             let mut diags = vec![];


### PR DESCRIPTION
## Description

Generalize the code for dealing with determining the types of fields of opaque types.

Also add a call to drop any delayed compiler errors that arise from calls to Instance::resolve that fail to resolve because of some error in the resolution environment. Failing this, more recent rust compilers will crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
