### PR TITLE
Add the rustc type of a cast expression to the path type cache.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1846,6 +1846,8 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     self.bv.current_environment.value_map =
                         self.bv.current_environment.value_map.remove(&source_path);
                 }
+                self.type_visitor_mut()
+                    .set_path_rustc_type(Path::get_as_path(result.clone()), ty);
                 self.bv.current_environment.update_value_at(path, result);
             }
         }


### PR DESCRIPTION
## Description

Add the rustc type of a cast expression to the path type cache. If this is not done and the cast expression ends up in a path via path canonicalization, then inferring the rustc type of the canonicalized path may go wrong.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
