### PR TITLE
Reference and Offset tweaks

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1054,7 +1054,6 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(result.into());
             }
         };
-        //todo: if self is a pointer then special case ptr & 1.
         AbstractValue::make_binary(self.clone(), other, |left, right| Expression::BitAnd {
             left,
             right,

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1153,7 +1153,9 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     let lh_type = self
                         .type_visitor
                         .get_path_rustc_type(&tpath, self.current_span);
-                    if let PathEnum::HeapBlock { .. } = &path.value {
+                    if !self.type_visitor.path_ty_cache.contains_key(path)
+                        && path.is_rooted_by_non_local_structure()
+                    {
                         self.type_visitor
                             .path_ty_cache
                             .insert(path.clone(), type_visitor::get_target_type(lh_type));

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -140,14 +140,10 @@ impl MiraiCallbacks {
 
     fn is_excluded(file_name: &str) -> bool {
         file_name.contains("client/swiss-knife/src") // too slow 
-        || file_name.contains("config/src") // Z3 encoding error
         || file_name.contains("config/management/src") // too slow
         || file_name.contains("config/management/genesis/src") // too slow    
-        || file_name.contains("config/management/network-address-encryption/src") // Z3 encoding error  
-        || file_name.contains("config/management/operational/src") // too slow and also Z3 encoding error    
-        || file_name.contains("consensus/safety-rules/src") // Z3 encoding error
-        || file_name.contains("crypto/crypto/src") // Z3 encoding error    
-        || file_name.contains("json-rpc/src") // Z3 encoding error
+        || file_name.contains("config/management/operational/src") // too slow    
+        || file_name.contains("json-rpc/src") // stack overflow
         || file_name.contains("language/bytecode-verifier/src") // too slow
         || file_name.contains("language/move-lang/src") // too slow
         || file_name.contains("language/move-model/src") // too slow
@@ -155,7 +151,6 @@ impl MiraiCallbacks {
         || file_name.contains("language/tools/move-coverage/src") // too slow
         || file_name.contains("language/vm/src") // too slow
         || file_name.contains("sdk/client/src") // assertion failed    
-        || file_name.contains("secure/storage/vault/src")  // Z3 encoding error do this first
         || file_name.contains("types/src") // too slow
     }
 

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -1120,7 +1120,7 @@ impl Expression {
             Expression::Offset { .. } => ThinPointer,
             Expression::Reference(_) => ThinPointer,
             Expression::InitialParameterValue { var_type, .. } => var_type.clone(),
-            Expression::Rem { left, .. } => left.expression.infer_type(),
+            Expression::Rem { right, .. } => right.expression.infer_type(),
             Expression::Shl { left, .. } => left.expression.infer_type(),
             Expression::ShlOverflows { .. } => Bool,
             Expression::Shr { result_type, .. } => result_type.clone(),

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1759,6 +1759,7 @@ impl Z3Solver {
             Expression::IntrinsicBitVectorUnary { .. } => self.bv_fresh_const(num_bits),
             Expression::Join { path, .. } => self.bv_join(num_bits, path),
             Expression::Neg { operand } => self.bv_neg(num_bits, operand),
+            Expression::Offset { .. } => self.bv_fresh_const(num_bits),
             Expression::Reference(path) => self.bv_reference(num_bits, path),
             Expression::Shl { left, right } => {
                 self.bv_binary(num_bits, left, right, z3_sys::Z3_mk_bvshl)


### PR DESCRIPTION
## Description

Tweak the transfer logic for references to better keep track of path types. Tweak remainder operation on Offset values, and how Offset values are encoded as bit vectors in Z3.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
