### PR TITLE
Track concrete result types in summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -439,18 +439,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -245,11 +245,18 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                     }
                 }
 
+                let return_type = self.type_visitor().specialize_generic_argument_type(
+                    self.mir.return_ty(),
+                    &self.type_visitor().generic_argument_map,
+                );
+                let return_type_index = self.type_visitor().get_index_for(return_type);
+
                 result = summaries::summarize(
                     self.mir.arg_count,
                     self.exit_environment.as_ref(),
                     &self.preconditions,
                     &self.post_condition,
+                    return_type_index,
                     self.tcx,
                 );
             }

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2787,6 +2787,15 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             // Assign function result to place
             let target_path = self.block_visitor.visit_rh_place(place);
             let result_path = &Some(target_path.clone());
+            // If the summary has a concrete type for the return result, use that type rather
+            // than the possibly abstract type of the target path.
+            let result_type = self
+                .type_visitor()
+                .get_type_from_index(function_summary.return_type_index);
+            if utils::is_concrete(result_type.kind()) {
+                self.type_visitor_mut()
+                    .set_path_rustc_type(target_path.clone(), result_type);
+            }
             let return_value_path = Path::new_result();
 
             let mut pre_environment = self.environment_before_call.clone();

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -143,7 +143,8 @@ impl MiraiCallbacks {
 
     fn is_excluded(&self, file_name: &str) -> bool {
         // Exclude crates that contain code that causes MIRAI to crash or not terminate within 2 hours
-        if file_name.contains("client/faucet/src") // non termination
+        if file_name.contains("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
+            || file_name.contains("client/faucet/src") // non termination
             || file_name.contains("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.contains("config/management/operational/src") // crash
             || file_name.contains("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
@@ -169,8 +170,7 @@ impl MiraiCallbacks {
 
         // Exclude crates that currently slow down testing too much
         if self.options.diag_level == DiagLevel::Default
-            && (file_name.contains("client/assets-proof/src")
-                || file_name.contains("client/swiss-knife/src")
+            && (file_name.contains("client/swiss-knife/src")
                 || file_name.contains("common/metrics/src")
                 || file_name.contains("common/num-variants/src")
                 || file_name.contains("common/rate-limiter/src")

--- a/checker/src/summaries.rs
+++ b/checker/src/summaries.rs
@@ -92,6 +92,12 @@ pub struct Summary {
     // under the current path condition.
     // The resulting value should be conjoined to the current path condition.
     pub post_condition: Option<Rc<AbstractValue>>,
+
+    /// The type table index for the Rust type of the actual return value.
+    /// Used to make type tracking more precise when the body returns a value of concrete type
+    /// but the return type specification is abstract.
+    #[serde(skip)]
+    pub return_type_index: usize,
 }
 
 /// Bundles together the condition of a precondition with the provenance (place where defined) of
@@ -212,6 +218,7 @@ pub fn summarize(
     exit_environment: Option<&Environment>,
     preconditions: &[Precondition],
     post_condition: &Option<Rc<AbstractValue>>,
+    return_type_index: usize,
     tcx: TyCtxt<'_>,
 ) -> Summary {
     trace!(
@@ -236,6 +243,7 @@ pub fn summarize(
         preconditions,
         side_effects,
         post_condition: post_condition.clone(),
+        return_type_index,
     }
 }
 

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -424,6 +424,7 @@ pub fn is_concrete(ty: &TyKind<'_>) -> bool {
         | TyKind::Dynamic(..)
         | TyKind::Error(..)
         | TyKind::Infer(..)
+        | TyKind::Never
         | TyKind::Opaque(..)
         | TyKind::Param(..) => false,
         TyKind::Ref(_, ty, _) => is_concrete(ty.kind()),


### PR DESCRIPTION
## Description

Add the return type inferred from a function body to the summary of the body. If the summary has a concrete type for the return result, use that type rather than the possibly abstract type of the target path.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
