### PR TITLE
Special case for Self parameter that gets specialized to a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi",

--- a/checker/tests/run-pass/test_source.rs
+++ b/checker/tests/run-pass/test_source.rs
@@ -6,7 +6,7 @@
 
 use mirai_annotations::*;
 
-// MIRAI_FLAGS --test_only --diag=verify
+// MIRAI_FLAGS --test_only
 
 #[test]
 fn some_test() {
@@ -16,23 +16,6 @@ fn some_test() {
 #[test]
 fn another_test() {
     verify!(2 == 1); //~ provably false verification condition
-}
-
-#[test]
-fn no_summary_analyzed_anyway() {
-    trait Dynamic {
-        fn f(&self, x: u64) -> u64;
-    }
-    struct S;
-    impl Dynamic for S {
-        fn f(&self, x: u64) -> u64 {
-            return x + 1;
-        }
-    }
-    let d: &dyn Dynamic = &S {} as &dyn Dynamic; // forget type info of S
-
-    let i = d.f(1); //~ the called function did not resolve to an implementation with a MIR body
-    verify!(i == 3); // ignored because the previous unresolved call makes every subsequent thing moot
 }
 
 pub fn main() {

--- a/checker/tests/run-pass/trait_call.rs
+++ b/checker/tests/run-pass/trait_call.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Checks that calls via traits can be resolved if call site has enough type information
+
+// MIRAI_FLAGS --diag=verify
+
+use mirai_annotations::*;
+
+pub trait Tr {
+    fn bar(&self) -> i32;
+}
+
+struct Bar {
+    i: i32,
+}
+
+impl Tr for Bar {
+    fn bar(&self) -> i32 {
+        self.i
+    }
+}
+
+struct Foo {
+    bx: Box<dyn Tr>,
+}
+
+pub fn t1() {
+    let bar = Bar { i: 1 };
+    let foo = Foo {
+        bx: Box::new(bar) as Box<dyn Tr>,
+    };
+    let bi = foo.bx.bar();
+    verify!(bi == 1);
+}
+
+pub fn t2(t: &dyn Tr) {
+    let bi = t.bar(); //~ the called function did not resolve to an implementation with a MIR body
+    verify!(bi == 3); // ignored because the previous unresolved call makes every subsequent thing moot
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Fix specialization of the Self generic argument of a callee to override the specialized type of a field with the type of the actual self argument (stored in that field at the point of call), so that trait method resolution succeeds in this case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
