### PR TITLE
Havoc index paths when the index becomes widened

### DIFF
--- a/checker/tests/run-pass/plus_one.rs
+++ b/checker/tests/run-pass/plus_one.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that array index assignments get weakened appropriately inside loop bodies
+
+use mirai_annotations::*;
+
+pub fn plus_one(key: [u8; 32]) {
+    let mut buf = key.to_vec();
+    for i in (0..32).rev() {
+        if buf[i] == 255 {
+            buf[i] = 0;
+            // If the above does a strong update on a widened i, then this branch will be
+            // unreachable in the next loop iteration and the diagnostic below will be suppressed.
+            bar(i); //~ possible unsatisfied precondition
+        } else {
+            buf[i] += 1;
+            break;
+        }
+    }
+}
+
+fn bar(i: usize) {
+    precondition!(i > 1); //~ related location
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

A widened index is like a pattern because it changes from one loop iteration to the next, so havoc index paths when the index becomes widened.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

