### PR TITLE
Taking the address of field 0 of a transparent wrapper is special

### DIFF
--- a/checker/tests/run-pass/queue_drop.rs
+++ b/checker/tests/run-pass/queue_drop.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// A test that does unsafe casting and manipulation of pointers to transparent wrappers
+
+// MIRAI_FLAGS --diag=verify
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread::Thread;
+
+const RUNNING: usize = 0x1;
+const STATE_MASK: usize = 0x3;
+
+#[repr(align(4))] // Ensure the two lower bits are free to use as state bits.
+pub struct Waiter {
+    thread: Cell<Option<Thread>>,
+    signaled: AtomicBool,
+    next: *const Waiter,
+}
+
+pub struct WaiterQueue<'a> {
+    state_and_queue: &'a AtomicUsize,
+    set_state_on_drop_to: usize,
+}
+
+impl Drop for WaiterQueue<'_> {
+    fn drop(&mut self) {
+        let state_and_queue = self
+            .state_and_queue
+            .swap(self.set_state_on_drop_to, Ordering::AcqRel);
+
+        assert_eq!(state_and_queue & STATE_MASK, RUNNING);
+
+        unsafe {
+            let mut queue = (state_and_queue & !STATE_MASK) as *const Waiter;
+            while !queue.is_null() {
+                let next = (*queue).next;
+                let thread = (*queue).thread.replace(None).unwrap();
+                (*queue).signaled.store(true, Ordering::Release);
+                queue = next;
+                thread.unpark();
+            }
+        }
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Taking the address of field 0 of a transparent wrapper over another transparent wrapper (e.g. `&w1<w2<s>>.0`) should not be seen as taking the address of field 0 of the first non transparent struct (e.g. &s.0) even though it is the same memory address , since the type this expression in MIR seems to be `&w2<s>`, not `&(typeof(s.0))`. Given the MIR type (`&w2<s>`), subsequently getting field 0 from the address, would end up with path `*&s.0.0`, which will not type correctly (and won't be a valid environment key either).

I don't think I really understand this fully, but the work around in the PR gets past a bug.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
