### PR TITLE
Move Scalar::Ptr code

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -146,7 +146,6 @@ impl MiraiCallbacks {
         || file_name.contains("config/management/network-address-encryption/src") // Z3 encoding error  
         || file_name.contains("config/management/operational/src") // too slow and also Z3 encoding error    
         || file_name.contains("consensus/safety-rules/src") // Z3 encoding error
-        || file_name.contains("consensus/src") // not implemented     
         || file_name.contains("crypto/crypto/src") // Z3 encoding error    
         || file_name.contains("json-rpc/src") // Z3 encoding error
         || file_name.contains("language/bytecode-verifier/src") // too slow
@@ -154,14 +153,9 @@ impl MiraiCallbacks {
         || file_name.contains("language/move-model/src") // too slow
         || file_name.contains("language/move-prover/bytecode/src") // too slow 
         || file_name.contains("language/tools/move-coverage/src") // too slow
-        || file_name.contains("language/tools/move-explain/src") // not implemented  
-        || file_name.contains("language/tools/resource-viewer/src") // not implemented    
         || file_name.contains("language/vm/src") // too slow
-        || file_name.contains("network/simple-onchain-discovery/src") // not implemented
-        || file_name.contains("sdk/client/src") // not implemented    
+        || file_name.contains("sdk/client/src") // assertion failed    
         || file_name.contains("secure/storage/vault/src")  // Z3 encoding error do this first
-        || file_name.contains("storage/backup/backup-cli/src") // not implemented
-        || file_name.contains("storage/diemdb/src") // not implemented
         || file_name.contains("types/src") // too slow
     }
 


### PR DESCRIPTION
## Description

Reorganize all of the code that deals with deserializing constants encoded via Scalar::Ptr. Fix a bug by getting rid of visit_reference_to_array_constant.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
