### PR TITLE
Make Diem build work for paranoid mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,14 +232,14 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
 dependencies = [
  "cc",
  "libc",
  "log",
- "rustc_version",
+ "rustversion",
  "winapi",
 ]
 
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
 
 [[package]]
 name = "parking_lot"
@@ -540,13 +540,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
+name = "rustversion"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "same-file"
@@ -568,21 +565,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -33,7 +33,7 @@ itertools = "*"
 rand = "*"
 rpds = { version = "*", features = ["serde"] }
 serde = {version = "*", features = ["derive", "alloc", "rc"] }
-tar = "*"
+tar = "0.4.33"
 sled = "*"
 shellwords = "*"
 tempfile = "*"

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -683,11 +683,11 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             DiagLevel::PARANOID => {
                 if self.bv.check_for_errors && self.might_be_reachable() {
                     // Give a diagnostic about this call, and make it the programmer's problem.
-                    let error = self.bv.cv.session.struct_span_err(
+                    let warning = self.bv.cv.session.struct_span_warn(
                         self.bv.current_span,
                         "the called function could not be summarized, all bets are off",
                     );
-                    self.bv.emit_diagnostic(error);
+                    self.bv.emit_diagnostic(warning);
                 }
             }
         }

--- a/checker/src/fixed_point_visitor.rs
+++ b/checker/src/fixed_point_visitor.rs
@@ -161,14 +161,14 @@ impl<'fixed, 'analysis, 'compilation, 'tcx, E>
             if changed {
                 if self.bv.cv.options.diag_level == DiagLevel::PARANOID {
                     let span = self.bv.current_span;
-                    let error = self.bv.cv.session.struct_span_err(
+                    let warning = self.bv.cv.session.struct_span_warn(
                         span,
                         &format!(
                             "Fixed point loop iterations exceeded limit of {}",
                             k_limits::MAX_FIXPOINT_ITERATIONS
                         ),
                     );
-                    self.bv.emit_diagnostic(error);
+                    self.bv.emit_diagnostic(warning);
                 } else {
                     warn!(
                         "Fixed point loop iterations {} exceeded limit of {} at {:?} in function {}.",


### PR DESCRIPTION
## Description

Downgrade paranoid mode diagnostics from error to warning so that builds don't stop.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
