### PR TITLE
Fix is_top and is_bottom

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Upload coverage data to codecov.io
         uses: codecov/codecov-action@v1
         with:
-          path-to-lcov: "lcov.info"
+          files: "lcov.info"

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1739,10 +1739,10 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 }
             }
         }
-        if consequent.expression == Expression::Top {
+        if consequent.is_top() {
             return consequent;
         }
-        if alternate.expression == Expression::Top {
+        if alternate.is_top() {
             return alternate;
         }
         AbstractValue::make_from(
@@ -2596,17 +2596,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     /// True if the set of concrete values that correspond to this domain is empty.
     #[logfn_inputs(TRACE)]
     fn is_bottom(&self) -> bool {
-        match &self.expression {
-            Expression::Bottom => true,
-            Expression::Variable { path, .. } => {
-                if let PathEnum::Computed { value } = &path.value {
-                    value.is_bottom()
-                } else {
-                    false
-                }
-            }
-            _ => false,
-        }
+        matches!(&self.expression, Expression::Bottom)
     }
 
     /// True if this value is a compile time constant.
@@ -2646,17 +2636,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     /// True if all possible concrete values are elements of the set corresponding to this domain.
     #[logfn_inputs(TRACE)]
     fn is_top(&self) -> bool {
-        match &self.expression {
-            Expression::Top => true,
-            Expression::Variable { path, .. } => {
-                if let PathEnum::Computed { value } = &path.value {
-                    value.is_top()
-                } else {
-                    false
-                }
-            }
-            _ => false,
-        }
+        matches!(&self.expression, Expression::Top)
     }
 
     /// True if this value is an empty tuple, which is the sole value of the unit type.
@@ -4335,7 +4315,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 default
             };
         }
-        if self.expression == Expression::Top {
+        if self.is_top() {
             // No type or path information for the discriminator means we know nothing.
             return AbstractValue::make_typed_unknown(
                 default.expression.infer_type(),


### PR DESCRIPTION
## Description

Variable expressions should not return true for is_top or is_bottom since variables (parameters and explicitly abstract values) are not completely unknown (they have type and identity) and always have values.

This manifested as a bug when variables were constrained by assumptions, but the relational expressions in the assumptions simplified to just TOP, leaving no information for the solver to use.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
