### PR TITLE
Extract promotable disjunctions for conditions that are not negated.

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -948,7 +948,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                     .current_environment
                     .entry_condition
                     .extract_promotable_conjuncts(),
-                condition.extract_promotable_conjuncts(),
+                condition.extract_promotable_disjuncts(),
             ) {
                 (Some(promotable_entry_cond), Some(promotable_condition))
                     if promotable_entry_cond.as_bool_if_known().is_none()
@@ -1111,7 +1111,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
         // We might get here, or not, and the condition might be false, or not.
         // Give a warning if we don't know all of the callers, or if we run into a k-limit
         // or if the condition is not promotable or if the condition is being explicitly verified.
-        let promotable_cond = cond.extract_promotable_conjuncts();
+        let promotable_cond = cond.extract_promotable_disjuncts();
         if self.bv.function_being_analyzed_is_root()
             || self.bv.preconditions.len() >= k_limits::MAX_INFERRED_PRECONDITIONS
             || promotable_cond.is_none()
@@ -1179,7 +1179,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         );
                         self.bv.emit_diagnostic(warning);
                     } else if promotable_entry_condition.is_none()
-                        || tag_check.extract_promotable_conjuncts().is_none()
+                        || tag_check.extract_promotable_disjuncts().is_none()
                     {
                         let span = self.bv.current_span.source_callsite();
                         let warning = self.bv.cv.session.struct_span_warn(
@@ -1214,7 +1214,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             // contain local variables, and we don't reach a k-limit.
             match (
                 promotable_entry_condition,
-                tag_check.extract_promotable_conjuncts(),
+                tag_check.extract_promotable_disjuncts(),
             ) {
                 (Some(promotable_entry_cond), Some(promotable_tag_check))
                     if !tag_check_as_bool.unwrap_or(false)
@@ -1316,7 +1316,7 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
 
                     // At this point, we don't know that this assert is unreachable and we don't know
                     // that the condition is as expected, so we need to warn about it somewhere.
-                    let promotable_cond_val = cond_val.extract_promotable_conjuncts();
+                    let promotable_cond_val = cond_val.extract_promotable_disjuncts();
                     let promotable_entry_cond = self
                         .bv
                         .current_environment

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -643,7 +643,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                             None => {
                                 // Might have to clone the Some(..) variant, so can't be handled here,
                                 if let Some(promotable_is_zero) =
-                                    is_zero.extract_promotable_conjuncts()
+                                    is_zero.extract_promotable_disjuncts()
                                 {
                                     // The caller might be able to avoid the diagnostic because it
                                     // knows the actual argument whereas here we only know the type.
@@ -965,7 +965,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                                 .current_environment
                                 .entry_condition
                                 .extract_promotable_conjuncts(),
-                            non_zero.extract_promotable_conjuncts(),
+                            non_zero.extract_promotable_disjuncts(),
                         ) {
                             (Some(promotable_entry_condition), Some(promotable_non_zero))
                                 if self.block_visitor.bv.preconditions.len()
@@ -2704,7 +2704,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                         .current_environment
                         .entry_condition
                         .extract_promotable_conjuncts(),
-                    refined_condition.extract_promotable_conjuncts(),
+                    refined_condition.extract_promotable_disjuncts(),
                 ) {
                     (Some(promotable_entry_condition), Some(promotable_condition)) => {
                         promotable_entry_condition

--- a/checker/tests/run-pass/nibble_path.rs
+++ b/checker/tests/run-pass/nibble_path.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that inferred preconditions with disjunctions can be promoted.
+
+// MIRAI_FLAGS --diag=verify
+
+pub struct Nibble(u8);
+
+impl From<u8> for Nibble {
+    fn from(nibble: u8) -> Self {
+        assert!(nibble < 16, "Nibble out of range: {}", nibble);
+        Self(nibble)
+    }
+}
+
+#[derive(Clone)]
+pub struct NibblePath {
+    /// Indicates the total number of nibbles in bytes. Either `bytes.len() * 2 - 1` or
+    /// `bytes.len() * 2`.
+    // Guarantees intended ordering based on the top-to-bottom declaration order of the struct's
+    // members.
+    num_nibbles: usize,
+    /// The underlying bytes that stores the path, 2 nibbles per byte. If the number of nibbles is
+    /// odd, the second half of the last byte must be 0.
+    bytes: Vec<u8>,
+    // invariant num_nibbles <= ROOT_NIBBLE_HEIGHT
+}
+
+impl NibblePath {
+    pub fn pop(&mut self) -> Option<Nibble> {
+        let popped_nibble = if self.num_nibbles % 2 == 0 {
+            self.bytes.last_mut().map(|last_byte| {
+                let nibble = *last_byte & 0x0f;
+                *last_byte &= 0xf0;
+                Nibble::from(nibble)
+            })
+        } else {
+            self.bytes.pop().map(|byte| Nibble::from(byte >> 4))
+        };
+        if popped_nibble.is_some() {
+            self.num_nibbles -= 1;
+        }
+        popped_nibble
+    }
+}
+
+pub struct NodeKey {
+    // The version at which the node is created.
+    //version: Version,
+    // The nibble path this node represents in the tree.
+    nibble_path: NibblePath,
+}
+
+impl NodeKey {
+    pub fn gen_parent_node_key(&self) {
+        let mut node_nibble_path = self.nibble_path.clone();
+        let _x = node_nibble_path.pop();
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Extract promotable disjunctions for conditions that are not negated. For example, a path condition that leads to an assert instruction will get negated in the inferred precondition (because the condition need not be true if the assert is never reached). The assert condition, on the other hands needs to be true and will be true if any one of its disjunctions are true, so all promotable disjunctions must be extracted from such conditions, unlike path conditions, where we want to extract conjunctions (which then become disjunctions when we negate the condition). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
