### PR TITLE
Constrain the results of bit counting functions by using intervals

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -926,6 +926,23 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 ) if x1.eq(x2) && y1.eq(y2) => {
                     return x1.less_than(y1.clone());
                 }
+                // [(x && (0 == y)) && (y && z)] -> false
+                (
+                    Expression::And {
+                        left: _x,
+                        right: yz,
+                    },
+                    Expression::And {
+                        left: y2,
+                        right: _z,
+                    },
+                ) => {
+                    if let Expression::Equals { left, right: y1 } = &yz.expression {
+                        if left.is_zero() && y1.eq(y2) {
+                            return Rc::new(FALSE);
+                        }
+                    }
+                }
                 _ => (),
             }
 

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -173,6 +173,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/compiler/src") // Sorts Int and Bool are incompatible
             || file_name.contains("language/compiler/ir-to-bytecode/src") // Sorts Int and Bool are incompatible
             || file_name.contains("language/compiler/ir-to-bytecode/syntax/src") // Sorts Int and Bool are incompatible
+            || file_name.contains("consensus/src") // too slow
             || file_name.contains("language/diem-tools/transaction-replay/src")  // Not a type   
             || file_name.contains("language/diem-tools/writeset-transaction-generator/src") // stack overflow
             || file_name.contains("language/diem-framework/src") // too slow 
@@ -184,8 +185,9 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-prover/abigen/src") // too slow
             || file_name.contains("language/move-prover/boogie-backend-exp/src") // too slow
             || file_name.contains("language/move-prover/boogie-backend/src") // index out of bounds
-            || file_name.contains("language/move-prover/docgen/src") // too slow
             || file_name.contains("language/move-prover/bytecode/src") // too slow 
+            || file_name.contains("language/move-prover/docgen/src") // too slow
+            || file_name.contains("move-prover/errmapgen/src") // too slow
             || file_name.contains("language/move-prover/lab/src") // too slow
             || file_name.contains("language/move-stdlib/src") // Sorts Bool and Int are incompatible
             || file_name.contains("language/tools/disassembler/src") // crash

--- a/checker/tests/run-pass/bit_counting.rs
+++ b/checker/tests/run-pass/bit_counting.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// A test that checks that bit counting operations have return results that are constrained
+// beyond their type signature.
+
+use mirai_annotations::*;
+
+pub fn t1(bit_map: u8) {
+    let ones = bit_map.count_ones();
+    verify!(ones < 9);
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/bit_vector_and_vec_push.rs
+++ b/checker/tests/run-pass/bit_vector_and_vec_push.rs
@@ -32,5 +32,5 @@ pub fn main() {
     let mut buf = Vec::<u8>::new();
     write_u32_as_uleb128(&mut buf, 129);
     verify!(buf.len() == 2); //~ possible false verification condition
-    verify!(buf.len() == 1); //~ provably false verification condition
+    verify!(buf.len() == 1); //~ possible false verification condition
 }


### PR DESCRIPTION
## Description

Constrain the results of bit counting functions by using intervals.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
