### PR TITLE
Promote widened expressions that only refer to parameters

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2616,10 +2616,15 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
     #[logfn_inputs(TRACE)]
     fn check_function_preconditions(&mut self, function_summary: &Summary) {
         verify!(self.block_visitor.bv.check_for_errors);
+        // A precondition can refer to the result if the precondition prevents the result expression
+        // from overflowing.
+        let result = self
+            .destination
+            .map(|(r, _)| self.block_visitor.visit_rh_place(&r));
         for precondition in &function_summary.preconditions {
             let mut refined_condition = precondition.condition.refine_parameters_and_paths(
                 &self.actual_args,
-                &None,
+                &result,
                 &self.environment_before_call,
                 &self.block_visitor.bv.current_environment,
                 self.block_visitor.bv.fresh_variable_offset,

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -706,10 +706,9 @@ impl Expression {
                         .expression
                         .contains_local_variable(is_post_condition)
             }
-            Expression::Join { left, right, path } => {
+            Expression::Join { left, right, .. } => {
                 left.expression.contains_local_variable(is_post_condition)
                     || right.expression.contains_local_variable(is_post_condition)
-                    || path.contains_local_variable(is_post_condition)
             }
             Expression::Memcmp {
                 left,
@@ -753,12 +752,9 @@ impl Expression {
             Expression::UnknownTagField { path } | Expression::Variable { path, .. } => {
                 path.contains_local_variable(is_post_condition)
             }
-            Expression::WidenedJoin { operand, path } => {
-                operand
-                    .expression
-                    .contains_local_variable(is_post_condition)
-                    || path.contains_local_variable(is_post_condition)
-            }
+            Expression::WidenedJoin { operand, .. } => operand
+                .expression
+                .contains_local_variable(is_post_condition),
         }
     }
 

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -11,7 +11,7 @@ fn fact(n: u8) -> u128 {
         1
     } else {
         let n1fac = fact(n - 1);
-        (n as u128) * n1fac //~ possible attempt to multiply with overflow
+        (n as u128) * n1fac
     }
 }
 

--- a/checker/tests/run-pass/queue_drop.rs
+++ b/checker/tests/run-pass/queue_drop.rs
@@ -38,18 +38,12 @@ impl Drop for WaiterQueue<'_> {
             let mut queue = (state_and_queue & !STATE_MASK) as *const Waiter;
             while !queue.is_null() {
                 let next = (*queue).next;
-                let thread = (*queue).thread.replace(None).unwrap(); //~ possible called `Option::unwrap()` on a `None` value
+                let thread = (*queue).thread.replace(None).unwrap();
                 (*queue).signaled.store(true, Ordering::Release);
                 queue = next;
                 thread.unpark();
             }
         }
-    }
-
-    #[cfg(windows)]
-    fn dummy() {
-        // Trigger the warning from thread.replace, which does not come up when runnign on Windows
-        let _ = None.unwrap();
     }
 }
 


### PR DESCRIPTION
## Description

Allow joins and widened joins to be promoted into preconditions if the operand does not contain references to locals (joins always have a local in their paths, so they never got promoted before).

Tweak the simplification rule that abstracts joins if they are used in equality conditions, to only do so if the join cannot be promoted (otherwise joins will get abstracted into unknown locals that cannot be promoted). 

The two (false positive) diagnostics that now go away in the test cases, go away because they get promoted into preconditions. In the case of the factorial test, that precondition gets satisfied in by the caller. In the other test, there is no caller.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
