### PR TITLE
Do not check preconditions of unreachable calls

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2368,6 +2368,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     #[logfn_inputs(TRACE)]
     pub fn check_preconditions_if_necessary(&mut self, function_summary: &Summary) {
         if self.block_visitor.bv.check_for_errors
+            && self
+                .block_visitor
+                .bv
+                .current_environment
+                .entry_condition
+                .as_bool_if_known()
+                .unwrap_or(true)
             && !self.block_visitor.bv.assume_preconditions_of_next_call
             && !self
                 .block_visitor
@@ -2419,6 +2426,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 // The precondition is definitely true.
                 continue;
             };
+
+            if !entry_cond_as_bool.unwrap_or(true) {
+                // The call is unreachable, so the precondition does not matter
+                continue;
+            }
 
             let warn;
             if !refined_precondition_as_bool.unwrap_or(true) {

--- a/checker/tests/run-pass/assume.rs
+++ b/checker/tests/run-pass/assume.rs
@@ -8,21 +8,24 @@
 
 use mirai_annotations::*;
 
-pub fn main() {
-    foo(2); // This breaks an assumed pre-condition and leads to a runtime failure.
-            // It is not checked by Mirai, because of the assumption.
-            // Unlike this test case, in real life assumptions are made for complicated reasons that are
-            // hard to encode in checked preconditions.
-    foo2(2); //~ assertion failed: `(left == right)`
-             // This gives a diagnostic because foo2 asserts i == 3 which gets promoted to a precondition
+pub fn t1() {
+    foo1(2); // This breaks an assumed pre-condition and leads to a runtime failure.
+             // It is not checked by Mirai, because of the assumption.
+             // Unlike this test case, in real life assumptions are made for complicated reasons that are
+             // hard to encode in checked preconditions.
 }
 
-pub fn foo(i: i32) {
-    checked_assume!(i == 3); // this is a pre-condition that is assumed to hold.
+pub fn foo1(i: i32) {
+    checked_assume!(i == 3); // this is a pre-condition that is assumed to hold at call sites.
                              // It is not promoted, but it is checked here at runtime.
     let x = if i == 3 { 1 } else { 2 };
     verify!(x == 1); // This is neither true, nor checked at runtime, but it can only fail if
                      // the assumption above, which is checked at runtime, does not fail.
+}
+
+pub fn t2() {
+    foo2(2); //~ assertion failed: `(left == right)`
+             // This gives a diagnostic because foo2 asserts i == 3 which gets promoted to a precondition
 }
 
 fn foo2(i: i32) {
@@ -30,5 +33,7 @@ fn foo2(i: i32) {
     assert_eq!(i, 3); //~ related location
     let x = if i == 3 { 1 } else { 2 };
     verify!(x == 1); // This is neither true, nor checked at runtime, but it can only fail if
-                     // the first verify fails, so the problem is already pointed out and we need not repeat ourselves.
+                     // the assert_eq fails, so the problem is already pointed out and we need not repeat ourselves.
 }
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Do not check preconditions of unreachable calls. We analyze unreachable blocks to discover ugly things like "assume!(false)", but since they are unreachable, most of the analysis is useless and should not result in diagnostics. Such diagnostics are particularly irksome since any assumptions that are added to shut them up, attract diagnostics to the effect of "why are you assuming something in unreachable code?".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
