### PR TITLE
Fix specialization of bound existential type predicates

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -163,7 +163,7 @@ impl MiraiCallbacks {
             || file_name.contains("consensus/src") // Sorts Int and <null> are incompatible 
             || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.contains("crypto/crypto/src") // too slow
-            || file_name.contains("crypto/crypto-derive/src") // too much parsing
+            || file_name.contains("crypto/crypto-derive/src") // too slow
             || file_name.contains("diem-node/src") // Sorts Int and <null> are incompatible
             || file_name.contains("execution/db-bootstrapper/src") // crash
             || file_name.contains("execution/execution-correctness/src") // Sorts Int and <null> are incompatible


### PR DESCRIPTION
## Description

Use the map_bound function to preserve the correct bounds when specializing the predicates of dynamic types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
