### PR TITLE
Special case paths to fields of structs that looks like fat pointers

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -180,6 +180,7 @@ impl MiraiCallbacks {
         || file_name.contains("mempool/src")
         || file_name.contains("network/src") // you should never look at the bits of a ZST 
         || file_name.contains("network/builder/src")    
+        || file_name.contains("network/simple-onchain-discovery/src")    
         || file_name.contains("secure/push-metrics/src")    
         || file_name.contains("secure/net/src")
         || file_name.contains("secure/storage/src")    

--- a/checker/tests/run-pass/drop.rs
+++ b/checker/tests/run-pass/drop.rs
@@ -9,18 +9,17 @@
 use mirai_annotations::*;
 
 struct Guard<'a> {
-    j: i32,
     i: &'a mut i32,
 }
 
 impl Drop for Guard<'_> {
     fn drop(&mut self) {
-        *self.i = self.j;
+        *self.i = 100;
     }
 }
 
 fn call_guard(i: &mut i32) {
-    let _ = Guard { j: 100, i };
+    let _ = Guard { i };
 }
 
 pub fn t1() {


### PR DESCRIPTION
## Description

Special case paths to fields of structs that looks like fat pointers. Whereas other selectors implicitly dereference the thin parts of fat pointers, fields do not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
