### PR TITLE
Add simplification rule for join, etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -596,9 +596,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/documentation/Overview.md
+++ b/documentation/Overview.md
@@ -63,15 +63,15 @@ that is not part of Diem. There also performance problems that arise from inhere
 code analysis.
 
 If you would like to use MIRAI to analyze your code, you should not expect things to work perfectly out of the box.
-Try out MIRAI anyway, and let the MIRA team know how things went and if they can help you in some way.
+Try out MIRAI anyway, and let the MIRAI team know how things went and if they can help you in some way.
 
 ## How to use MIRAI
 
 You'll need to build and install MIRAI as described [here](https://github.com/facebookexperimental/MIRAI#using-mirai).
-That done, you just build your project as normal (but set `RUSTFLAGS="-Z always_encode_mir"`) and then touch the lib.rs
-file of your project and build again as above, but also setting `RUSTC_WRAPPER=mirai`.
+That done, you just build your project as normal (but start clean and set `RUSTFLAGS="-Z always_encode_mir"`) and then
+touch the lib.rs file of your project and build again while also setting `RUSTC_WRAPPER=mirai`.
 
-Using the MIRAI wrapper rather than just plain old Rustc will statically analyze all of the code reachable from entry
+Using the MIRAI wrapper rather than just plain old Rustc will statically analyze all the code reachable from entry
 points in your project. If any of these code paths can lead to an abrupt termination, you'll see Rustc-like diagnostics.
 
 ## Entry points

--- a/validate.sh
+++ b/validate.sh
@@ -15,8 +15,6 @@ cargo fmt --all
 cargo audit
 cargo clippy -- -D warnings
 # Build
-cd checker; cargo rustc --lib -- -D rust-2018-idioms
-cd ..
 cargo build
 
 # build the mirai-standard-contracts crate


### PR DESCRIPTION
## Description

Additional simplification rules, mostly motivated by joins getting too large.
[(a && (x || b)) && (a && b)] -> a && b
[(0 = x || k == x) && (0 != x)] -> k == x if k != 0
[if x { false } else { y } ] -> !x && y
[x join (if c { x } else { y })] -> x join y
[x join (y join (x join z))] -> x join (y join z)
[&x[o1] join &x[o2]] -> &x[o1 join o2]

The last rule above also needs:
&x[o1] subset &x[o2] if o1 subset o2
widen(&x[o1 join o2]) -> &x[widen(o1 join o2)]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem