### PR TITLE
Try to keep actual argument types concrete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "lock_api"

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2687,7 +2687,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     pub fn add_post_condition_to_exit_conditions(&mut self, function_summary: &Summary) {
         let destination = self.destination;
         if let Some((place, target)) = &destination {
-            let target_path = self.block_visitor.visit_rh_place(place);
+            let target_path = self.block_visitor.visit_lh_place(place);
             let result_path = &Some(target_path);
             let mut exit_condition = self
                 .block_visitor


### PR DESCRIPTION
## Description

When the rustc type for an actual argument operand is not concrete, get the canonical path to the operand and infer the type of the path. That way aliases that abstract the type of the operand are removed from the path and the original, hopefully concrete, type can shine through and inform the summarization of the called function.

Doing so triggered a latent bug caused by aliasing enum values with unsafe wrappers, so that has also been fixed by adding special
case code to get_path_rustc_type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
