### PR TITLE
Add side effects via references to summaries

### DIFF
--- a/checker/tests/run-pass/closure_mut_param.rs
+++ b/checker/tests/run-pass/closure_mut_param.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses a closure that side-effects a mutable captured variable
+
+use mirai_annotations::*;
+
+fn foo<F>(f: F)
+where
+    F: FnOnce(),
+{
+    f()
+}
+
+pub fn main() {
+    let mut x = 1;
+    let f = || x += 1;
+    foo(f);
+    verify!(x == 2);
+}


### PR DESCRIPTION
## Description

When a path root is some kind of wrapper, for example PathEnum::Computed, and the wrapped value contains a path, for example an Expression::Reference, then recurse into the wrapped path when looking for the real root of a path.  This matters when looking for side effects to include in a summary, since assignments to pointer expressions derived from parameters have this form. It also matters when canonicalizing a path where the qualifier is rooted in an initial value wrapper.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
