### PR TITLE
Add more special case logic to handle cloning Option::None

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "cc14fc54a812b4472b4113facc3e44d099fbc0ea2ce0551fa5c703f8edfbfd38"
 dependencies = [
  "autocfg",
 ]
@@ -597,9 +597,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -544,7 +544,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
     /// is more likely to be concrete. By seeding the initial type cache of a called function
     /// with this information, we can get resolution of trait calls where the receiver is a
     /// field reachable from a parameter, rather than the parameter itself.
-    #[logfn_inputs(DEBUG)]
+    #[logfn_inputs(TRACE)]
     pub fn get_adt_map(
         &self,
         actual_arguments: &[(Rc<Path>, Rc<AbstractValue>)],

--- a/checker/tests/run-pass/trait_call.rs
+++ b/checker/tests/run-pass/trait_call.rs
@@ -6,7 +6,7 @@
 
 // Checks that calls via traits can be resolved if call site has enough type information
 
-// MIRAI_FLAGS --diag=verify
+// MIRAI_FLAGS --diag=library
 
 use mirai_annotations::*;
 
@@ -38,7 +38,7 @@ struct Foo {
     bx: Box<dyn Tr>,
 }
 
-struct Foo2 {
+pub struct Foo2 {
     pub opt: Option<Box<dyn Tr>>,
 }
 
@@ -108,8 +108,12 @@ pub fn t6() {
     verify!(c.is_none());
 }
 
+pub fn t7(foo: Foo2) {
+    let _c = t6c(foo); //~ possible incomplete analysis of call because of failure to resolve std::Clone::clone method
+}
+
 fn t6c(foo: Foo2) -> Option<Box<dyn Tr>> {
-    foo.opt.clone() //~ the called function did not resolve to an implementation with a MIR body
+    foo.opt.clone() //~ related location
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

If a call to std::Clone:clone cannot be resolved because the self argument type is not concrete, do not give a diagnostic right away,
but generate a precondition requiring the self argument to be none (if the self argument is derived from a parameter).

Also add a special case for cloning a function pointer.

Do some code cleanup.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem