### PR TITLE
Weaken index paths

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -614,7 +614,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 let message = if cond_as_bool == Some(true) {
                     "assumption is provably true and can be deleted"
                 } else if cond_as_bool == Some(false) {
-                    "assumption is provably false and it will be ignored in the assertion"
+                    "assumption is provably false and it will be ignored"
                 } else {
                     return;
                 };

--- a/checker/tests/run-pass/assume_provably_false.rs
+++ b/checker/tests/run-pass/assume_provably_false.rs
@@ -4,12 +4,12 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// A test that checks that a provably false assumption is ignored in the assertion.
+// A test that checks that a provably false assumption is ignored
 
 use mirai_annotations::*;
 
 pub fn main() {
     let a = 5;
-    assume!(a < 5); //~ assumption is provably false and it will be ignored in the assertion
-    verify!(a == 5);
+    assume!(a < 5); //~ assumption is provably false and it will be ignored
+    verify!(a < 5); //~ provably false verification condition
 }

--- a/checker/tests/run-pass/read_exact.rs
+++ b/checker/tests/run-pass/read_exact.rs
@@ -11,6 +11,7 @@
 // (instead of just relying on it being there already) might overwrite a previous effect.
 
 use mirai_annotations::*;
+use std::io::Read;
 
 fn read_exact(a: &[u8], buf: &mut [u8]) {
     precondition!(buf.len() <= a.len());
@@ -26,6 +27,18 @@ pub fn t1(c: &[u8]) {
     let mut buf = [0; 1];
     let _ = read_exact(c, &mut buf);
     verify!(buf[0] == 0); //~ possible false verification condition
+}
+
+fn read_u8(_self: &mut std::io::Cursor<&[u8]>) -> std::io::Result<u8> {
+    let mut buf = [0; 1];
+    _self.read_exact(&mut buf)?;
+    Ok(buf[0])
+}
+pub fn t2(val: &[u8]) -> std::io::Result<()> {
+    let mut reader = std::io::Cursor::new(val);
+    let num_nibbles = read_u8(&mut reader)? as usize;
+    verify!(num_nibbles == 0); //~ possible false verification condition
+    Ok(())
 }
 
 pub fn main() {}

--- a/checker/tests/run-pass/read_to_end.rs
+++ b/checker/tests/run-pass/read_to_end.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Tests that Cursor::read_to_end havocs the length of its parameter vector.
+
+use mirai_annotations::*;
+use std::io::{Cursor, Read, Result};
+
+pub fn t1(buf: &[u8]) -> Result<()> {
+    let mut reader = Cursor::new(buf);
+    let mut v = Vec::with_capacity(1);
+    reader.read_to_end(&mut v)?;
+    verify!(v.len() == 0); //~ possible false verification condition
+    Ok(())
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When index paths can be altered via an aliasing slice, they must be weakened all the way to top.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
