### PR TITLE
Set Z3 backtrack positions to be earlier

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1394,11 +1394,11 @@ impl<'block, 'analysis, 'compilation, 'tcx, E>
             // The abstract domains are unable to decide if the entry condition is always true or
             // always false.
             // See if the SMT solver can prove that the entry condition is always false.
+            self.bv.smt_solver.set_backtrack_position();
             let smt_expr = {
                 let ec = &self.bv.current_environment.entry_condition.expression;
                 self.bv.smt_solver.get_as_smt_predicate(ec)
             };
-            self.bv.smt_solver.set_backtrack_position();
             self.bv.smt_solver.assert(&smt_expr);
             if self.bv.smt_solver.solve() == SmtResult::Unsatisfiable {
                 // The solver can prove that the entry condition is always false.


### PR DESCRIPTION
## Description

Translating a MIRAI expression into a Z3 expression can result in type based constraints being added to the solver environment. To purge these, the back tract position should be set to precede the call to the expression translation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
