### PR TITLE
Get rid of get_path_to_thin_pointer_at_offset_0

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -1017,7 +1017,14 @@ impl PathRefinement for Rc<Path> {
                     Expression::Variable { path, .. } => {
                         return Path::new_qualified(path.clone(), selector.clone());
                     }
-                    _ => {}
+                    _ => {
+                        if **selector == PathSelector::Deref {
+                            return Path::new_qualified(
+                                Path::get_as_path(value.clone()),
+                                selector.clone(),
+                            );
+                        }
+                    }
                 }
             }
             // An impossible downcast is equivalent to BOTTOM


### PR DESCRIPTION
## Description

(Almost) get rid of get_path_to_thin_pointer_at_offset_0. More to come.

The reason for this is that it is too general. Auto deref of fat pointers and boxes should be handled more explicitly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
