### PR TITLE
Do not distribute when information loss may occur

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/tests/run-pass/hex_encode.rs
+++ b/checker/tests/run-pass/hex_encode.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+use mirai_annotations::*;
+
+const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
+
+fn byte2hex(byte: u8) -> (u8, u8) {
+    let hi = HEX_CHARS_LOWER[((byte >> 4) & 0x0f) as usize];
+    let lo = HEX_CHARS_LOWER[(byte & 0x0f) as usize];
+    (hi, lo)
+}
+
+pub fn hex_encode(src: &[u8], dst: &mut [u8]) {
+    for (byte, out) in src.iter().zip(dst.chunks_mut(2)) {
+        let (hi, lo) = byte2hex(*byte);
+        assume!(out.len() == 2);
+        out[0] = hi;
+        assume!(out.len() == 2); // comment this out and it fails
+        out[1] = lo;
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When doing a simplification such as [c3 == (c ? v1 : v2)] -> c ? (c3 == v1) : (c3 == v2 ) where v1 or v2 may be TOP (because of a k-limit, for example), the resulting expression will be actually be c ? TOP : (c3 == v2), which cannot later be used as a constraint on the value of v1. Add logic to prevent this special case from arising.

Also add more rules to collapse disjunctions that overlap.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
