### PR TITLE
Tweak the code for removing field 0 of a transparent wrapper

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -3233,8 +3233,17 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
                         if let TyKind::Adt(def, ..) = base_ty.kind() {
                             debug!("def {:?}", def);
                             if def.repr.transparent() {
-                                // don't add the field access
-                                continue;
+                                if let TyKind::Adt(def, ..) = ty.kind() {
+                                    if def.repr.transparent() {
+                                        debug!("source def {:?}", def);
+                                    } else {
+                                        // don't add the field access
+                                        continue;
+                                    }
+                                } else {
+                                    // don't add the field access
+                                    continue;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Description

Tweak the code for removing field 0 from a path when the qualifier is a transparent wrapper.

Looking at this more closely made me realize that transparent wrappers don't quite work the way I thought they did (the name is highly misleading). Doing a principled fix, however, will take days if not weeks, so I'm putting it off for now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
