### PR TITLE
Support generic static constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -400,9 +400,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]

--- a/checker/tests/run-pass/generic_static.rs
+++ b/checker/tests/run-pass/generic_static.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Checks that trait implementations with constant overrides are handled correctly.
+
+use mirai_annotations::*;
+
+pub trait T {
+    const FOO: bool = false;
+}
+
+pub struct A {}
+
+impl T for A {
+    const FOO: bool = true;
+}
+
+pub fn p<X: T>() {
+    precondition!(X::FOO)
+}
+
+pub fn t1() {
+    p::<A>();
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Support generic static constants. Specifically if a constant is defined in a trait and overridden in a type that implements the trait, a reference to the constant via the trait should be specialized to the override. See the test case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
