### PR TITLE
Fix join logic for unit values

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -423,6 +423,7 @@ pub trait AbstractValueTrait: Sized {
     fn is_compile_time_constant(&self) -> bool;
     fn is_contained_in_zeroed_heap_block(&self) -> bool;
     fn is_top(&self) -> bool;
+    fn is_unit(&self) -> bool;
     fn join(&self, other: Self, path: &Rc<Path>) -> Self;
     fn less_or_equal(&self, other: Self) -> Self;
     fn less_than(&self, other: Self) -> Self;
@@ -1855,6 +1856,15 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             }
             _ => false,
         }
+    }
+
+    /// True if this value is an empty tuple, which is the sole value of the unit type.
+    #[logfn_inputs(TRACE)]
+    fn is_unit(&self) -> bool {
+        matches!(
+            &self.expression,
+            Expression::CompileTimeConstant(ConstantDomain::Unit)
+        )
     }
 
     /// Returns an abstract value whose corresponding set of concrete values includes all of the values

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -453,13 +453,13 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                             AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
                         }
                         _ => {
-                            if path.is_rooted_by_parameter() {
+                            if result_type == ExpressionType::Unit {
+                                Rc::new(ConstantDomain::Unit.into())
+                            } else if path.is_rooted_by_parameter() {
                                 AbstractValue::make_initial_parameter_value(
                                     result_type.clone(),
                                     path.clone(),
                                 )
-                            } else if result_type == ExpressionType::Unit {
-                                Rc::new(ConstantDomain::Unit.into())
                             } else {
                                 AbstractValue::make_typed_unknown(result_type.clone(), path.clone())
                             }

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -273,7 +273,7 @@ impl Environment {
                     value_map.insert_mut(p, join_or_widen(val1, val2, path));
                 }
                 None => {
-                    if !path.is_rooted_by_parameter() {
+                    if !path.is_rooted_by_parameter() || val1.is_unit() {
                         // joining val1 and bottom
                         // The bottom value corresponds to dead (impossible) code, so the join collapses.
                         value_map.insert_mut(p, val1.clone());

--- a/checker/tests/run-pass/tag_domain.rs
+++ b/checker/tests/run-pass/tag_domain.rs
@@ -33,7 +33,6 @@ pub fn test(secret: i32) {
 
     let info = secret | 1;
     verify!(has_tag!(&info, SecretTaint));
-    // todo: keep track of tag information from preconditions
     verify!(does_not_have_tag!(&info, SecretSanitizer));
 
     let encrypted = info ^ 99991;
@@ -47,7 +46,6 @@ pub fn test(secret: i32) {
 
     let polluted = temp | secret;
     verify!(has_tag!(&polluted, SecretTaint));
-    // todo: keep track of tag information from preconditions
     verify!(does_not_have_tag!(&polluted, SecretSanitizer));
 }
 


### PR DESCRIPTION
## Description

Joining two values of type unit, should just result in the empty tuple value, which is the sole concrete value that belongs to type unit.

Included is an unrelated cleanup of out-dated comments in a test case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
