### PR TITLE
Make strict mode sound

### DIFF
--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -58,14 +58,15 @@ pub enum DiagLevel {
     /// This minimizes false positives but can lead to a lot code not being analyzed
     /// while devirtualization isn't perfect and not all intrinsics have been modeled.
     RELAXED,
-    /// When a function calls another function without a body or summary, it assumes that the called
-    /// function is angelic and that it has no preconditions and no post condition. Analysis of the
-    /// caller continues optimistically. This can lead to false positives because of the missing
-    /// post conditions and imprecision can be amplified if the missing function occurs deep down
-    /// in a long call chain.
+    /// Always emit at least one diagnostic for functions that cannot be fully analyzed because of
+    /// time-outs or calls to functions without bodies or foreign function summaries. In this mode
+    /// the analysis is sound because every potential issue in analyzed has a related diagnostic,
+    /// but it is also angelic because it assumes that argument values provided by code that is not
+    /// being analyzed will never cause the program to wrong, i.e. that non analyzed code is "angelic".
     STRICT,
-    /// When a function calls another function without a body or summary, a diagnostic is generated
-    /// to flag the call as a problem. Analysis of the caller then proceeds as in the STRICT case.
+    /// Like strict, but issues diagnostics if non analyzed code can provide arguments will cause
+    /// the analyzed code to go wrong. I.e. it requires all preconditions to be explicit.
+    /// This mode should be used for any library whose callers are not known and there not analyzed.
     PARANOID,
 }
 

--- a/checker/tests/run-pass/test_source.rs
+++ b/checker/tests/run-pass/test_source.rs
@@ -15,7 +15,7 @@ fn some_test() {
 
 #[test]
 fn another_test() {
-    verify!(2 == 1); //~provably false verification condition
+    verify!(2 == 1); //~ provably false verification condition
 }
 
 #[test]
@@ -31,12 +31,11 @@ fn no_summary_analyzed_anyway() {
     }
     let d: &dyn Dynamic = &S {} as &dyn Dynamic; // forget type info of S
 
-    // With --diag=strict we still see an error even though d.f is uninterpreted.
-    verify!(d.f(1) == 3); //~ possible false verification condition
-    verify!(3 == 4); //~provably false verification condition
+    let i = d.f(1); //~ the called function could not be summarized, all bets are off
+    verify!(i == 3); // ignored because the previous unresolved call makes every subsequent thing moot
 }
 
-pub fn not_a_test() {
-    // Should not complain because it is not a test function.
+pub fn main() {
+    // Should not complain because it is not a test function and therefore not analyzed.
     verify!(2 == 1);
 }


### PR DESCRIPTION
## Description

Change strict mode to give a diagnostic when there is a call to an unresolved function or a function without a body or a foreign function without a summary. With that strict mode becomes "sound" in as much that any actual problems in the code under analysis will attract at least one diagnostic, if only "this function can't be analyzed". Code that is not under analysis, i.e. code that may call public functions of the code under analysis, is assumed to be "angelic" in as much as any inferred precondition of the code under analysis is assumed to be honored by such code. This means that there are no diagnostics for code that could break if called incorrectly, which currently seems like a good way to reduce number of diagnostics to investigate and the need for writing annotations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem (in strict mode)