### PR TITLE
Use source callsite when callee is known to be a macro

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -917,7 +917,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
 
         // If we never get here, rather call verify_unreachable!()
         if !entry_cond_as_bool.unwrap_or(true) {
-            let span = self.bv.current_span;
+            let span = self.bv.current_span.source_callsite();
             let message =
                 "this is unreachable, mark it as such by using the verify_unreachable! macro";
             let warning = self.bv.cv.session.struct_span_warn(span, message);
@@ -931,7 +931,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         }
 
         if function_name == KnownNames::MiraiPostcondition {
-            let span = self.bv.current_span;
+            let span = self.bv.current_span.source_callsite();
             let msg = if cond_as_bool.is_some() {
                 "provably false postcondition"
             } else {
@@ -946,7 +946,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         // If a verification condition is always false, give an error since that is bad style.
         if function_name == KnownNames::MiraiVerify && !cond_as_bool.unwrap_or(true) {
             // If the condition is always false, give a style error
-            let span = self.bv.current_span;
+            let span = self.bv.current_span.source_callsite();
             let error = self
                 .bv
                 .cv
@@ -996,7 +996,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         .expression
                         .contains_parameter())
             {
-                let span = self.bv.current_span;
+                let span = self.bv.current_span.source_callsite();
                 let warning = self.bv.cv.session.struct_span_warn(span, warning.as_str());
                 self.bv.emit_diagnostic(warning);
             }
@@ -1034,14 +1034,14 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     if self.bv.function_being_analyzed_is_root()
                         || self.bv.preconditions.len() >= k_limits::MAX_INFERRED_PRECONDITIONS
                     {
-                        let span = self.bv.current_span;
+                        let span = self.bv.current_span.source_callsite();
                         let warning = self.bv.cv.session.struct_span_warn(
                             span,
                             format!("the {} may have a {} tag", value_name, tag_name).as_str(),
                         );
                         self.bv.emit_diagnostic(warning);
                     } else if tag_check.expression.contains_local_variable() {
-                        let span = self.bv.current_span;
+                        let span = self.bv.current_span.source_callsite();
                         let warning = self.bv.cv.session.struct_span_warn(
                             span,
                             format!(
@@ -1059,7 +1059,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 Some(tag_check_result) if !tag_check_result => {
                     // The existence of the tag on the value is different from the expectation.
                     // In this case, report an error.
-                    let span = self.bv.current_span;
+                    let span = self.bv.current_span.source_callsite();
                     let error = self.bv.cv.session.struct_span_err(
                         span,
                         format!("the {} has a {} tag", value_name, tag_name).as_str(),
@@ -1086,7 +1086,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     condition,
                     message: Rc::from(format!("the {} may have a {} tag", value_name, tag_name)),
                     provenance: None,
-                    spans: vec![self.bv.current_span],
+                    spans: vec![self.bv.current_span.source_callsite()],
                 };
                 self.bv.preconditions.push(precondition);
             }

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -596,7 +596,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
                 // If we never get here, rather call verify_unreachable!()
                 if !entry_cond_as_bool.unwrap_or(true) {
-                    let span = self.block_visitor.bv.current_span;
+                    let span = self.block_visitor.bv.current_span.source_callsite();
                     let message =
                         "this is unreachable, mark it as such by using the verify_unreachable! macro";
                     let warning = self
@@ -618,7 +618,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 } else {
                     return;
                 };
-                let span = self.block_visitor.bv.current_span;
+                let span = self.block_visitor.bv.current_span.source_callsite();
                 let warning = self
                     .block_visitor
                     .bv
@@ -721,7 +721,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     path_cond = Some(true);
                 };
 
-                let span = self.block_visitor.bv.current_span;
+                let span = self.block_visitor.bv.current_span.source_callsite();
 
                 if path_cond.unwrap_or(false)
                     && self.block_visitor.bv.function_being_analyzed_is_root()


### PR DESCRIPTION
## Description

If a call is to a special (builtin) function, it may well be from a mirai_annotations macro, so make sure that any diagnostic about the call is redirected to the original source location of the macro invocation. This already happens when the diagnostic is printed out, but if the source location stored in the diagnostic itself still points inside the macro, the diagnostic will not be sorted in the right order.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
