### PR TITLE
Push preconditions for calls to incomplete summaries

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -4905,12 +4905,11 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 if self.is_top() || self.is_bottom() {
                     return self.clone();
                 }
-                unimplemented!(
+                info!(
                     "replacing embedded path root of {:?}, old_root {:?}, new_root {:?}",
-                    self,
-                    old_root,
-                    new_root
+                    self, old_root, new_root
                 );
+                self.clone()
             }
         }
     }

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -758,7 +758,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                 if promotable_entry_condition.as_bool_if_known().is_none() {
                     let precondition = Precondition {
                         condition: promotable_entry_condition.logical_not(),
-                        message: Rc::from("incomplete analysis of call because of failure to resolve an indirect call"),
+                        message: Rc::from("incomplete analysis of call because of a nested call to a function without a MIR body"),
                         provenance: None,
                         spans: vec![self.bv.current_span.source_callsite()],
                     };

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -142,28 +142,63 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(&self, file_name: &str) -> bool {
-        if file_name.contains("client/swiss-knife/src") // too slow 
+        if file_name.contains("client/faucet/src") // too slow
+            || file_name.contains("client/swiss-knife/src") // too slow 
+            || file_name.contains("common/debug-interface/src") // !def.is_enum()
+            || file_name.contains("common/logger/src") // !def.is_enum()
             || file_name.contains("common/logger/derive/src") // meta programming
+            || file_name.contains("common/metrics/src") // too slow
             || file_name.contains("common/num-variants/src") // meta programming
+            || file_name.contains("common/rate-limiter/src") // too slow
             || file_name.contains("common/time-service/src") // collections of call backs
+            || file_name.contains("common/trace/src") // Sorts Int and <null> are incompatible
+            || file_name.contains("config/src") // Sorts Int and <null> are incompatible
+            || file_name.contains("config/seed-peer-generator/src") //  Sorts Int and <null> are incompatible
             || file_name.contains("config/management/src") // too slow
             || file_name.contains("config/management/genesis/src") // too slow    
             || file_name.contains("config/management/network-address-encryption/src") // Sorts Int and <null> are incompatible
             || file_name.contains("config/management/operational/src") // too slow
+            || file_name.contains("consensus/src") // Sorts Int and <null> are incompatible 
             || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.contains("crypto/crypto-derive/src") // too much parsing
+            || file_name.contains("diem-node/src") // Sorts Int and <null> are incompatible    
+            || file_name.contains("execution/execution-correctness/src") // Sorts Int and <null> are incompatible
             || file_name.contains("json-rpc/src") // stack overflow
             || file_name.contains("language/bytecode-verifier/src") // too slow
             || file_name.contains("language/diem-tools/diem-events-fetcher/src") // resolve error
+            || file_name.contains("language/compiler/src") // Sorts Int and Bool are incompatible
+            || file_name.contains("language/compiler/ir-to-bytecode/src") // Sorts Int and Bool are incompatible
+            || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // Sorts Int and Bool are incompatible
+            || file_name.contains("language/diem-tools/transaction-replay/src")  // Not a type   
+            || file_name.contains("language/diem-tools/writeset-transaction-generator/src") // stack overflow
+            || file_name.contains("language/diem-framework/src") // too slow    
             || file_name.contains("language/move-lang/src") // too slow
             || file_name.contains("language/move-model/src") // too slow
+            || file_name.contains("language/move-prover/src") // too slow 
             || file_name.contains("language/move-prover/boogie-backend/src") // index out of bounds
+            || file_name.contains("language/move-prover/docgen/src") // too slow
             || file_name.contains("language/move-prover/bytecode/src") // too slow 
+            || file_name.contains("language/tools/move-bytecode-viewer/src") // too slow
+            || file_name.contains("language/tools/move-cli/src") // too slow
             || file_name.contains("language/tools/move-coverage/src") // too slow
+            || file_name.contains("language/tools/vm-genesis/src") // too slow
+            || file_name.contains("language/transaction-builder/generator/src") // too slow
             || file_name.contains("language/vm/src") // too slow
+            || file_name.contains("mempool/src") //  !def.is_enum()
+            || file_name.contains("network/src") // too slow
+            || file_name.contains("network/builder/src") // Sorts Int and <null> are incompatible
+            || file_name.contains("network/simple-onchain-discovery/src") // Sorts Int and <null> are incompatible   
+            || file_name.contains("sdk/client/src") // Sorts <null> and Int are incompatible
+            || file_name.contains("secure/key-manager/src") // too slow   
+            || file_name.contains("secure/storage/github/src") // !def.is_enum()
+            || file_name.contains("secure/net/src") // too slow
             || file_name.contains("secure/storage/vault/src") // Sorts Int and <null> are incompatible
             || file_name.contains("state-sync/src") // Sorts <null> and Int are incompatible
+            || file_name.contains("secure/storage/src") // !def.is_enum()
             || file_name.contains("storage/backup/backup-cli/src") // unreachable code
+            || file_name.contains("storage/diemdb/src") // stack overflow
+            || file_name.contains("storage/schemadb/src") // too slow
+            || file_name.contains("storage/storage-client/src") // too slow
             || file_name.contains("types/src")
         {
             return true;


### PR DESCRIPTION
## Description

Push preconditions for calls to incomplete summaries. Add more crates to exclusion list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
