### PR TITLE
Add hack to fix canonicalization of old(q.deref).discr

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -813,9 +813,16 @@ impl PathRefinement for Rc<Path> {
                         if let PathEnum::QualifiedPath { selector: qs, .. } = &path.value {
                             if *qs.as_ref() == PathSelector::Deref {
                                 // old(q.deref).s => old(q.deref.s)
+                                // todo: this is a brittle hack. Perhaps the best fix is to just not do this canonicalization.
+                                let var_type =
+                                    if matches!(selector.as_ref(), PathSelector::Discriminant) {
+                                        ExpressionType::Usize
+                                    } else {
+                                        ExpressionType::ThinPointer
+                                    };
                                 return Path::new_computed(
                                     AbstractValue::make_initial_parameter_value(
-                                        ExpressionType::ThinPointer,
+                                        var_type,
                                         Path::new_qualified(path.clone(), selector.clone()),
                                     ),
                                 );


### PR DESCRIPTION
## Description

Path canonicalization is problematic when the path to canonicalize is a selection performed on a qualifier path that corresponds to an initial parameter value. Since there have been no writes to the qualifier path, the selected value is part of the initial value and this value needs to be distinguished from values that may be written to the (naked) path later on. In other words, it makes sense to canonicalize z.s to old(q.deref.s) if z is bound to old(q.deref) in the current environment.  The problem is that initial value expressions need types and the type of z.s is not given in the call to canonicalize (and fixing this is a major work item).

Most of the time it turns out that the type of q.deref.s is a thin pointer, so that has just been supplied in all cases and it works surprisingly well, not least because the type is seldom used. It is used, however, in translating MIRAI expressions to Z3 expressions and if the type is wrong, it can lead to a crash in Z3. To work around this crash for now, this PR adds a special case that provides a numeric type to q.deref.discr.

A more principled fix will have to wait for later.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

