### PR TITLE
Hide actual location of type visitor instance behind accessor functions

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -707,7 +707,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
     /// Returns an ExpressionType value corresponding to the Rustc type of the place.
     #[logfn_inputs(TRACE)]
     pub fn get_place_type(
-        &mut self,
+        &self,
         place: &mir::Place<'tcx>,
         current_span: rustc_span::Span,
     ) -> ExpressionType {


### PR DESCRIPTION
## Description

Hide actual location of type visitor instance behind accessor functions. This makes the code a bit more consistent and opens the possibility of moving the actual location of the type visitor somewhere else, if needed in order to make type information more available during path and value refinement.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
