### PR TITLE
Promote preconditions if the caller can satisfy the condition alone

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -160,6 +160,7 @@ impl MiraiCallbacks {
             || file_name.contains("config/management/operational/src") // too slow
             || file_name.contains("consensus/src") // Sorts Int and <null> are incompatible 
             || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
+            || file_name.contains("crypto/crypto/src") // too slow
             || file_name.contains("crypto/crypto-derive/src") // too much parsing
             || file_name.contains("diem-node/src") // Sorts Int and <null> are incompatible    
             || file_name.contains("execution/execution-correctness/src") // Sorts Int and <null> are incompatible
@@ -175,6 +176,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-lang/src") // too slow
             || file_name.contains("language/move-model/src") // too slow
             || file_name.contains("language/move-prover/src") // too slow 
+            || file_name.contains("language/move-prover/abigen/src") // too slow
             || file_name.contains("language/move-prover/boogie-backend/src") // index out of bounds
             || file_name.contains("language/move-prover/docgen/src") // too slow
             || file_name.contains("language/move-prover/bytecode/src") // too slow 


### PR DESCRIPTION
## Description

Promote preconditions if the caller can satisfy the condition alone. Ideally, the promoted precondition should be the or of the negation of the current path condition and the precondition. That way, the caller can satisfy the precondition by either proving that it
will never be reached, or by proving that the condition is always true. But when either the path condition or the condition cannot be promoted because it involves state that is inaccessible to the caller, then the caller should at least get the chance to prove the remaining condition.

When neither condition can be promoted, mark the current analysis as incomplete if the precondition was added to avoid a call to an incomplete nested call. Also, if running in default mode, don't give a diagnostic in this case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
