### PR TITLE
Canonicalize initial parameter value paths

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -353,6 +353,7 @@ impl AbstractValue {
     /// Creates an abstract value about which nothing is known other than its type and address.
     #[logfn_inputs(TRACE)]
     pub fn make_typed_unknown(var_type: ExpressionType, path: Rc<Path>) -> Rc<AbstractValue> {
+        let path = path.remove_initial_value_wrapper();
         AbstractValue::make_from(Expression::Variable { path, var_type }, 1)
     }
 
@@ -2746,7 +2747,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     }
 
     /// Returns an element that is "self - other".
-    #[logfn_inputs(DEBUG)]
+    #[logfn_inputs(TRACE)]
     fn subtract(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
         // [0 - other] -> -other
         if let Expression::CompileTimeConstant(ConstantDomain::I128(0))


### PR DESCRIPTION
## Description

Canonicalize initial parameter value paths by stripping the wrapper from the root of a path that is about to be wrapped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
