### PR TITLE
Used signed arithmetic to compute pointer offsets

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1946,7 +1946,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         checked_assume!(self.actual_args.len() == 2);
         let base_val = self.actual_args[0].1.clone();
         let offset_val = self.actual_args[1].1.clone();
-        let offset_scale = self.handle_size_of();
+        let offset_scale = self.handle_size_of().cast(ExpressionType::Isize);
         let offset_in_bytes = offset_val.multiply(offset_scale);
         base_val.offset(offset_in_bytes)
     }
@@ -2007,7 +2007,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
         checked_assume!(self.actual_args.len() == 2);
         let base_val = self.actual_args[0].1.clone();
         let offset_val = self.actual_args[1].1.clone();
-        let offset_scale = self.handle_size_of();
+        let offset_scale = self.handle_size_of().cast(ExpressionType::Isize);
         let offset_in_bytes = offset_val.multiply(offset_scale);
         let result = base_val.offset(offset_in_bytes);
         if self.block_visitor.bv.check_for_errors

--- a/checker/tests/run-pass/join_commands.rs
+++ b/checker/tests/run-pass/join_commands.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// MIRAI_FLAGS --diag=default
+
+pub enum DebugCommand {
+    Breakpoint(String),
+}
+
+impl DebugCommand {
+    pub fn debug_string(&self) -> &str {
+        match self {
+            Self::Breakpoint(_) => "breakpoint ",
+        }
+    }
+
+    pub fn commands() -> Vec<DebugCommand> {
+        vec![Self::Breakpoint("".to_string())]
+    }
+
+    pub fn join_commands() -> String {
+        Self::commands()
+            .iter()
+            .map(|command| command.debug_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Used signed arithmetic to compute pointer offsets.
Also add simplification pattern: [0 == c * x] -> 0 == x

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
