### PR TITLE
Update the path type cache in one place only

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2085,7 +2085,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         }
                     }
                 };
-                self.bv.type_visitor.path_ty_cache.insert(path.clone(), lty);
+                self.bv.type_visitor.set_path_rustc_type(path.clone(), lty);
                 let val_at_path = self.bv.lookup_path_and_refine_result(path, lty);
                 if let Expression::Variable { .. } = &val_at_path.expression {
                     // Seems like there is nothing at the path, but...
@@ -2359,8 +2359,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
     ) -> &'a [u8] {
         self.bv
             .type_visitor
-            .path_ty_cache
-            .insert(target_path.clone(), ty);
+            .set_path_rustc_type(target_path.clone(), ty);
         match ty.kind() {
             TyKind::Adt(def, substs) => {
                 trace!("deserializing {:?} {:?}", def, substs);
@@ -2957,8 +2956,13 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             }
             _ => (),
         };
-        if !self.bv.type_visitor.path_ty_cache.contains_key(&path) {
-            self.bv.type_visitor.path_ty_cache.insert(path.clone(), ty);
+        if !self
+            .bv
+            .type_visitor
+            .get_path_type_cache()
+            .contains_key(&path)
+        {
+            self.bv.type_visitor.set_path_rustc_type(path.clone(), ty);
         }
         path
     }
@@ -3066,8 +3070,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                             Path::new_deref(thin_pointer_path, ExpressionType::from(ty.kind()));
                         self.bv
                             .type_visitor
-                            .path_ty_cache
-                            .insert(deref_path.clone(), ty);
+                            .set_path_rustc_type(deref_path.clone(), ty);
                         result = deref_path;
                         continue;
                     } else {

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1152,12 +1152,13 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                     let lh_type = self
                         .type_visitor
                         .get_path_rustc_type(&tpath, self.current_span);
-                    if !self.type_visitor.path_ty_cache.contains_key(path)
+                    if !self.type_visitor.get_path_type_cache().contains_key(path)
                         && path.is_rooted_by_non_local_structure()
                     {
-                        self.type_visitor
-                            .path_ty_cache
-                            .insert(path.clone(), type_visitor::get_target_type(lh_type));
+                        self.type_visitor.set_path_rustc_type(
+                            path.clone(),
+                            type_visitor::get_target_type(lh_type),
+                        );
                     }
                     if type_visitor::is_slice_pointer(lh_type.kind()) {
                         if let PathEnum::QualifiedPath { selector, .. } = &tpath.value {
@@ -2271,8 +2272,7 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
             .clone();
         let block_path = Path::get_as_path(block.clone());
         self.type_visitor
-            .path_ty_cache
-            .insert(block_path.clone(), ty);
+            .set_path_rustc_type(block_path.clone(), ty);
         let layout_path = Path::new_layout(block_path);
         let layout = AbstractValue::make_from(
             Expression::HeapBlockLayout {

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -30,7 +30,7 @@ pub struct TypeVisitor<'tcx> {
     pub generic_argument_map: Option<HashMap<rustc_span::Symbol, GenericArg<'tcx>>>,
     pub generic_arguments: Option<SubstsRef<'tcx>>,
     pub mir: &'tcx mir::Body<'tcx>,
-    pub path_ty_cache: HashMap<Rc<Path>, Ty<'tcx>>,
+    path_ty_cache: HashMap<Rc<Path>, Ty<'tcx>>,
     pub dummy_untagged_value_type: Ty<'tcx>,
     tcx: TyCtxt<'tcx>,
 }
@@ -91,7 +91,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                         qualifier = Path::new_deref(path.clone(), ExpressionType::NonPrimitive)
                     }
                     let closure_field_path = Path::new_field(qualifier, i);
-                    self.path_ty_cache.insert(closure_field_path.clone(), ty);
+                    self.set_path_rustc_type(closure_field_path.clone(), ty);
                     let closure_field_val =
                         AbstractValue::make_typed_unknown(var_type, closure_field_path.clone());
                     first_state
@@ -155,6 +155,17 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
             self.def_id
         };
         self.tcx.param_env(env_def_id)
+    }
+
+    /// Returns a shared reference to the path type cache of the visitor
+    pub fn get_path_type_cache(&self) -> &HashMap<Rc<Path>, Ty<'tcx>> {
+        &self.path_ty_cache
+    }
+
+    /// Updates the type cache of the visitor so that looking up the type of path returns ty.
+    #[logfn_inputs(DEBUG)]
+    pub fn set_path_rustc_type(&mut self, path: Rc<Path>, ty: Ty<'tcx>) {
+        self.path_ty_cache.insert(path, ty);
     }
 
     /// This is a hacky and brittle way to navigate the Rust compiler's type system.


### PR DESCRIPTION
## Description

Update the path type cache in one place only, in order to reduce duplicated code and make setting break points easier.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
