### PR TITLE
When a structural copy upcasts the type, ignore the type system

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1233,6 +1233,14 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                         //todo: figure out why this happens
                         target_type = rtype.as_rustc_type(self.tcx);
                     }
+                    // If the copy does an upcast we have to track the type of
+                    // the source value and use it to override the type system
+                    // when resolving methods using the target value as self.
+                    let source_type = self
+                        .type_visitor
+                        .get_path_rustc_type(&path, self.current_span);
+                    self.type_visitor
+                        .set_path_rustc_type(tpath.clone(), source_type);
                     if let PathEnum::LocalVariable { ordinal, .. } = &path.value {
                         if *ordinal >= self.fresh_variable_offset {
                             // A fresh variable from the callee adds no information that is not

--- a/checker/tests/run-pass/type_tracking.rs
+++ b/checker/tests/run-pass/type_tracking.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Checks that argument types are tracked across return results
+
+use mirai_annotations::*;
+
+pub trait Tr {
+    fn bar(&self) -> i32 {
+        2
+    }
+}
+
+struct Bar {
+    i: i32,
+}
+
+impl Tr for Bar {
+    fn bar(&self) -> i32 {
+        self.i
+    }
+}
+
+fn disguise(x: impl Tr) -> impl Tr {
+    x
+}
+
+pub fn t1() {
+    let b = Bar { i: 1 };
+    let d = disguise(b);
+    verify!(d.bar() == 1);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When a structural copy upcasts the type of the source (for example, when the target type is `impl T` and the source type is a struct that implements T) the type system loses track of the original type in some situations (see test case) and this leads to trait method calls not being resolved. Fix this by tracking such types inside MIRAI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
