### PR TITLE
Add rule: [(x || (y && !z)) || (y && z)))] -> x || y

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -3378,6 +3378,30 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     }
                 }
 
+                // [(x || (y && !z)) || (y && z)))] -> x || y
+                (
+                    Expression::Or {
+                        left: x,
+                        right: ynz,
+                    },
+                    Expression::And {
+                        left: y2,
+                        right: z2,
+                    },
+                ) => {
+                    if let Expression::And {
+                        left: y1,
+                        right: nz,
+                    } = &ynz.expression
+                    {
+                        if let Expression::LogicalNot { operand: z1 } = &nz.expression {
+                            if y1.eq(y2) && z1.eq(z2) {
+                                return x.and(y1.clone());
+                            }
+                        }
+                    }
+                }
+
                 // [x || !(x || y)] -> x || !y
                 (_, Expression::LogicalNot { operand }) => match &operand.expression {
                     Expression::Or { left: x2, right: y } if *self == *x2 => {

--- a/checker/tests/run-pass/bit_vector_and_vec_push.rs
+++ b/checker/tests/run-pass/bit_vector_and_vec_push.rs
@@ -6,7 +6,7 @@
 
 // A test that uses bit vectors in the SMT solver
 
-//use mirai_annotations::*;
+use mirai_annotations::*;
 
 pub fn write_u32_as_uleb128(binary: &mut Vec<u8>, value: u32) {
     let mut val = value;
@@ -29,8 +29,8 @@ pub fn write_u32_as_uleb128(binary: &mut Vec<u8>, value: u32) {
 }
 
 pub fn main() {
-    // let mut buf = Vec::<u8>::new();
-    // write_u32_as_uleb128(&mut buf, 129);
-    // verify!(buf.len() == 2); // ~ possible false verification condition
-    // verify!(buf.len() == 1); // ~ provably false verification condition
+    let mut buf = Vec::<u8>::new();
+    write_u32_as_uleb128(&mut buf, 129);
+    verify!(buf.len() == 2); //~ possible false verification condition
+    verify!(buf.len() == 1); //~ provably false verification condition
 }


### PR DESCRIPTION
## Description

Add simplification rule to or: [(x || (y && !z)) || (y && z)))] -> x || y

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
