### PR TITLE
Tweak type inference

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -636,7 +636,15 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                             | Expression::InitialParameterValue { path: ipath, .. }
                             | Expression::Variable { path: ipath, .. } => {
                                 if (*path) == *ipath || path.is_rooted_by(ipath) {
-                                    let param_path_root = Path::new_parameter(i + 1);
+                                    let mut param_path_root = Path::new_parameter(i + 1);
+                                    if matches!(&arg_val.expression, Expression::Reference(..)) {
+                                        let deref_type = self
+                                            .bv
+                                            .type_visitor
+                                            .get_target_path_type(ipath, self.bv.current_span);
+                                        param_path_root =
+                                            Path::new_deref(param_path_root, deref_type);
+                                    }
                                     let param_path = path.replace_root(ipath, param_path_root);
                                     result.push((param_path, value.clone()));
                                     break;

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1607,8 +1607,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     #[logfn_inputs(TRACE)]
     fn handle_copy_non_overlapping(&mut self) {
         checked_assume!(self.actual_args.len() == 3);
-        let source_path = Path::get_as_path(self.actual_args[0].1.clone());
-        let target_root = Path::get_as_path(self.actual_args[1].1.clone());
+        let source_path = Path::new_deref(
+            Path::get_as_path(self.actual_args[0].1.clone()),
+            ExpressionType::NonPrimitive,
+        );
+        let target_root = Path::new_deref(
+            Path::get_as_path(self.actual_args[1].1.clone()),
+            ExpressionType::NonPrimitive,
+        );
         let count = self.actual_args[2].1.clone();
         let target_path = Path::new_slice(target_root, count);
         let collection_type = self.actual_argument_types[0];
@@ -1677,8 +1683,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     fn handle_swap_non_overlapping(&mut self) {
         checked_assume!(self.actual_args.len() == 3);
         let ty = self.actual_argument_types[0];
-        let target_root = Path::get_as_path(self.actual_args[0].1.clone());
-        let source_root = Path::get_as_path(self.actual_args[1].1.clone());
+        let target_root = Path::new_deref(
+            Path::get_as_path(self.actual_args[0].1.clone()),
+            ExpressionType::NonPrimitive,
+        );
+        let source_root = Path::new_deref(
+            Path::get_as_path(self.actual_args[1].1.clone()),
+            ExpressionType::NonPrimitive,
+        );
         let count = self.actual_args[2].1.clone();
         let source_slice = Path::new_slice(source_root.clone(), count.clone());
         let target_slice = Path::new_slice(target_root.clone(), count.clone());

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -108,9 +108,7 @@ impl Environment {
                             // deref_true_path is now the canonical version of true_path
                             deref_true_path
                         } else {
-                            // The selector implicit dereferences true_path, so deref_true_path.selector
-                            // is thus a shorter version, which should be canonical.
-                            Path::new_qualified(deref_true_path, selector.clone())
+                            Path::new_qualified(true_path, selector.clone())
                         }
                     } else {
                         Path::new_qualified(true_path, selector.clone())
@@ -123,9 +121,7 @@ impl Environment {
                             // deref_false_path is now the canonical version of false_path
                             deref_false_path
                         } else {
-                            // The selector implicit dereferences true_path, so deref_false_path.selector
-                            // is thus a shorter version, which should be canonical.
-                            Path::new_qualified(deref_false_path, selector.clone())
+                            Path::new_qualified(false_path, selector.clone())
                         }
                     } else {
                         Path::new_qualified(false_path, selector.clone())

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -95,8 +95,8 @@ impl Path {
     /// A split path, however, can serve as the qualifier of a newly constructed qualified path
     /// and the qualified path might not be canonical. This routine tries to remove the two sources of
     /// de-canonicalization that are currently know. Essentially: when a path that binds to a value
-    /// that is a reference is implicitly dereferenced by the selector, the canonical path will
-    /// be the one without the reference, or the actual heap block, if the path binds to a heap
+    /// that is a reference is explicitly dereferenced by the selector, the canonical path will
+    /// be the one without the ref-deref, or the actual heap block, if the path binds to a heap
     /// location. This routine returns a re-canonicalized path in the two scenarios above,
     /// otherwise returns `None`.
     ///


### PR DESCRIPTION
## Description

Various tweaks that fix type inference related problems. Mainly introducing explicit de-refs, but also a generic specialization bug and 
a bug in get_dereferenced_type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
