### PR TITLE
Deal with aliasing between slice and index paths

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1249,6 +1249,13 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                         self.type_visitor
                             .get_path_rustc_type(&target_path, self.current_span),
                     );
+                    let previous_value = pre_environment.value_at(&tpath);
+                    if let Some(pval) = previous_value {
+                        if rvalue.eq(pval) {
+                            // This effect is a no-op
+                            continue;
+                        }
+                    }
                     self.copy_or_move_elements(tpath.clone(), source_path, target_type, false);
                     continue;
                 }

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -594,11 +594,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     .bv
                     .check_condition_value_and_reachability(cond);
 
-                // If we never get here, rather call unreachable!()
+                // If we never get here, rather call verify_unreachable!()
                 if !entry_cond_as_bool.unwrap_or(true) {
                     let span = self.block_visitor.bv.current_span;
                     let message =
-                        "this is unreachable, mark it as such by using the unreachable! macro";
+                        "this is unreachable, mark it as such by using the verify_unreachable! macro";
                     let warning = self
                         .block_visitor
                         .bv

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -154,6 +154,7 @@ impl MiraiCallbacks {
         || file_name.contains("common/metrics/src")
         || file_name.contains("common/metrics-core/src")    
         || file_name.contains("common/trace/src")
+        || file_name.contains("diem-node/src")    
         || file_name.contains("execution/execution-correctness/src")    
         || file_name.contains("execution/executor/src")    
         || file_name.contains("json-rpc/src")    
@@ -167,6 +168,7 @@ impl MiraiCallbacks {
         || file_name.contains("language/move-model/src")    
         || file_name.contains("language/move-prover/src") // compiler panic
         || file_name.contains("language/move-prover/bytecode/src")    
+        || file_name.contains("language/move-prover/abigen/src")    
         || file_name.contains("language/move-prover/docgen/src")    
         || file_name.contains("language/move-prover/spec-lang/src") // compiler panic
         || file_name.contains("language/move-vm/test-utils/src")    

--- a/checker/tests/run-pass/read_exact.rs
+++ b/checker/tests/run-pass/read_exact.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test case that checks that effects that join old values with updates do not
+// overwrite the caller's state when the joined value refines to the value that
+// was there in the previous state.
+// This matters when the target path is a slice, because the slice might alias
+// another slice/index path and hence writing the pre-state value to the post-state
+// (instead of just relying on it being there already) might overwrite a previous effect.
+
+use mirai_annotations::*;
+
+fn read_exact(a: &[u8], buf: &mut [u8]) {
+    precondition!(buf.len() <= a.len());
+    if buf.len() == 1 {
+        buf[0] = a[0];
+    } else {
+        buf.copy_from_slice(a);
+    }
+}
+
+pub fn t1(c: &[u8]) {
+    precondition!(1 <= c.len());
+    let mut buf = [0; 1];
+    let _ = read_exact(c, &mut buf);
+    verify!(buf[0] == 0); //~ possible false verification condition
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/true_assumption.rs
+++ b/checker/tests/run-pass/true_assumption.rs
@@ -17,7 +17,7 @@ pub fn test_assume() {
 pub fn test_unreachable_assume() {
     let i = 1;
     if i != 1 {
-        assume!(i == 1); //~ this is unreachable, mark it as such by using the unreachable! macro
+        assume!(i == 1); //~ this is unreachable, mark it as such by using the verify_unreachable! macro
     }
 }
 


### PR DESCRIPTION
## Description

When slice and index paths get joined, they end up as two separate side-effects and the second one to be applied might undo the first one.  If the call site can collapse the join condition, one of the two side-effects will just write the pre-state into the post-state, which is unnecessary. Detecting and avoid this, fixes the interference for this special case. 

Also fix the wording of an unrelated diagnostic that caught my eye and exclude a crate that takes very long to analyze in strict mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem in strict mode
