### PR TITLE
Ignore environment keys that appear during widening iterations

### DIFF
--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -311,15 +311,9 @@ impl Environment {
         let value_map1 = &self.value_map;
         let value_map2 = &other.value_map;
         for (path, val1) in value_map1.iter().filter(|(_, v)| !v.is_bottom()) {
-            match value_map2.get(path) {
-                Some(val2) => {
-                    if !(val1.subset(val2)) {
-                        trace!("self at {:?} is {:?} other is {:?}", path, val1, val2);
-                        return false;
-                    }
-                }
-                None => {
-                    trace!("self at {:?} is {:?} other is None", path, val1);
+            if let Some(val2) = value_map2.get(path) {
+                if !(val1.subset(val2)) {
+                    trace!("self at {:?} is {:?} other is {:?}", path, val1, val2);
                     return false;
                 }
             }


### PR DESCRIPTION
## Description

Environment keys that appear during the widening phase of a fixed point loop are hard to widen and cause fixed point loops to diverge. On the other hand, they are not likely to be accessible via paths in the source code because indexers and offset in those are constructed from values that are actually widened. It should therefore be safe to just ignore the new keys when checking if a fixed point has been reached.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem