### PR TITLE
Make explicitly assumed conditions have a zero expression size.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -946,7 +946,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 _ => (),
             }
 
-            let other = if self_bool.is_none() {
+            // Refine other expression, except if it is known, or it is an assumed condition
+            // (the latter having an expression size zero so that they get retained when
+            // conjuncts are pruned away because of an expression overflow).
+            let other = if self_bool.is_none() && other.expression_size > 0 {
                 other.refine_with(self, 7)
             } else {
                 other

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1345,11 +1345,15 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 .entry_condition
                 .clone()
         } else {
+            // Give the assumed condition priority over the existing conjuncts when the and expression
+            // size overflows.
+            let assumed_condition =
+                AbstractValue::make_from(assumed_condition.expression.clone(), 0);
             self.block_visitor
                 .bv
                 .current_environment
                 .entry_condition
-                .and(assumed_condition.clone())
+                .and(assumed_condition)
         };
         if let Some((_, target)) = &self.destination {
             self.block_visitor

--- a/checker/tests/run-pass/hex_encode.rs
+++ b/checker/tests/run-pass/hex_encode.rs
@@ -19,7 +19,6 @@ pub fn hex_encode(src: &[u8], dst: &mut [u8]) {
         let (hi, lo) = byte2hex(*byte);
         assume!(out.len() == 2);
         out[0] = hi;
-        assume!(out.len() == 2); // comment this out and it fails
         out[1] = lo;
     }
 }


### PR DESCRIPTION
## Description

When a developer adds an explicit assume to help the prover, it makes no sense to trim away that assumption from the path condition because the path condition overflows. Making such expressions have size zero, helps with this, particularly in trim_prefix_conjuncts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
