### PR TITLE
Push preconditions for calls to incomplete summaries

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2496,9 +2496,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
     /// Give diagnostic depending on self.bv.options.diag_level
     #[logfn_inputs(TRACE)]
     pub fn report_incomplete_summary(&mut self) {
-        self.block_visitor.bv.analysis_is_incomplete = true;
         if self.block_visitor.might_be_reachable().unwrap_or(true) {
-            // The the callee is local, there will already be a diagnostic about the incomplete summary.
+            self.block_visitor.bv.analysis_is_incomplete = true;
+            // If the callee is local, there will already be a diagnostic about the incomplete summary.
             if !self.callee_def_id.is_local()
                 && self.block_visitor.bv.cv.options.diag_level != DiagLevel::Default
             {

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -148,18 +148,22 @@ impl MiraiCallbacks {
             || file_name.contains("common/time-service/src") // collections of call backs
             || file_name.contains("config/management/src") // too slow
             || file_name.contains("config/management/genesis/src") // too slow    
+            || file_name.contains("config/management/network-address-encryption/src") // Sorts Int and <null> are incompatible
             || file_name.contains("config/management/operational/src") // too slow
+            || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.contains("crypto/crypto-derive/src") // too much parsing
             || file_name.contains("json-rpc/src") // stack overflow
             || file_name.contains("language/bytecode-verifier/src") // too slow
             || file_name.contains("language/diem-tools/diem-events-fetcher/src") // resolve error
             || file_name.contains("language/move-lang/src") // too slow
             || file_name.contains("language/move-model/src") // too slow
+            || file_name.contains("language/move-prover/boogie-backend/src") // index out of bounds
             || file_name.contains("language/move-prover/bytecode/src") // too slow 
             || file_name.contains("language/tools/move-coverage/src") // too slow
             || file_name.contains("language/vm/src") // too slow
             || file_name.contains("secure/storage/vault/src") // Sorts Int and <null> are incompatible
             || file_name.contains("state-sync/src") // Sorts <null> and Int are incompatible
+            || file_name.contains("storage/backup/backup-cli/src") // unreachable code
             || file_name.contains("types/src")
         {
             return true;


### PR DESCRIPTION
## Description

If a call to an incompletely analyzed function has a path condition that can be reduced to a pre-condition that precludes the incomplete call from being reached, then push such a precondition. At worst, this just adds more context to the diagnostic. At best it can make the diagnostic go away.

Additionally, make the block containing the call behave like it was never reached (already the case) while still carrying on with the analysis of the rest of the function (instead of immediately bailing out). This causes more diagnostics to show up, but also uncovers more places where the analyzer terminates abruptly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem.
