### PR TITLE
Remove unused depth parameter

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1089,7 +1089,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 }
                 PathEnum::Computed { .. }
                 | PathEnum::Offset { .. }
-                | PathEnum::QualifiedPath { .. } => tpath = tpath.canonicalize(pre_environment, 0),
+                | PathEnum::QualifiedPath { .. } => tpath = tpath.canonicalize(pre_environment),
                 _ => {}
             }
             let mut rvalue = value.refine_parameters_and_paths(
@@ -1763,10 +1763,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
             for i in from..to {
                 let index_val = self.get_u128_const_val(u128::from(i));
                 let indexed_source = Path::new_index(source_path.clone(), index_val)
-                    .canonicalize(&self.current_environment, 0);
+                    .canonicalize(&self.current_environment);
                 let target_index_val = self.get_u128_const_val(u128::try_from(i - from).unwrap());
                 let indexed_target = Path::new_index(target_path.clone(), target_index_val)
-                    .canonicalize(&self.current_environment, 0);
+                    .canonicalize(&self.current_environment);
                 trace!(
                     "indexed_target {:?} indexed_source {:?} elem_ty {:?}",
                     indexed_target,
@@ -1992,7 +1992,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 check_for_early_return!(self);
                 let qualified_path = path
                     .replace_root(&source_path, target_path.clone())
-                    .canonicalize(&self.current_environment, 0);
+                    .canonicalize(&self.current_environment);
                 if move_elements {
                     trace!("moving child {:?} to {:?}", value, qualified_path);
                 // todo: doing the remove part of the move here makes it difficult to combine
@@ -2474,7 +2474,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
         precondition!(!root_rustc_type.is_scalar());
 
         let tag_field_path =
-            Path::new_tag_field(qualifier.clone()).canonicalize(&self.current_environment, 0);
+            Path::new_tag_field(qualifier.clone()).canonicalize(&self.current_environment);
         let mut tag_field_value = self.lookup_path_and_refine_result(
             tag_field_path.clone(),
             self.type_visitor.dummy_untagged_value_type,

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -332,7 +332,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 Path::get_as_path(self.actual_args[0].1.clone()),
                 target_type,
             )
-            .canonicalize(&self.block_visitor.bv.current_environment, 0);
+            .canonicalize(&self.block_visitor.bv.current_environment);
             let target_type = self
                 .block_visitor
                 .bv
@@ -700,11 +700,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 } else {
                     let arguments_struct_path = Path::get_as_path(self.actual_args[0].1.clone());
                     let pieces_path_fat = Path::new_field(arguments_struct_path, 0)
-                        .canonicalize(&self.block_visitor.bv.current_environment, 0);
+                        .canonicalize(&self.block_visitor.bv.current_environment);
                     let pieces_path_thin = Path::new_field(pieces_path_fat, 0);
                     let index = Rc::new(0u128.into());
                     let piece0_path_fat = Path::new_index(pieces_path_thin, index)
-                        .canonicalize(&self.block_visitor.bv.current_environment, 0);
+                        .canonicalize(&self.block_visitor.bv.current_environment);
                     self.coerce_to_string(&piece0_path_fat)
                 };
                 if msg.contains("entered unreachable code")
@@ -1139,7 +1139,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             )
             .unwrap_or(source_pointer_path);
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
-                .canonicalize(&self.block_visitor.bv.current_environment, 0);
+                .canonicalize(&self.block_visitor.bv.current_environment);
             trace!("MiraiAddTag: tagging {:?} with {:?}", tag, source_path);
 
             // Check if the tagged value has a pointer type (e.g., a reference).
@@ -1227,7 +1227,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             )
             .unwrap_or(source_pointer_path);
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
-                .canonicalize(&self.block_visitor.bv.current_environment, 0);
+                .canonicalize(&self.block_visitor.bv.current_environment);
             trace!(
                 "MiraiCheckTag: checking if {:?} has {}been tagged with {:?}",
                 source_path,
@@ -1376,7 +1376,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let field_name =
                 self.coerce_to_string(&Path::get_as_path(self.actual_args[1].1.clone()));
             let source_path = Path::new_model_field(qualifier, field_name)
-                .canonicalize(&self.block_visitor.bv.current_environment, 0);
+                .canonicalize(&self.block_visitor.bv.current_environment);
 
             let target_path = self.block_visitor.visit_place(place);
             if self
@@ -1532,7 +1532,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let field_name =
                 self.coerce_to_string(&Path::get_as_path(self.actual_args[1].1.clone()));
             let target_path = Path::new_model_field(qualifier, field_name)
-                .canonicalize(&self.block_visitor.bv.current_environment, 0);
+                .canonicalize(&self.block_visitor.bv.current_environment);
             let source_path = Path::get_as_path(self.actual_args[2].1.clone());
             let target_type = self.actual_argument_types[2];
             self.block_visitor.bv.copy_or_move_elements(
@@ -1585,7 +1585,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
         // Get a layout path and update the environment
         let layout_path = Path::new_layout(heap_block_path)
-            .canonicalize(&self.block_visitor.bv.current_environment, 0);
+            .canonicalize(&self.block_visitor.bv.current_environment);
         self.block_visitor
             .bv
             .current_environment
@@ -1626,7 +1626,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 Path::get_as_path(self.actual_args[0].1.clone()),
                 target_type,
             ))
-            .canonicalize(&self.block_visitor.bv.current_environment, 0);
+            .canonicalize(&self.block_visitor.bv.current_environment);
             let mut discriminant_value = self.block_visitor.bv.lookup_path_and_refine_result(
                 discriminant_path,
                 self.block_visitor.bv.tcx.types.u128,
@@ -1760,7 +1760,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
         // Get a layout path and update the environment
         let layout_path = Path::new_layout(heap_block_path)
-            .canonicalize(&self.block_visitor.bv.current_environment, 0);
+            .canonicalize(&self.block_visitor.bv.current_environment);
         self.block_visitor
             .bv
             .current_environment
@@ -1877,7 +1877,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             Path::get_as_path(self.actual_args[0].1.clone()),
             target_type,
         )
-        .canonicalize(&self.block_visitor.bv.current_environment, 0);
+        .canonicalize(&self.block_visitor.bv.current_environment);
         let source_path = &Path::get_as_path(self.actual_args[1].1.clone());
         if let Some((place, _)) = &self.destination {
             let target_path = self.block_visitor.visit_place(place);
@@ -2140,8 +2140,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 assume_unreachable!("transmute called on types with different bit lengths");
             }
             let (source_path, source_type) = &source_fields[source_field_index];
-            let source_path =
-                source_path.canonicalize(&self.block_visitor.bv.current_environment, 0);
+            let source_path = source_path.canonicalize(&self.block_visitor.bv.current_environment);
             let mut val = self
                 .block_visitor
                 .bv
@@ -2182,7 +2181,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     }
                     let (source_path, source_type) = &source_fields[source_field_index];
                     let source_path =
-                        source_path.canonicalize(&self.block_visitor.bv.current_environment, 0);
+                        source_path.canonicalize(&self.block_visitor.bv.current_environment);
                     let source_bits = ExpressionType::from(source_type.kind()).bit_length();
                     let mut next_val = self
                         .block_visitor
@@ -2225,7 +2224,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             Path::get_as_path(self.actual_args[0].1.clone()),
             target_type,
         )
-        .canonicalize(&self.block_visitor.bv.current_environment, 0);
+        .canonicalize(&self.block_visitor.bv.current_environment);
         let dest_type = self.actual_argument_types[0];
         let source_path = Path::get_as_path(self.actual_args[1].1.clone());
         let byte_value = &self.actual_args[1].1;

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -110,7 +110,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
     /// The result of this function is the t part.
     #[logfn_inputs(TRACE)]
     pub fn get_first_part_of_target_path_type_tuple(
-        &mut self,
+        &self,
         path: &Rc<Path>,
         current_span: rustc_span::Span,
     ) -> ExpressionType {
@@ -123,7 +123,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
     // Path is required to be rooted in a temporary used to track an operation result.
     #[logfn_inputs(TRACE)]
     pub fn get_target_path_type(
-        &mut self,
+        &self,
         path: &Rc<Path>,
         current_span: rustc_span::Span,
     ) -> ExpressionType {
@@ -143,11 +143,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
     /// This is a hacky and brittle way to navigate the Rust compiler's type system.
     /// Eventually it should be replaced with a comprehensive and principled mapping.
     #[logfn_inputs(TRACE)]
-    pub fn get_path_rustc_type(
-        &mut self,
-        path: &Rc<Path>,
-        current_span: rustc_span::Span,
-    ) -> Ty<'tcx> {
+    pub fn get_path_rustc_type(&self, path: &Rc<Path>, current_span: rustc_span::Span) -> Ty<'tcx> {
         if let Some(ty) = self.path_ty_cache.get(path) {
             return ty;
         }


### PR DESCRIPTION
## Description

Remove unused depth parameter. Also remove duplicated code from refine_parameters_and_paths by introducing a call to canonicalize.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
