### PR TITLE
Handle expression overflows in summary effects

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -191,6 +191,8 @@ impl AbstractValue {
         }
         let mut expression_size = left.expression_size.saturating_add(right.expression_size);
         if expression_size > k_limits::MAX_EXPRESSION_SIZE {
+            // The overall expression is going to overflow, so pre-compute the simpler domains from
+            // the larger expression and then replace its expression with TOP.
             if left.expression_size < right.expression_size {
                 right = AbstractValue::make_from(right.expression.clone(), u64::MAX);
                 expression_size = left.expression_size + 1;

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1106,6 +1106,10 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     self.current_environment.update_value_at(tpath, rvalue);
                     continue;
                 }
+                Expression::Top if rtype != ExpressionType::NonPrimitive => {
+                    self.current_environment.update_value_at(tpath, rvalue);
+                    continue;
+                }
                 Expression::HeapBlockLayout { source, .. } => {
                     match source {
                         LayoutSource::DeAlloc => {
@@ -1230,7 +1234,6 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                             var_type.clone(),
                             path.clone(),
                         );
-                        // todo: investigate test failures that happen when removing the next two lines
                         self.current_environment.update_value_at(tpath, rvalue);
                         continue;
                     } else if rtype == ExpressionType::NonPrimitive {


### PR DESCRIPTION
## Description

When an expression overflows to TOP, make sure that it is incorporated in the summary if it is of a primitive type and is assigned to a path that is reachable by the caller.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Libra
