### PR TITLE
Flesh out most of the code needed to support ConstValue::ByRef constants

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -620,6 +620,19 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
         }
     }
 
+    /// Returns the size (including padding) and alignment, in bytes,  of an instance of the given type.
+    pub fn get_type_size_and_alignment(&self, ty: Ty<'tcx>) -> (u128, u128) {
+        let param_env = self.get_param_env();
+        if let Ok(ty_and_layout) = self.tcx.layout_of(param_env.and(ty)) {
+            (
+                ty_and_layout.layout.size.bytes() as u128,
+                ty_and_layout.align.pref.bytes() as u128,
+            )
+        } else {
+            (0, 8)
+        }
+    }
+
     #[logfn_inputs(TRACE)]
     fn specialize_const(
         &self,


### PR DESCRIPTION
## Description

Use deserialize_constant_bytes to parse all serialized constants that use the ConstValue::ByRef encoding.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
