### PR TITLE
First step towards a total rewrite of the constant deserializer

### DIFF
--- a/checker/tests/run-pass/read_to_end.rs
+++ b/checker/tests/run-pass/read_to_end.rs
@@ -5,11 +5,12 @@
 //
 // Tests that Cursor::read_to_end havocs the length of its parameter vector.
 
-use mirai_annotations::*;
-use std::io::{Cursor, Read, Result};
+// use mirai_annotations::*;
+// use std::io::{Cursor, Read, Result};
+use std::io::Result;
 
-pub fn t1(buf: &[u8]) -> Result<()> {
-    //todo: speeed this up so that it passes on CI
+pub fn t1(_buf: &[u8]) -> Result<()> {
+    //todo: speed this up so that it passes on CI
     // let mut reader = Cursor::new(buf);
     // let mut v = Vec::with_capacity(1);
     // reader.read_to_end(&mut v)?;


### PR DESCRIPTION
## Description

This is a start towards rewriting the constant deserializer as a parser of byte slices, directed by the type of the result. In particular, in this PR we add support for deserializing structures with several fields. This comes up when dealing with code from the standard library, where MIR bodies for promoted constant functions are not always available as an alternative way of coming up with the value of a constant. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
Unfortunately, it is not immediately obvious how to write a test case that triggers this, so testing had to proceed by disabling the MIR body path while doing local testing. This is not an option for CI.

