### PR TITLE
Use t::MIN/MAX instead of std::t::MIN/MAX

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -196,6 +196,7 @@ impl MiraiCallbacks {
             || file_name.contains("mempool/src") //  !def.is_enum()
             || file_name.contains("network/src") // too slow
             || file_name.contains("network/builder/src") // Sorts Int and <null> are incompatible
+            || file_name.contains("network/netcore/src") // crash
             || file_name.contains("network/simple-onchain-discovery/src") // Sorts Int and <null> are incompatible   
             || file_name.contains("sdk/src") // too slow
             || file_name.contains("sdk/client/src") // Sorts <null> and Int are incompatible

--- a/checker/src/interval_domain.rs
+++ b/checker/src/interval_domain.rs
@@ -12,8 +12,8 @@ use std::cmp;
 use std::convert::TryFrom;
 
 /// An element of the Interval domain is a range of i128 numbers denoted by a lower bound and
-/// upper bound. A lower bound of std::i128::MIN denotes -infinity and an upper bound of
-/// std::i128::MAX denotes +infinity.
+/// upper bound. A lower bound of i128::MIN denotes -infinity and an upper bound of
+/// i128::MAX denotes +infinity.
 /// Interval domain elements are constructed on demand from AbstractDomain expressions.
 /// They are most useful for checking if an array index is within bounds.
 #[derive(Serialize, Deserialize, Clone, Eq, PartialOrd, PartialEq, Hash, Ord)]
@@ -26,9 +26,9 @@ impl std::fmt::Debug for IntervalDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match (self.lower_bound, self.upper_bound) {
             (1, 0) => f.write_str("[bottom]"),
-            (std::i128::MIN, std::i128::MAX) => f.write_str("[..]"),
-            (std::i128::MIN, _) => f.write_fmt(format_args!("[..{}]", self.upper_bound)),
-            (_, std::i128::MAX) => f.write_fmt(format_args!("[{}..]", self.lower_bound)),
+            (i128::MIN, i128::MAX) => f.write_str("[..]"),
+            (i128::MIN, _) => f.write_fmt(format_args!("[..{}]", self.upper_bound)),
+            (_, i128::MAX) => f.write_fmt(format_args!("[{}..]", self.lower_bound)),
             _ => f.write_fmt(format_args!("[{}..{}]", self.lower_bound, self.upper_bound)),
         }
     }
@@ -40,8 +40,8 @@ pub const BOTTOM: IntervalDomain = IntervalDomain {
 };
 
 pub const TOP: IntervalDomain = IntervalDomain {
-    lower_bound: std::i128::MIN,
-    upper_bound: std::i128::MAX,
+    lower_bound: i128::MIN,
+    upper_bound: i128::MAX,
 };
 
 impl From<i128> for IntervalDomain {
@@ -61,8 +61,8 @@ impl From<u128> for IntervalDomain {
             i.into()
         } else {
             IntervalDomain {
-                lower_bound: std::i128::MAX,
-                upper_bound: std::i128::MAX,
+                lower_bound: i128::MAX,
+                upper_bound: i128::MAX,
             }
         }
     }
@@ -135,32 +135,27 @@ impl IntervalDomain {
         };
         match target_type {
             I8 => {
-                self.lower_bound >= i128::from(std::i8::MIN)
-                    && self.upper_bound <= i128::from(std::i8::MAX)
+                self.lower_bound >= i128::from(i8::MIN) && self.upper_bound <= i128::from(i8::MAX)
             }
             I16 => {
-                self.lower_bound >= i128::from(std::i16::MIN)
-                    && self.upper_bound <= i128::from(std::i16::MAX)
+                self.lower_bound >= i128::from(i16::MIN) && self.upper_bound <= i128::from(i16::MAX)
             }
             I32 => {
-                self.lower_bound >= i128::from(std::i32::MIN)
-                    && self.upper_bound <= i128::from(std::i32::MAX)
+                self.lower_bound >= i128::from(i32::MIN) && self.upper_bound <= i128::from(i32::MAX)
             }
             I64 => {
-                self.lower_bound >= i128::from(std::i64::MIN)
-                    && self.upper_bound <= i128::from(std::i64::MAX)
+                self.lower_bound >= i128::from(i64::MIN) && self.upper_bound <= i128::from(i64::MAX)
             }
-            I128 => self.lower_bound > std::i128::MIN && self.upper_bound < std::i128::MAX,
+            I128 => self.lower_bound > i128::MIN && self.upper_bound < i128::MAX,
             Isize => {
-                self.lower_bound >= (std::isize::MIN as i128)
-                    && self.upper_bound <= (std::isize::MAX as i128)
+                self.lower_bound >= (isize::MIN as i128) && self.upper_bound <= (isize::MAX as i128)
             }
-            U8 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u8::MAX),
-            U16 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u16::MAX),
-            U32 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u32::MAX),
-            U64 => self.lower_bound >= 0 && self.upper_bound <= i128::from(std::u64::MAX),
-            U128 => self.lower_bound >= 0 && self.upper_bound < std::i128::MAX,
-            Usize => self.lower_bound >= 0 && self.upper_bound <= (std::usize::MAX as i128),
+            U8 => self.lower_bound >= 0 && self.upper_bound <= i128::from(u8::MAX),
+            U16 => self.lower_bound >= 0 && self.upper_bound <= i128::from(u16::MAX),
+            U32 => self.lower_bound >= 0 && self.upper_bound <= i128::from(u32::MAX),
+            U64 => self.lower_bound >= 0 && self.upper_bound <= i128::from(u64::MAX),
+            U128 => self.lower_bound >= 0 && self.upper_bound < i128::MAX,
+            Usize => self.lower_bound >= 0 && self.upper_bound <= (usize::MAX as i128),
             _ => false,
         }
     }
@@ -179,7 +174,7 @@ impl IntervalDomain {
             I64 | U64 => self.lower_bound >= 0 && self.upper_bound < 64,
             I128 | U128 => self.lower_bound >= 0 && self.upper_bound < 128,
             Isize | Usize => {
-                self.lower_bound >= 0 && self.upper_bound < i128::from(std::usize::MAX.count_ones())
+                self.lower_bound >= 0 && self.upper_bound < i128::from(usize::MAX.count_ones())
             }
             _ => false,
         }
@@ -188,7 +183,7 @@ impl IntervalDomain {
     // All concrete integer values belong to this interval, so we know nothing.
     #[logfn_inputs(TRACE)]
     pub fn is_top(&self) -> bool {
-        self.lower_bound == std::i128::MIN && self.upper_bound == std::i128::MAX
+        self.lower_bound == i128::MIN && self.upper_bound == i128::MAX
     }
 
     // [x...y] <= [a...b] = y <= a
@@ -280,8 +275,8 @@ impl IntervalDomain {
             return TOP.clone();
         }
         IntervalDomain {
-            lower_bound: self.upper_bound.checked_neg().unwrap_or(std::i128::MAX),
-            upper_bound: self.lower_bound.checked_neg().unwrap_or(std::i128::MAX),
+            lower_bound: self.upper_bound.checked_neg().unwrap_or(i128::MAX),
+            upper_bound: self.lower_bound.checked_neg().unwrap_or(i128::MAX),
         }
     }
 

--- a/checker/tests/run-pass/cmp_max.rs
+++ b/checker/tests/run-pass/cmp_max.rs
@@ -40,56 +40,56 @@ pub fn test_i128() {
     let val1: i128 = result!();
     let val2: i128 = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::i128::MAX);
+    verify!(result <= i128::MAX);
 }
 
 pub fn test_isize() {
     let val1: isize = result!();
     let val2: isize = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::isize::MAX);
+    verify!(result <= isize::MAX);
 }
 
 pub fn test_u8() {
     let val1: u8 = result!();
     let val2: u8 = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::u8::MAX);
+    verify!(result <= u8::MAX);
 }
 
 pub fn test_u16() {
     let val1: u16 = result!();
     let val2: u16 = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::u16::MAX);
+    verify!(result <= u16::MAX);
 }
 
 pub fn test_u32() {
     let val1: u32 = result!();
     let val2: u32 = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::u32::MAX);
+    verify!(result <= u32::MAX);
 }
 
 pub fn test_u64() {
     let val1: u64 = result!();
     let val2: u64 = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::u64::MAX);
+    verify!(result <= u64::MAX);
 }
 
 pub fn test_u128() {
     let val1: u128 = result!();
     let val2: u128 = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::u128::MAX);
+    verify!(result <= u128::MAX);
 }
 
 pub fn test_usize() {
     let val1: usize = result!();
     let val2: usize = result!();
     let result = core::cmp::max(val1, val2);
-    verify!(result <= std::usize::MAX);
+    verify!(result <= usize::MAX);
 }
 
 pub fn main() {}

--- a/standard_contracts/src/foreign_contracts.rs
+++ b/standard_contracts/src/foreign_contracts.rs
@@ -2249,12 +2249,12 @@ pub mod core {
 
             // Performs an exact division, resulting in undefined behavior when
             // `x % y != 0` or `y == 0` or `x == T::min_value() && y == -1`
-            exact_signed_div!(i8, exact_div__i8, std::i8::MIN);
-            exact_signed_div!(i16, exact_div__i16, std::i16::MIN);
-            exact_signed_div!(i32, exact_div__i32, std::i32::MIN);
-            exact_signed_div!(i64, exact_div__i64, std::i64::MIN);
-            exact_signed_div!(i128, exact_div__i128, std::i128::MIN);
-            exact_signed_div!(isize, exact_div__isize, std::isize::MIN);
+            exact_signed_div!(i8, exact_div__i8, i8::MIN);
+            exact_signed_div!(i16, exact_div__i16, i16::MIN);
+            exact_signed_div!(i32, exact_div__i32, i32::MIN);
+            exact_signed_div!(i64, exact_div__i64, i64::MIN);
+            exact_signed_div!(i128, exact_div__i128, i128::MIN);
+            exact_signed_div!(isize, exact_div__isize, isize::MIN);
             exact_div!(u8, exact_div__u8);
             exact_div!(u16, exact_div__u16);
             exact_div!(u32, exact_div__u32);
@@ -2262,12 +2262,12 @@ pub mod core {
             exact_div!(u128, exact_div__u128);
             exact_div!(usize, exact_div__usize);
 
-            unchecked_signed_div!(i8, unchecked_div__i8, std::i8::MIN);
-            unchecked_signed_div!(i16, unchecked_div__i16, std::i16::MIN);
-            unchecked_signed_div!(i32, unchecked_div__i32, std::i32::MIN);
-            unchecked_signed_div!(i64, unchecked_div__i64, std::i64::MIN);
-            unchecked_signed_div!(i128, unchecked_div__i128, std::i128::MIN);
-            unchecked_signed_div!(isize, unchecked_div__isize, std::isize::MIN);
+            unchecked_signed_div!(i8, unchecked_div__i8, i8::MIN);
+            unchecked_signed_div!(i16, unchecked_div__i16, i16::MIN);
+            unchecked_signed_div!(i32, unchecked_div__i32, i32::MIN);
+            unchecked_signed_div!(i64, unchecked_div__i64, i64::MIN);
+            unchecked_signed_div!(i128, unchecked_div__i128, i128::MIN);
+            unchecked_signed_div!(isize, unchecked_div__isize, isize::MIN);
             unchecked_div!(u8, unchecked_div__u8);
             unchecked_div!(u16, unchecked_div__u16);
             unchecked_div!(u32, unchecked_div__u32);
@@ -2275,12 +2275,12 @@ pub mod core {
             unchecked_div!(u128, unchecked_div__u128);
             unchecked_div!(usize, unchecked_div__usize);
 
-            unchecked_signed_rem!(i8, unchecked_rem__i8, std::i8::MIN);
-            unchecked_signed_rem!(i16, unchecked_rem__i16, std::i16::MIN);
-            unchecked_signed_rem!(i32, unchecked_rem__i32, std::i32::MIN);
-            unchecked_signed_rem!(i64, unchecked_rem__i64, std::i64::MIN);
-            unchecked_signed_rem!(i128, unchecked_rem__i128, std::i128::MIN);
-            unchecked_signed_rem!(isize, unchecked_rem__isize, std::isize::MIN);
+            unchecked_signed_rem!(i8, unchecked_rem__i8, i8::MIN);
+            unchecked_signed_rem!(i16, unchecked_rem__i16, i16::MIN);
+            unchecked_signed_rem!(i32, unchecked_rem__i32, i32::MIN);
+            unchecked_signed_rem!(i64, unchecked_rem__i64, i64::MIN);
+            unchecked_signed_rem!(i128, unchecked_rem__i128, i128::MIN);
+            unchecked_signed_rem!(isize, unchecked_rem__isize, isize::MIN);
             unchecked_rem!(u8, unchecked_rem__u8);
             unchecked_rem!(u16, unchecked_rem__u16);
             unchecked_rem!(u32, unchecked_rem__u32);
@@ -2314,48 +2314,48 @@ pub mod core {
             unchecked_shr!(u128, unchecked_shr__u128);
             unchecked_shr!(usize, unchecked_shr__usize);
 
-            unchecked_add!(i8, i128, unchecked_add__i8, std::i8::MAX);
-            unchecked_add!(i16, i128, unchecked_add__i16, std::i16::MAX);
-            unchecked_add!(i32, i128, unchecked_add__i32, std::i32::MAX);
-            unchecked_add!(i64, i128, unchecked_add__i64, std::i64::MAX);
-            unchecked_add!(i128, i128, unchecked_add__i128, std::i128::MAX);
-            unchecked_add!(isize, i128, unchecked_add__isize, std::i128::MAX);
-            unchecked_add!(u8, u128, unchecked_add__u8, std::u8::MAX);
-            unchecked_add!(u16, u128, unchecked_add__u16, std::u16::MAX);
-            unchecked_add!(u32, u128, unchecked_add__u32, std::u32::MAX);
-            unchecked_add!(u64, u128, unchecked_add__u64, std::u64::MAX);
-            unchecked_add!(u128, u128, unchecked_add__u128, std::u128::MAX);
-            unchecked_add!(usize, u128, unchecked_add__usize, std::usize::MAX);
+            unchecked_add!(i8, i128, unchecked_add__i8, i8::MAX);
+            unchecked_add!(i16, i128, unchecked_add__i16, i16::MAX);
+            unchecked_add!(i32, i128, unchecked_add__i32, i32::MAX);
+            unchecked_add!(i64, i128, unchecked_add__i64, i64::MAX);
+            unchecked_add!(i128, i128, unchecked_add__i128, i128::MAX);
+            unchecked_add!(isize, i128, unchecked_add__isize, i128::MAX);
+            unchecked_add!(u8, u128, unchecked_add__u8, u8::MAX);
+            unchecked_add!(u16, u128, unchecked_add__u16, u16::MAX);
+            unchecked_add!(u32, u128, unchecked_add__u32, u32::MAX);
+            unchecked_add!(u64, u128, unchecked_add__u64, u64::MAX);
+            unchecked_add!(u128, u128, unchecked_add__u128, u128::MAX);
+            unchecked_add!(usize, u128, unchecked_add__usize, usize::MAX);
 
-            unchecked_sub!(i8, unchecked_sub__i8, std::i8::MAX);
-            unchecked_sub!(i16, unchecked_sub__i16, std::i16::MAX);
-            unchecked_sub!(i32, unchecked_sub__i32, std::i32::MAX);
-            unchecked_sub!(i64, unchecked_sub__i64, std::i64::MAX);
-            unchecked_sub!(isize, unchecked_sub__isize, std::i128::MAX);
-            unchecked_sub!(u8, unchecked_sub__u8, std::u8::MAX);
-            unchecked_sub!(u16, unchecked_sub__u16, std::u16::MAX);
-            unchecked_sub!(u32, unchecked_sub__u32, std::u32::MAX);
-            unchecked_sub!(u64, unchecked_sub__u64, std::u64::MAX);
+            unchecked_sub!(i8, unchecked_sub__i8, i8::MAX);
+            unchecked_sub!(i16, unchecked_sub__i16, i16::MAX);
+            unchecked_sub!(i32, unchecked_sub__i32, i32::MAX);
+            unchecked_sub!(i64, unchecked_sub__i64, i64::MAX);
+            unchecked_sub!(isize, unchecked_sub__isize, i128::MAX);
+            unchecked_sub!(u8, unchecked_sub__u8, u8::MAX);
+            unchecked_sub!(u16, unchecked_sub__u16, u16::MAX);
+            unchecked_sub!(u32, unchecked_sub__u32, u32::MAX);
+            unchecked_sub!(u64, unchecked_sub__u64, u64::MAX);
             pub fn unchecked_sub__usize(x: usize, y: usize) -> usize {
                 // Do not enable these preconditions until the prover can handle ptr1 - ptr2
                 // where ptr1 has been widened.
                 // precondition!((x as i128) - (y as i128) >= 0);
-                // precondition!((x as i128) - (y as i128) <= (std::usize::MAX as i128));
+                // precondition!((x as i128) - (y as i128) <= (usize::MAX as i128));
                 x - y
             }
 
-            unchecked_mul!(i8, i128, unchecked_mul__i8, std::i8::MAX);
-            unchecked_mul!(i16, i128, unchecked_mul__i16, std::i16::MAX);
-            unchecked_mul!(i32, i128, unchecked_mul__i32, std::i32::MAX);
-            unchecked_mul!(i64, i128, unchecked_mul__i64, std::i64::MAX);
-            unchecked_mul!(i128, i128, unchecked_mul__i128, std::i128::MAX);
-            unchecked_mul!(isize, i128, unchecked_mul__isize, std::isize::MAX);
-            unchecked_mul!(u8, u128, unchecked_mul__u8, std::u8::MAX);
-            unchecked_mul!(u16, u128, unchecked_mul__u16, std::u16::MAX);
-            unchecked_mul!(u32, u128, unchecked_mul__u32, std::u32::MAX);
-            unchecked_mul!(u64, u128, unchecked_mul__u64, std::u64::MAX);
-            unchecked_mul!(u128, u128, unchecked_mul__u128, std::u128::MAX);
-            unchecked_mul!(usize, u128, unchecked_mul__usize, std::usize::MAX);
+            unchecked_mul!(i8, i128, unchecked_mul__i8, i8::MAX);
+            unchecked_mul!(i16, i128, unchecked_mul__i16, i16::MAX);
+            unchecked_mul!(i32, i128, unchecked_mul__i32, i32::MAX);
+            unchecked_mul!(i64, i128, unchecked_mul__i64, i64::MAX);
+            unchecked_mul!(i128, i128, unchecked_mul__i128, i128::MAX);
+            unchecked_mul!(isize, i128, unchecked_mul__isize, isize::MAX);
+            unchecked_mul!(u8, u128, unchecked_mul__u8, u8::MAX);
+            unchecked_mul!(u16, u128, unchecked_mul__u16, u16::MAX);
+            unchecked_mul!(u32, u128, unchecked_mul__u32, u32::MAX);
+            unchecked_mul!(u64, u128, unchecked_mul__u64, u64::MAX);
+            unchecked_mul!(u128, u128, unchecked_mul__u128, u128::MAX);
+            unchecked_mul!(usize, u128, unchecked_mul__usize, usize::MAX);
 
             // rotate_left: (X << (S % BW)) | (X >> ((BW - S) % BW))
             rotate_left!(i8, rotate_left__i8);
@@ -2386,57 +2386,57 @@ pub mod core {
             rotate_right!(usize, rotate_right__usize);
 
             // (a + b) mod 2<sup>N</sup>, where N is the width of T
-            wrapping_add!(i8, i128, wrapping_add__i8, std::i8::MAX);
-            wrapping_add!(i16, i128, wrapping_add__i16, std::i16::MAX);
-            wrapping_add!(i32, i128, wrapping_add__i32, std::i32::MAX);
-            wrapping_add!(i64, i128, wrapping_add__i64, std::i64::MAX);
-            wrapping_add!(isize, i128, wrapping_add__isize, std::isize::MAX);
-            wrapping_add!(u8, u128, wrapping_add__u8, std::u8::MAX);
-            wrapping_add!(u16, u128, wrapping_add__u16, std::u16::MAX);
-            wrapping_add!(u32, u128, wrapping_add__u32, std::u32::MAX);
-            wrapping_add!(u64, u128, wrapping_add__u64, std::u64::MAX);
-            wrapping_add!(usize, u128, wrapping_add__usize, std::usize::MAX);
+            wrapping_add!(i8, i128, wrapping_add__i8, i8::MAX);
+            wrapping_add!(i16, i128, wrapping_add__i16, i16::MAX);
+            wrapping_add!(i32, i128, wrapping_add__i32, i32::MAX);
+            wrapping_add!(i64, i128, wrapping_add__i64, i64::MAX);
+            wrapping_add!(isize, i128, wrapping_add__isize, isize::MAX);
+            wrapping_add!(u8, u128, wrapping_add__u8, u8::MAX);
+            wrapping_add!(u16, u128, wrapping_add__u16, u16::MAX);
+            wrapping_add!(u32, u128, wrapping_add__u32, u32::MAX);
+            wrapping_add!(u64, u128, wrapping_add__u64, u64::MAX);
+            wrapping_add!(usize, u128, wrapping_add__usize, usize::MAX);
             default_contract!(wrapping_add__i128);
             default_contract!(wrapping_add__u128);
 
             // (a - b) mod 2 ** N, where N is the width of T in bits.
-            wrapping_sub!(i8, i128, wrapping_sub__i8, std::i8::MAX);
-            wrapping_sub!(i16, i128, wrapping_sub__i16, std::i16::MAX);
-            wrapping_sub!(i32, i128, wrapping_sub__i32, std::i32::MAX);
-            wrapping_sub!(i64, i128, wrapping_sub__i64, std::i64::MAX);
-            wrapping_sub!(isize, i128, wrapping_sub__isize, std::isize::MAX);
-            wrapping_sub!(u8, i128, wrapping_sub__u8, std::u8::MAX);
-            wrapping_sub!(u16, i128, wrapping_sub__u16, std::u16::MAX);
-            wrapping_sub!(u32, i128, wrapping_sub__u32, std::u32::MAX);
-            wrapping_sub!(u64, i128, wrapping_sub__u64, std::u64::MAX);
-            wrapping_sub!(usize, i128, wrapping_sub__usize, std::usize::MAX);
+            wrapping_sub!(i8, i128, wrapping_sub__i8, i8::MAX);
+            wrapping_sub!(i16, i128, wrapping_sub__i16, i16::MAX);
+            wrapping_sub!(i32, i128, wrapping_sub__i32, i32::MAX);
+            wrapping_sub!(i64, i128, wrapping_sub__i64, i64::MAX);
+            wrapping_sub!(isize, i128, wrapping_sub__isize, isize::MAX);
+            wrapping_sub!(u8, i128, wrapping_sub__u8, u8::MAX);
+            wrapping_sub!(u16, i128, wrapping_sub__u16, u16::MAX);
+            wrapping_sub!(u32, i128, wrapping_sub__u32, u32::MAX);
+            wrapping_sub!(u64, i128, wrapping_sub__u64, u64::MAX);
+            wrapping_sub!(usize, i128, wrapping_sub__usize, usize::MAX);
             default_contract!(wrapping_sub__i128);
             default_contract!(wrapping_sub__u128);
 
             // (a * b) mod 2 ** N, where N is the width of T in bits.
-            wrapping_mul!(i8, i128, wrapping_mul__i8, std::i8::MAX);
-            wrapping_mul!(i16, i128, wrapping_mul__i16, std::i16::MAX);
-            wrapping_mul!(i32, i128, wrapping_mul__i32, std::i32::MAX);
-            wrapping_mul!(i64, i128, wrapping_mul__i64, std::i64::MAX);
-            wrapping_mul!(isize, i128, wrapping_mul__isize, std::isize::MAX);
-            wrapping_mul!(u8, u128, wrapping_mul__u8, std::u8::MAX);
-            wrapping_mul!(u16, u128, wrapping_mul__u16, std::u16::MAX);
-            wrapping_mul!(u32, u128, wrapping_mul__u32, std::u32::MAX);
-            wrapping_mul!(u64, u128, wrapping_mul__u64, std::u64::MAX);
-            wrapping_mul!(usize, u128, wrapping_mul__usize, std::usize::MAX);
+            wrapping_mul!(i8, i128, wrapping_mul__i8, i8::MAX);
+            wrapping_mul!(i16, i128, wrapping_mul__i16, i16::MAX);
+            wrapping_mul!(i32, i128, wrapping_mul__i32, i32::MAX);
+            wrapping_mul!(i64, i128, wrapping_mul__i64, i64::MAX);
+            wrapping_mul!(isize, i128, wrapping_mul__isize, isize::MAX);
+            wrapping_mul!(u8, u128, wrapping_mul__u8, u8::MAX);
+            wrapping_mul!(u16, u128, wrapping_mul__u16, u16::MAX);
+            wrapping_mul!(u32, u128, wrapping_mul__u32, u32::MAX);
+            wrapping_mul!(u64, u128, wrapping_mul__u64, u64::MAX);
+            wrapping_mul!(usize, u128, wrapping_mul__usize, usize::MAX);
             default_contract!(wrapping_mul__i128);
             default_contract!(wrapping_mul__u128);
 
-            saturating_add!(i8, i128, saturating_add__i8, std::i8::MAX);
-            saturating_add!(i16, i128, saturating_add__i16, std::i16::MAX);
-            saturating_add!(i32, i128, saturating_add__i32, std::i32::MAX);
-            saturating_add!(i64, i128, saturating_add__i64, std::i64::MAX);
-            saturating_add!(isize, i128, saturating_add__isize, std::isize::MAX);
-            saturating_add!(u8, u128, saturating_add__u8, std::u8::MAX);
-            saturating_add!(u16, u128, saturating_add__u16, std::u16::MAX);
-            saturating_add!(u32, u128, saturating_add__u32, std::u32::MAX);
-            saturating_add!(u64, u128, saturating_add__u64, std::u64::MAX);
-            saturating_add!(usize, u128, saturating_add__usize, std::usize::MAX);
+            saturating_add!(i8, i128, saturating_add__i8, i8::MAX);
+            saturating_add!(i16, i128, saturating_add__i16, i16::MAX);
+            saturating_add!(i32, i128, saturating_add__i32, i32::MAX);
+            saturating_add!(i64, i128, saturating_add__i64, i64::MAX);
+            saturating_add!(isize, i128, saturating_add__isize, isize::MAX);
+            saturating_add!(u8, u128, saturating_add__u8, u8::MAX);
+            saturating_add!(u16, u128, saturating_add__u16, u16::MAX);
+            saturating_add!(u32, u128, saturating_add__u32, u32::MAX);
+            saturating_add!(u64, u128, saturating_add__u64, u64::MAX);
+            saturating_add!(usize, u128, saturating_add__usize, usize::MAX);
             default_contract!(saturating_add__i128);
             default_contract!(saturating_add__u128);
 


### PR DESCRIPTION
## Description

Use t::MIN/MAX instead of std::t::MIN/MAX, which has been deprecated.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem