### PR TITLE
Reduce usage of fresh constants in Z3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -518,18 +518,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/tests/run-pass/bit_counting.rs
+++ b/checker/tests/run-pass/bit_counting.rs
@@ -13,4 +13,12 @@ pub fn t1(bit_map: u8) {
     verify!(ones < 9);
 }
 
+pub fn t2(mut existence_bitmap: u16) {
+    for _ in 0..existence_bitmap.count_ones() {
+        let next_child = existence_bitmap.trailing_zeros() as u8;
+        assume!(next_child < 16); // because we'll only get here if existence_bitmap is not zero
+        existence_bitmap &= !(1 << next_child);
+    }
+}
+
 pub fn main() {}


### PR DESCRIPTION
## Description

An expression that cannot be directly encoded as a Z3 expression becomes a "constant". It is important to use the same constant name for all occurrences of the expression, otherwise assertions that constrain an expression cannot be used to prove conditions that involve the expression.

The TOP and BOTTOM are exceptions to this. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
