### PR TITLE
Use deserialize_constant_array for all [ref](array|slice) constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
+checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -150,7 +150,6 @@ impl MiraiCallbacks {
         || file_name.contains("language/move-prover/bytecode/src") // too slow 
         || file_name.contains("language/tools/move-coverage/src") // too slow
         || file_name.contains("language/vm/src") // too slow
-        || file_name.contains("sdk/client/src") // assertion failed    
         || file_name.contains("types/src") // too slow
     }
 


### PR DESCRIPTION
## Description

Use deserialize_constant_array for all [ref](array|slice) constants

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
