### PR TITLE
Use a new Z3 solver instance for each body analysis

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -16,7 +16,7 @@ use crate::known_names::KnownNames;
 use crate::options::DiagLevel;
 use crate::path::PathRefinement;
 use crate::path::{Path, PathEnum, PathSelector};
-use crate::smt_solver::SmtResult;
+use crate::smt_solver::{SmtResult, SmtSolver};
 use crate::summaries::{Precondition, Summary};
 use crate::tag_domain::Tag;
 use crate::utils;
@@ -41,24 +41,22 @@ use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
 
 /// Holds the state for the basic block visitor
-pub struct BlockVisitor<'block, 'analysis, 'compilation, 'tcx, E> {
-    pub bv: &'block mut BodyVisitor<'analysis, 'compilation, 'tcx, E>,
+pub struct BlockVisitor<'block, 'analysis, 'compilation, 'tcx> {
+    pub bv: &'block mut BodyVisitor<'analysis, 'compilation, 'tcx>,
 }
 
-impl<'block, 'analysis, 'compilation, 'tcx, E> Debug
-    for BlockVisitor<'block, 'analysis, 'compilation, 'tcx, E>
+impl<'block, 'analysis, 'compilation, 'tcx> Debug
+    for BlockVisitor<'block, 'analysis, 'compilation, 'tcx>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         "BlockVisitor".fmt(f)
     }
 }
 
-impl<'block, 'analysis, 'compilation, 'tcx, E>
-    BlockVisitor<'block, 'analysis, 'compilation, 'tcx, E>
-{
+impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'compilation, 'tcx> {
     pub fn new(
-        body_visitor: &'block mut BodyVisitor<'analysis, 'compilation, 'tcx, E>,
-    ) -> BlockVisitor<'block, 'analysis, 'compilation, 'tcx, E> {
+        body_visitor: &'block mut BodyVisitor<'analysis, 'compilation, 'tcx>,
+    ) -> BlockVisitor<'block, 'analysis, 'compilation, 'tcx> {
         BlockVisitor { bv: body_visitor }
     }
 

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -30,10 +30,10 @@ use crate::tag_domain::Tag;
 use crate::type_visitor::TypeVisitor;
 use crate::{abstract_value, utils};
 
-pub struct CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx, E> {
+pub struct CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx> {
     pub actual_args: Vec<(Rc<Path>, Rc<AbstractValue>)>,
     pub actual_argument_types: Vec<Ty<'tcx>>,
-    pub block_visitor: &'call mut BlockVisitor<'block, 'analysis, 'compilation, 'tcx, E>,
+    pub block_visitor: &'call mut BlockVisitor<'block, 'analysis, 'compilation, 'tcx>,
     pub callee_def_id: DefId,
     pub callee_func_ref: Option<Rc<FunctionReference>>,
     pub callee_fun_val: Rc<AbstractValue>,
@@ -47,25 +47,25 @@ pub struct CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx, E> {
     pub initial_type_cache: Option<Rc<HashMap<Rc<Path>, Ty<'tcx>>>>,
 }
 
-impl<'call, 'block, 'analysis, 'compilation, 'tcx, E> Debug
-    for CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx, E>
+impl<'call, 'block, 'analysis, 'compilation, 'tcx> Debug
+    for CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         "CallVisitor".fmt(f)
     }
 }
 
-impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
-    CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx, E>
+impl<'call, 'block, 'analysis, 'compilation, 'tcx>
+    CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx>
 {
     pub(crate) fn new(
-        block_visitor: &'call mut BlockVisitor<'block, 'analysis, 'compilation, 'tcx, E>,
+        block_visitor: &'call mut BlockVisitor<'block, 'analysis, 'compilation, 'tcx>,
         callee_def_id: DefId,
         callee_generic_arguments: Option<SubstsRef<'tcx>>,
         callee_generic_argument_map: Option<HashMap<rustc_span::Symbol, GenericArg<'tcx>>>,
         environment_before_call: Environment,
         func_const: ConstantDomain,
-    ) -> CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx, E> {
+    ) -> CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx> {
         if let ConstantDomain::Function(func_ref) = &func_const {
             let callee_known_name = func_ref.known_name;
             CallVisitor {
@@ -112,7 +112,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let mut body_visitor = BodyVisitor::new(
                 self.block_visitor.bv.cv,
                 self.callee_def_id,
-                self.block_visitor.bv.smt_solver,
                 self.block_visitor.bv.buffered_diagnostics,
                 self.block_visitor.bv.active_calls_map,
                 self.block_visitor.bv.cv.type_cache.clone(),
@@ -532,7 +531,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                     .expect("a fun ref");
                 let generator_def_id = generator_fun_ref.def_id.expect("a def id");
                 let environment_before_call = self.block_visitor.bv.current_environment.clone();
-                let mut block_visitor = BlockVisitor::<E>::new(self.block_visitor.bv);
+                let mut block_visitor = BlockVisitor::new(self.block_visitor.bv);
                 let mut generator_call_visitor = CallVisitor::new(
                     &mut block_visitor,
                     generator_def_id,
@@ -1192,7 +1191,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
                 )
             }
             let environment_before_call = self.block_visitor.bv.current_environment.clone();
-            let mut block_visitor = BlockVisitor::<E>::new(self.block_visitor.bv);
+            let mut block_visitor = BlockVisitor::new(self.block_visitor.bv);
             let mut indirect_call_visitor = CallVisitor::new(
                 &mut block_visitor,
                 def_id,
@@ -1972,7 +1971,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx, E>
             let right = self.actual_args[1].1.clone();
             let modulo = target_type.modulo_value();
             let (result, overflow_flag) =
-                BlockVisitor::<E>::do_checked_binary_op(bin_op, target_type.clone(), left, right);
+                BlockVisitor::do_checked_binary_op(bin_op, target_type.clone(), left, right);
             let (modulo_result, overflow_flag) = if !modulo.is_bottom() {
                 (result.remainder(target_type.modulo_value()), overflow_flag)
             } else {

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -15,7 +15,6 @@ use crate::options::Options;
 use crate::summaries::PersistentSummaryCache;
 use crate::tag_domain::Tag;
 use crate::utils;
-use crate::z3_solver::Z3Solver;
 
 use crate::type_visitor::TypeCache;
 use log::*;
@@ -152,11 +151,9 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
     fn analyze_body(&mut self, def_id: DefId) {
         let mut diagnostics: Vec<DiagnosticBuilder<'compilation>> = Vec::new();
         let mut active_calls_map: HashMap<DefId, u64> = HashMap::new();
-        let mut z3_solver = Z3Solver::default();
         let mut body_visitor = BodyVisitor::new(
             self,
             def_id,
-            &mut z3_solver,
             &mut diagnostics,
             &mut active_calls_map,
             self.type_cache.clone(),

--- a/checker/src/fixed_point_visitor.rs
+++ b/checker/src/fixed_point_visitor.rs
@@ -19,8 +19,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
 
-pub struct FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx, E> {
-    pub bv: &'fixed mut BodyVisitor<'analysis, 'compilation, 'tcx, E>,
+pub struct FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx> {
+    pub bv: &'fixed mut BodyVisitor<'analysis, 'compilation, 'tcx>,
     already_visited: HashTrieSet<mir::BasicBlock>,
     pub block_indices: Vec<mir::BasicBlock>,
     loop_anchors: HashSet<mir::BasicBlock>,
@@ -30,8 +30,8 @@ pub struct FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx, E> {
     pub terminator_state: HashMap<mir::BasicBlock, Environment>,
 }
 
-impl<'fixed, 'analysis, 'compilation, 'tcx, E> Debug
-    for FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx, E>
+impl<'fixed, 'analysis, 'compilation, 'tcx> Debug
+    for FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         "FixedPoint".fmt(f)
@@ -40,13 +40,13 @@ impl<'fixed, 'analysis, 'compilation, 'tcx, E> Debug
 
 /// A visitor that simply traverses enough of the MIR associated with a particular code body
 /// so that we can test a call to every default implementation of the MirVisitor trait.
-impl<'fixed, 'analysis, 'compilation, 'tcx, E>
-    FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx, E>
+impl<'fixed, 'analysis, 'compilation, 'tcx>
+    FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx>
 {
     #[logfn_inputs(TRACE)]
     pub fn new(
-        body_visitor: &'fixed mut BodyVisitor<'analysis, 'compilation, 'tcx, E>,
-    ) -> FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx, E> {
+        body_visitor: &'fixed mut BodyVisitor<'analysis, 'compilation, 'tcx>,
+    ) -> FixedPointVisitor<'fixed, 'analysis, 'compilation, 'tcx> {
         let dominators = body_visitor.mir.dominators();
         let (block_indices, loop_anchors) = get_sorted_block_indices(body_visitor.mir, &dominators);
         // in_state[bb] is the join (or widening) of the out_state values of each predecessor of bb


### PR DESCRIPTION
## Description

The analysis of one function body should not affect the analysis of another body (except via the summary), so every analysis needs its own SMT solver instance. This was the case until on-demand analysis was introduced. Fixed this to be the case again.

For now, only use Z3 as the solver so that the change set is not too large.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

