### PR TITLE
Do not infer thin pointer path types

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1131,13 +1131,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let target_type = ExpressionType::from(
                 type_visitor::get_target_type(self.actual_argument_types[0]).kind(),
             );
-            let source_thin_pointer_path = Path::get_path_to_thin_pointer_at_offset_0(
+            let (source_thin_pointer_path, _) = Path::get_path_to_thin_pointer_at_offset_0(
                 self.block_visitor.bv.tcx,
                 &self.block_visitor.bv.current_environment,
                 &source_pointer_path,
                 source_pointer_rustc_type,
             )
-            .unwrap_or(source_pointer_path);
+            .unwrap_or((source_pointer_path, source_pointer_rustc_type));
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
                 .canonicalize(&self.block_visitor.bv.current_environment);
             trace!("MiraiAddTag: tagging {:?} with {:?}", tag, source_path);
@@ -1219,13 +1219,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let target_type = ExpressionType::from(
                 type_visitor::get_target_type(self.actual_argument_types[0]).kind(),
             );
-            let source_thin_pointer_path = Path::get_path_to_thin_pointer_at_offset_0(
+            let (source_thin_pointer_path, _) = Path::get_path_to_thin_pointer_at_offset_0(
                 self.block_visitor.bv.tcx,
                 &self.block_visitor.bv.current_environment,
                 &source_pointer_path,
                 source_pointer_rustc_type,
             )
-            .unwrap_or(source_pointer_path);
+            .unwrap_or((source_pointer_path, source_pointer_rustc_type));
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
                 .canonicalize(&self.block_visitor.bv.current_environment);
             trace!(
@@ -2056,7 +2056,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     &source_path,
                     source_rustc_type,
                 )
-                .unwrap_or(source_path);
+                .unwrap_or((source_path, target_rustc_type))
+                .0;
             } else if type_visitor::is_thin_pointer(&source_rustc_type.kind()) {
                 target_path = Path::get_path_to_thin_pointer_at_offset_0(
                     self.block_visitor.bv.tcx,
@@ -2064,7 +2065,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     &target_path,
                     target_rustc_type,
                 )
-                .unwrap_or(target_path);
+                .unwrap_or((target_path, source_rustc_type))
+                .0;
             }
 
             fn add_leaf_fields_for<'a>(


### PR DESCRIPTION
## Description

The type of a thin pointer is already known when a thin pointer path is constructed, so it may as well be returned to the caller who then does not have to infer it from the path.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
