### PR TITLE
Specialize opaque closures when adding closure fields

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1166,7 +1166,9 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                         } = &tpath.value
                         {
                             match selector.as_ref() {
-                                PathSelector::Field(0) | PathSelector::UnionField { .. } => {
+                                PathSelector::Field(0)
+                                | PathSelector::Slice(..)
+                                | PathSelector::UnionField { .. } => {
                                     // assign the pointer field of the slice pointer to the unqualified target
                                     tpath = qualifier.clone();
                                 }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -139,16 +139,20 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(file_name: &str) -> bool {
-        file_name.contains("consensus/safety-rules/src")
-        || file_name.contains("crypto/crypto/src")
+        file_name.contains("config/src") // Z3 encoding error  
+        || file_name.contains("config/management/src") // too slow
+        || file_name.contains("config/management/network-address-encryption/src") // Z3 encoding error  
+        || file_name.contains("config/management/operational/src") // Z3 encoding error     
+        || file_name.contains("consensus/safety-rules/src") // Z3 encoding error
+        || file_name.contains("json-rpc/src") // Z3 encoding error
         || file_name.contains("language/bytecode-verifier/src") // too slow
         || file_name.contains("language/move-lang/src") // too slow
         || file_name.contains("language/move-model/src") // too slow
         || file_name.contains("language/move-prover/bytecode/src") // too slow 
         || file_name.contains("language/tools/move-coverage/src") // too slow    
         || file_name.contains("language/vm/src") // too slow
-        || file_name.contains("network/network-address/src")
-        || file_name.contains("secure/storage/vault/src")
+        || file_name.contains("secure/storage/vault/src")  // Z3 encoding error
+        || file_name.contains("state-sync/src") // Z3 encoding error
         || file_name.contains("state-synchronizer/src") // Z3 encoding error
         || file_name.contains("types/src") // too slow
     }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -98,8 +98,11 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                         .insert_mut(closure_field_path, closure_field_val);
                 }
             }
-            TyKind::Opaque(def_id, ..) => {
-                self.add_any_closure_fields_for(self.tcx.type_of(*def_id), path, first_state);
+            TyKind::Opaque(def_id, substs) => {
+                let map = self.get_generic_arguments_map(*def_id, substs, &[]);
+                let path_ty =
+                    self.specialize_generic_argument_type(self.tcx.type_of(*def_id), &map);
+                self.add_any_closure_fields_for(path_ty, path, first_state);
             }
             TyKind::FnDef(..) | TyKind::FnPtr(..) => {}
             _ => {


### PR DESCRIPTION
## Description

Specialize opaque closures when adding closure fields.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
