### PR TITLE
Track concrete ADT types of field reachable via parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "lock_api"
@@ -519,18 +519,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -617,6 +617,10 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 }
             }
         }
+        let adt_map = self
+            .bv
+            .type_visitor
+            .get_adt_map(&actual_args, &self.bv.current_environment);
 
         let known_name = func_ref_to_call.known_name;
         let func_const = ConstantDomain::Function(func_ref_to_call);
@@ -635,6 +639,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         call_visitor.destination = *destination;
         call_visitor.callee_fun_val = func_to_call;
         call_visitor.function_constant_args = func_const_args;
+        call_visitor.initial_type_cache = adt_map;
         trace!("calling func {:?}", call_visitor.callee_func_ref);
         if call_visitor.handled_as_special_function_call() {
             return;

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -620,11 +620,11 @@ impl<'analysis, 'compilation, 'tcx, E> BodyVisitor<'analysis, 'compilation, 'tcx
                 .bv
                 .cv
                 .summary_cache
-                .get_summary_for_call_site(&func_ref, None);
+                .get_summary_for_call_site(&func_ref, &None, &None);
             if cached_summary.is_computed {
                 cached_summary
             } else {
-                summary = call_visitor.create_and_cache_function_summary(None);
+                summary = call_visitor.create_and_cache_function_summary(&None, &None);
                 &summary
             }
         } else {

--- a/checker/tests/run-pass/trait_call.rs
+++ b/checker/tests/run-pass/trait_call.rs
@@ -24,6 +24,16 @@ impl Tr for Bar {
     }
 }
 
+struct BarTwo {
+    i: i32,
+}
+
+impl Tr for BarTwo {
+    fn bar(&self) -> i32 {
+        self.i * 2
+    }
+}
+
 struct Foo {
     bx: Box<dyn Tr>,
 }
@@ -40,6 +50,39 @@ pub fn t1() {
 pub fn t2(t: &dyn Tr) {
     let bi = t.bar(); //~ the called function did not resolve to an implementation with a MIR body
     verify!(bi == 3); // ignored because the previous unresolved call makes every subsequent thing moot
+}
+
+pub fn t3() {
+    let bar = Bar { i: 1 };
+    let t = &bar as &dyn Tr;
+    let bi = t3c(t);
+    verify!(bi == 1);
+}
+
+fn t3c(t: &dyn Tr) -> i32 {
+    t.bar()
+}
+
+pub fn t4() {
+    let bar = Bar { i: 1 };
+    let foo = Foo {
+        bx: Box::new(bar) as Box<dyn Tr>,
+    };
+    let bi = t4c(foo);
+    verify!(bi == 1);
+}
+
+pub fn t4a() {
+    let bar = BarTwo { i: 1 };
+    let foo = Foo {
+        bx: Box::new(bar) as Box<dyn Tr>,
+    };
+    let bi = t4c(foo);
+    verify!(bi == 2);
+}
+
+fn t4c(foo: Foo) -> i32 {
+    foo.bx.bar()
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

At a call site, see if any of the paths rooted in an argument path are known to be of an ADT type kind. If so, add the (path, ty) pair to a hash map that can be used to initialize the path type cache used to summarize the callee. Include the hash map in the key used to
find a summary that has already been computed for this type of call.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
