### PR TITLE
Add special case logic to handle cloning Option::None

### DIFF
--- a/checker/tests/run-pass/trait_call.rs
+++ b/checker/tests/run-pass/trait_call.rs
@@ -98,9 +98,18 @@ impl Clone for Box<dyn Tr> {
 
 pub fn t5() {
     let foo2 = Foo2 { opt: None };
-    //todo: find a way avoid the diagnostic for the None case
-    let c = foo2.opt.clone(); //~ the called function did not resolve to an implementation with a MIR body
-    verify!(c.is_none()); // succeeds because of fall back special case that is a member copy
+    let c = foo2.opt.clone();
+    verify!(c.is_none());
+}
+
+pub fn t6() {
+    let foo2 = Foo2 { opt: None };
+    let c = t6c(foo2);
+    verify!(c.is_none());
+}
+
+fn t6c(foo: Foo2) -> Option<Box<dyn Tr>> {
+    foo.opt.clone() //~ the called function did not resolve to an implementation with a MIR body
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Add special case logic to handle cloning Option::None. When cloning an Option<T> where T is trait, it is not possible to resolve to the
appropriate clone method, since the actual value stored in the option is unknown thus cannot be used to obtain the concrete type to use instead of T. On the other hand, cloning None can be done without any knowledge of T, so doing this as special case avoids false positive diagnostics about a failure to resolve Option<T>.resolve.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
