### PR TITLE
Fix a simplifier rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "lock_api"
@@ -324,9 +324,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14fc54a812b4472b4113facc3e44d099fbc0ea2ce0551fa5c703f8edfbfd38"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
@@ -597,9 +597,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -699,13 +699,13 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                         return other;
                     }
                     if let Expression::LogicalNot { operand } = &other.expression {
-                        // [(x || y) && (!x)] -> y
+                        // [(x || y) && (!x)] -> y && !x
                         if *x == *operand {
-                            return y.clone();
+                            return y.and(other);
                         }
-                        // [(x || y) && (!y)] -> x
+                        // [(x || y) && (!y)] -> x && !y
                         if *y == *operand {
-                            return x.clone();
+                            return x.and(other);
                         }
                     }
                 }
@@ -740,13 +740,13 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                         return self.clone();
                     }
                     if let Expression::LogicalNot { operand } = &self.expression {
-                        // [(!x) && (x || y)] -> y
+                        // [(!x) && (x || y)] -> !x && y
                         if *x == *operand {
-                            return y.clone();
+                            return self.and(y.clone());
                         }
-                        // [(!y) && (x || y) ] -> x
+                        // [(!y) && (x || y) ] -> !y && x
                         if *y == *operand {
-                            return x.clone();
+                            return self.and(x.clone());
                         }
                     }
                     // [x && (x && y || x && z)] -> x && (y || z)

--- a/checker/tests/run-pass/simplify.rs
+++ b/checker/tests/run-pass/simplify.rs
@@ -17,17 +17,17 @@ pub fn f2(x: bool, y: bool) {
     let z = (x || y) && x;
     verify!(z == x);
     let z = (x || y) && y;
-    verify!(z == y);
+    verify!(z == y); //~ possible false verification condition
 }
 
 pub fn f3(x: bool, y: bool) {
     let z = (x || y) && (!x);
-    verify!(z == y);
+    verify!(z == y && !x); //~ possible false verification condition
 }
 
 pub fn f4(x: bool, y: bool) {
     let z = (x || y) && (!y);
-    verify!(z == x);
+    verify!(z == x && !y); //~ possible false verification condition
 }
 
 pub fn f5(x: bool, y: bool) {
@@ -81,7 +81,7 @@ pub fn f10(x: bool, y: bool, a: i32, b: i32) {
     } else {
         a
     };
-    verify!(z == if y { b } else { a });
+    verify!(z == if y { b } else { a }); //~ possible false verification condition
 }
 
 pub fn f11(x: bool, y: bool, a: i32, b: i32) {
@@ -94,7 +94,7 @@ pub fn f11(x: bool, y: bool, a: i32, b: i32) {
     } else {
         a
     };
-    verify!(z == if x { b } else { a });
+    verify!(z == if x { b } else { a }); //~ possible false verification condition
 }
 
 pub fn main() {}


### PR DESCRIPTION
## Description

Fix a simplification rule that was overly aggressive. Also make the invocation of the SMT solver a bit more robust in the face of simplifier weirdness.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
