### PR TITLE
Tweak offset canonicalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "rpds"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56481afe084b54bb78bf63b9914dddef620d786af556530e0fad1398eaf11b2a"
+checksum = "387f58b714cda2b5042ef9e91819445f60189900b618475186b11d7876f6adb4"
 dependencies = [
  "archery",
  "serde",

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2917,12 +2917,6 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     /// Returns an element that is "self.other".
     #[logfn_inputs(TRACE)]
     fn offset(&self, other: Rc<AbstractValue>) -> Rc<AbstractValue> {
-        if matches!(
-            other.expression,
-            Expression::CompileTimeConstant(ConstantDomain::I128(0))
-        ) {
-            return self.clone();
-        }
         if let Expression::Offset { left, right } = &self.expression {
             AbstractValue::make_binary(left.clone(), right.addition(other), |left, right| {
                 Expression::Offset { left, right }


### PR DESCRIPTION
## Description

Do not simplify offset(p, 0) to just p during expression construction because *p and *offset(p, 0) are not the same when p points to an array.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
