### PR TITLE
Deal with closures that are passed via fields of parameters

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -178,12 +178,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
         // Add parameter values that are function constants.
         // Also add entries for closure fields.
         for (path, val) in function_constant_args.iter() {
-            self.type_visitor.add_any_closure_fields_for(
-                &mut self.current_environment,
-                parameter_types,
-                &mut first_state,
-                &path,
-            );
+            let path_ty = self
+                .type_visitor
+                .get_path_rustc_type(path, self.current_span);
+            self.type_visitor
+                .add_any_closure_fields_for(path_ty, &path, &mut first_state);
             first_state.value_map.insert_mut(path.clone(), val.clone());
         }
         first_state.exit_conditions = HashTrieMap::default();

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -957,7 +957,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         };
 
         // Get the path of the tuple containing the arguments.
-        let callee_arg_array_path = Path::get_as_path(self.actual_args[1].1.clone());
+        let callee_arg_array_path = self.actual_args[1].0.clone();
 
         // Unpack the arguments. We use the generic arguments of the caller as a proxy for the callee function signature.
         let generic_argument_types: Vec<Ty<'tcx>> = self

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,13 +139,53 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(file_name: &str) -> bool {
-        file_name.contains("language/move-lang/src")
+        file_name.contains("client/faucet/src")
+        || file_name.contains("client/json-rpc/src")
+        || file_name.contains("client/swiss-knife/src")
+        || file_name.contains("config/src")
+        || file_name.contains("config/management/src")    
+        || file_name.contains("config/management/genesis/src")
+        || file_name.contains("config/management/network-address-encryption/src")
+        || file_name.contains("config/management/operational/src")  
+        || file_name.contains("consensus/src")    
+        || file_name.contains("consensus/safety-rules/src")    
+        || file_name.contains("common/debug-interface/src")
+        || file_name.contains("common/logger/src")
+        || file_name.contains("common/metrics/src")
+        || file_name.contains("common/metrics-core/src")    
+        || file_name.contains("common/trace/src")
+        || file_name.contains("execution/execution-correctness/src")    
+        || file_name.contains("execution/executor/src")    
+        || file_name.contains("json-rpc/src")    
+        || file_name.contains("language/bytecode-verifier/src")    
+        || file_name.contains("language/compiler/src")    
+        || file_name.contains("language/compiler/ir-to-bytecode/src")    
+        || file_name.contains("language/compiler/ir-to-bytecode/syntax/src")    
+        || file_name.contains("language/diem-tools/diem-events-fetcher/src")    
+        || file_name.contains("language/diem-vm/src")    
+        || file_name.contains("language/move-lang/src")
+        || file_name.contains("language/move-model/src")    
         || file_name.contains("language/move-prover/src") // compiler panic
+        || file_name.contains("language/move-prover/bytecode/src")    
+        || file_name.contains("language/move-prover/docgen/src")    
         || file_name.contains("language/move-prover/spec-lang/src") // compiler panic
+        || file_name.contains("language/move-vm/test-utils/src")    
+        || file_name.contains("language/stdlib/src")    
         || file_name.contains("language/tools/move-cli/src")
+        || file_name.contains("language/tools/move-coverage/src")
+        || file_name.contains("language/libra-tools/transaction-replay/src")
         || file_name.contains("language/vm/src")
-        || file_name.contains("network/src") // you should never look at the bits of a ZST
-        || file_name.contains("state-synchronizer/src") // Z3 encoding error
+        || file_name.contains("network/src") // you should never look at the bits of a ZST 
+        || file_name.contains("network/builder/src")    
+        || file_name.contains("secure/net/src")
+        || file_name.contains("secure/storage/src")    
+        || file_name.contains("secure/storage/vault/src")    
+        || file_name.contains("state-synchronizer/src") // Z3 encoding error 
+        || file_name.contains("storage/backup/backup-cli/src")
+        || file_name.contains("storage/backup/backup-service/src")
+        || file_name.contains("storage/diemdb/src")    
+        || file_name.contains("storage/storage-client/src")
+        || file_name.contains("types/src")
     }
 
     /// Analyze the crate currently being compiled, using the information given in compiler and tcx.

--- a/checker/tests/run-pass/unzip.rs
+++ b/checker/tests/run-pass/unzip.rs
@@ -12,9 +12,8 @@ pub fn test() {
     let a = [(1, 2), (3, 4)];
 
     let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
-    //todo: fix the false messages below
-    verify!(left == [1, 3]); //~ provably false verification condition
-    verify!(right == [2, 4]); //~ provably false verification condition
+    verify!(left == [1, 3]); //~ possible false verification condition
+    verify!(right == [2, 4]); //~ possible false verification condition
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Generalize the code that adds closure fields to the initial state so that closures that are passed as components of parameters also get handled. Also deal with closures that hide inside opaque types.

Add to the exclusion list so that MIRAI can run over Diem in strict mode without crashing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem in strict mode
