### PR TITLE
Stop using get_path_to_thin_pointer_at_offset_0 in tag checking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,7 @@ coverage:
   range: 60..85
   round: down
   precision: 0
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
-name = "cc"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,28 +109,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
- "loom",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if",
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -231,19 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,17 +312,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -540,12 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,12 +515,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1134,18 +1134,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         precondition!(self.actual_args.len() == 1);
 
         if let Some(tag) = self.extract_tag_kind_and_propagation_set() {
-            let source_pointer_path = Path::get_as_path(self.actual_args[0].1.clone());
+            let source_pointer_path = self.actual_args[0].0.clone();
             let source_pointer_rustc_type = self.actual_argument_types[0];
             let target_type = ExpressionType::from(
-                type_visitor::get_target_type(self.actual_argument_types[0]).kind(),
+                type_visitor::get_target_type(source_pointer_rustc_type).kind(),
             );
-            let (source_thin_pointer_path, _) = Path::get_path_to_thin_pointer_at_offset_0(
-                self.block_visitor.bv.tcx,
-                &self.block_visitor.bv.current_environment,
-                &source_pointer_path,
-                source_pointer_rustc_type,
-            )
-            .unwrap_or((source_pointer_path, source_pointer_rustc_type));
+            let source_thin_pointer_path =
+                Path::get_path_to_thin_pointer(source_pointer_path, source_pointer_rustc_type);
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
                 .canonicalize(&self.block_visitor.bv.current_environment);
             trace!("MiraiAddTag: tagging {:?} with {:?}", tag, source_path);
@@ -1222,18 +1217,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
         let result: Option<Rc<AbstractValue>>;
         if let Some(tag) = self.extract_tag_kind_and_propagation_set() {
-            let source_pointer_path = Path::get_as_path(self.actual_args[0].1.clone());
+            let source_pointer_path = self.actual_args[0].0.clone();
             let source_pointer_rustc_type = self.actual_argument_types[0];
             let target_type = ExpressionType::from(
-                type_visitor::get_target_type(self.actual_argument_types[0]).kind(),
+                type_visitor::get_target_type(source_pointer_rustc_type).kind(),
             );
-            let (source_thin_pointer_path, _) = Path::get_path_to_thin_pointer_at_offset_0(
-                self.block_visitor.bv.tcx,
-                &self.block_visitor.bv.current_environment,
-                &source_pointer_path,
-                source_pointer_rustc_type,
-            )
-            .unwrap_or((source_pointer_path, source_pointer_rustc_type));
+            let source_thin_pointer_path =
+                Path::get_path_to_thin_pointer(source_pointer_path, source_pointer_rustc_type);
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
                 .canonicalize(&self.block_visitor.bv.current_environment);
             trace!(


### PR DESCRIPTION
## Description

get_path_to_thin_pointer_at_offset_0 is too general, so introduce get_path_to_thin_pointer, which only returns a qualified path if the type of the given base path is one of the types that are known to behave like fat pointers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
