### PR TITLE
Fix type inference of thin pointer part of slice pointer

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1591,25 +1591,24 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             } = &value_path.value
             {
                 if let PathSelector::Deref = selector.as_ref() {
-                    let qualifier_type = self
-                        .bv
-                        .type_visitor
-                        .get_path_rustc_type(qualifier, self.bv.current_span);
-                    if type_visitor::is_slice_pointer(qualifier_type.kind()) {
-                        // de-referencing a slice pointer is normally the same as de-referencing its
-                        // thin pointer, so self.visit_lh_place above assumed that much.
-                        // In this context, however, we want the length of the slice pointer,
-                        // so we need to drop the thin pointer field selector.
-                        if let PathEnum::QualifiedPath {
-                            qualifier,
-                            selector,
-                            ..
-                        } = &qualifier.value
-                        {
-                            checked_assume!(matches!(selector.as_ref(), PathSelector::Field(0)));
-                            value_path = qualifier.clone();
-                        } else {
-                            assume_unreachable!("deref of a slice pointer did not produce ptr.0");
+                    // de-referencing a slice pointer is normally the same as de-referencing its
+                    // thin pointer, so self.visit_lh_place above assumed that much.
+                    // In this context, however, we want the length of the slice pointer,
+                    // so we need to drop the thin pointer field selector.
+                    if let PathEnum::QualifiedPath {
+                        qualifier,
+                        selector,
+                        ..
+                    } = &qualifier.value
+                    {
+                        if matches!(selector.as_ref(), PathSelector::Field(0)) {
+                            let qualifier_type = self
+                                .bv
+                                .type_visitor
+                                .get_path_rustc_type(qualifier, self.bv.current_span);
+                            if type_visitor::is_slice_pointer(qualifier_type.kind()) {
+                                value_path = qualifier.clone();
+                            }
                         }
                     }
                 } else {

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1137,6 +1137,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     let lh_type = self
                         .type_visitor
                         .get_path_rustc_type(&tpath, self.current_span);
+                    if let PathEnum::HeapBlock { .. } = &path.value {
+                        self.type_visitor
+                            .path_ty_cache
+                            .insert(path.clone(), type_visitor::get_target_type(lh_type));
+                    }
                     if type_visitor::is_slice_pointer(lh_type.kind()) {
                         if let PathEnum::QualifiedPath { selector, .. } = &tpath.value {
                             if matches!(selector.as_ref(), PathSelector::Field(0)) {

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1136,9 +1136,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         if let Some(tag) = self.extract_tag_kind_and_propagation_set() {
             let source_pointer_path = self.actual_args[0].0.clone();
             let source_pointer_rustc_type = self.actual_argument_types[0];
-            let target_type = ExpressionType::from(
-                type_visitor::get_target_type(source_pointer_rustc_type).kind(),
-            );
+            let source_rustc_type = type_visitor::get_target_type(source_pointer_rustc_type);
+            let target_type = ExpressionType::from(source_rustc_type.kind());
             let source_thin_pointer_path =
                 Path::get_path_to_thin_pointer(source_pointer_path, source_pointer_rustc_type);
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
@@ -1147,11 +1146,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
             // Check if the tagged value has a pointer type (e.g., a reference).
             // Emit an error message if so.
-            let source_rustc_type = self
-                .block_visitor
-                .bv
-                .type_visitor
-                .get_path_rustc_type(&source_path, self.block_visitor.bv.current_span);
             if self.block_visitor.bv.check_for_errors && source_rustc_type.is_any_ptr() {
                 let err = self.block_visitor.bv.cv.session.struct_span_err(
                     self.block_visitor.bv.current_span,
@@ -1219,9 +1213,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         if let Some(tag) = self.extract_tag_kind_and_propagation_set() {
             let source_pointer_path = self.actual_args[0].0.clone();
             let source_pointer_rustc_type = self.actual_argument_types[0];
-            let target_type = ExpressionType::from(
-                type_visitor::get_target_type(source_pointer_rustc_type).kind(),
-            );
+            let source_rustc_type = type_visitor::get_target_type(source_pointer_rustc_type);
+            let target_type = ExpressionType::from(source_rustc_type.kind());
             let source_thin_pointer_path =
                 Path::get_path_to_thin_pointer(source_pointer_path, source_pointer_rustc_type);
             let source_path = Path::new_deref(source_thin_pointer_path, target_type)
@@ -1235,11 +1228,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
 
             // Check if the tagged value has a pointer type (e.g., a reference).
             // Emit an error message if so.
-            let source_rustc_type = self
-                .block_visitor
-                .bv
-                .type_visitor
-                .get_path_rustc_type(&source_path, self.block_visitor.bv.current_span);
             if self.block_visitor.bv.check_for_errors && source_rustc_type.is_any_ptr() {
                 let err = self.block_visitor.bv.cv.session.struct_span_err(
                     self.block_visitor.bv.current_span,

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -627,6 +627,27 @@ impl ConstantDomain {
         }
     }
 
+    /// Returns the predefined rustc type that matches this constants.
+    /// Since there is no predefined type that matches a Function constant,
+    /// the predefined type never is returned in this case (as is for Bottom).
+    #[logfn(TRACE)]
+    pub fn get_rustc_type<'a>(&self, tcx: TyCtxt<'a>) -> Ty<'a> {
+        match self {
+            ConstantDomain::Bottom => tcx.types.never,
+            ConstantDomain::Char(..) => tcx.types.char,
+            ConstantDomain::False => tcx.types.bool,
+            ConstantDomain::Function(..) => tcx.types.never,
+            ConstantDomain::I128(..) => tcx.types.i128,
+            ConstantDomain::F64(..) => tcx.types.f64,
+            ConstantDomain::F32(..) => tcx.types.f32,
+            ConstantDomain::Str(..) => tcx.types.str_,
+            ConstantDomain::True => tcx.types.bool,
+            ConstantDomain::U128(..) => tcx.types.u128,
+            ConstantDomain::Unimplemented => tcx.types.trait_object_dummy_self,
+            ConstantDomain::Unit => tcx.types.unit,
+        }
+    }
+
     #[logfn(TRACE)]
     pub fn is_bottom(&self) -> bool {
         matches!(self, ConstantDomain::Bottom)


### PR DESCRIPTION
## Description

Fix some corner cases in get_path_rustc_type, most notably the type returned for the thin pointer part of a slice pointer.  Also fix up some uses of get_path_rustc_type that depended on the old behavior. Do not remove cached path type info for heap blocks that are part of promoted constants. Also update the path type cache for heap blocks imported via summaries.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
