### PR TITLE
Promote preconditions for analysis roots in default mode

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -181,6 +181,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/tools/move-bytecode-viewer/src") // too slow
             || file_name.contains("language/tools/move-cli/src") // too slow
             || file_name.contains("language/tools/move-coverage/src") // too slow
+            || file_name.contains("language/tools/resource-viewer/src") // too slow
             || file_name.contains("language/tools/vm-genesis/src") // too slow
             || file_name.contains("language/transaction-builder/generator/src") // too slow
             || file_name.contains("language/vm/src") // too slow

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -736,7 +736,7 @@ impl Expression {
             Expression::UnknownTagField { path } | Expression::Variable { path, .. } => {
                 path.contains_local_variable()
             }
-            Expression::WidenedJoin { .. } => true,
+            Expression::WidenedJoin { operand, .. } => operand.expression.contains_local_variable(),
         }
     }
 

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -788,7 +788,11 @@ impl PathRefinement for Rc<Path> {
                     selector.refine_parameters_and_paths(args, result, pre_env, post_env, fresh);
                 let refined_qualifier =
                     qualifier.refine_parameters_and_paths(args, result, pre_env, post_env, fresh);
-                Path::new_qualified(refined_qualifier, refined_selector).canonicalize(post_env)
+                if refined_qualifier == *qualifier && refined_selector == *selector {
+                    self.clone()
+                } else {
+                    Path::new_qualified(refined_qualifier, refined_selector).canonicalize(post_env)
+                }
             }
             PathEnum::Result => {
                 if result.is_none() {

--- a/checker/tests/run-pass/bit_vec.rs
+++ b/checker/tests/run-pass/bit_vec.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks relaxed mode preconditions for conditions that overflow in size
+
+// MIRAI_FLAGS --diag=default
+
+pub struct BitVec {
+    inner: Vec<u8>,
+}
+const BUCKET_SIZE: usize = 8;
+
+impl BitVec {
+    pub fn set(&mut self, pos: u8) {
+        let bucket: usize = pos as usize / BUCKET_SIZE;
+        if self.inner.len() <= bucket {
+            self.inner.resize(bucket + 1, 0);
+        }
+        let bucket_pos = pos as usize - (bucket * BUCKET_SIZE);
+        self.inner[bucket] |= 0b1000_0000 >> bucket_pos as u8;
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -6,15 +6,12 @@
 
 // A test that uses a widened summary.
 
-//use mirai_annotations::*;
-
 fn fact(n: u8) -> u128 {
     if n == 0 {
         1
     } else {
         let n1fac = fact(n - 1);
-        //assume!(n1fac <= std::u128::MAX / (n as u128));
-        (n as u128) * n1fac //~ possible attempt to multiply with overflow
+        (n as u128) * n1fac
     }
 }
 


### PR DESCRIPTION
## Description

Promote preconditions for analysis roots in default mode. Also push a precondition when the condition itself is TOP but the path condition can be promoted (thus preventing the call to the function with the possibly unsatisfied precondition).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
