### PR TITLE
Special case deref for boxed values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
  "serde",
@@ -62,9 +62,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
+checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
 
 [[package]]
 name = "parking_lot"

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -4231,9 +4231,8 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             Expression::InitialParameterValue { path, var_type } => {
                 let refined_path =
                     path.refine_parameters_and_paths(args, result, pre_env, pre_env, fresh);
-                if let PathEnum::Computed { value }
-                | PathEnum::HeapBlock { value }
-                | PathEnum::Offset { value } = &refined_path.value
+                if let PathEnum::Computed { value } | PathEnum::Offset { value } =
+                    &refined_path.value
                 {
                     return value.clone();
                 } else if let Some(val) = pre_env.value_at(&refined_path) {

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -110,8 +110,8 @@ impl Path {
                 return Some(path.clone());
             }
         } else if let Some(value) = environment.value_map.get(path) {
-            if let Expression::HeapBlock { .. } = &value.expression {
-                return Some(Path::get_as_path(value.clone()));
+            if let Expression::Reference(path) = &value.expression {
+                return Some(path.clone());
             }
         }
         None


### PR DESCRIPTION
## Description

Prepare for the removal of get_path_to_thin_pointer_at_offset_0 and its associated complexity by adding an explicit special case for dereferencing boxed values.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
