### PR TITLE
Handle inherited visibility when selecting root functions to analyze

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1329,7 +1329,8 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     if promotable_cond_val.is_none()
                         || promotable_entry_cond.is_none()
                         || self.bv.preconditions.len() >= k_limits::MAX_INFERRED_PRECONDITIONS
-                        || self.bv.function_being_analyzed_is_root()
+                        || (self.bv.function_being_analyzed_is_root()
+                            && self.bv.cv.options.diag_level >= DiagLevel::Library)
                     {
                         // Can't make this the caller's problem.
                         let warning = format!("possible {}", get_assert_msg_description(msg));

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -172,7 +172,9 @@ impl MiraiCallbacks {
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // Sorts Int and Bool are incompatible
             || file_name.contains("language/diem-tools/transaction-replay/src")  // Not a type   
             || file_name.contains("language/diem-tools/writeset-transaction-generator/src") // stack overflow
-            || file_name.contains("language/diem-framework/src") // too slow    
+            || file_name.contains("language/diem-framework/src") // too slow 
+            || file_name.contains("language/diem-tools/diem-validator-interface") // Sorts Int and <null> are incompatible
+            || file_name.contains("language/diem-vm/src") // too slow
             || file_name.contains("language/move-lang/src") // too slow
             || file_name.contains("language/move-model/src") // too slow
             || file_name.contains("language/move-prover/src") // too slow 
@@ -202,7 +204,8 @@ impl MiraiCallbacks {
             || file_name.contains("storage/diemdb/src") // stack overflow
             || file_name.contains("storage/schemadb/src") // too slow
             || file_name.contains("storage/storage-client/src") // too slow
-            || file_name.contains("types/src")
+            || file_name.contains("types/src") // too slow
+            || file_name.contains("vm-validator/src")
         {
             return true;
         }

--- a/checker/tests/run-pass/point.rs
+++ b/checker/tests/run-pass/point.rs
@@ -4,6 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// MIRAI_FLAGS --diag=verify
+
 use mirai_annotations::*;
 
 use std::ops::{Add, AddAssign};

--- a/checker/tests/run-pass/trait_call.rs
+++ b/checker/tests/run-pass/trait_call.rs
@@ -30,7 +30,7 @@ struct BarTwo {
 
 impl Tr for BarTwo {
     fn bar(&self) -> i32 {
-        self.i * 2
+        self.i * 2 //~ possible attempt to multiply with overflow
     }
 }
 


### PR DESCRIPTION
## Description

Handle inherited visibility when selecting root functions to analyze. In particular, functions that implement trait methods are now analysis roots as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
