### PR TITLE
Track concrete types across move/copy instructions

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1532,6 +1532,22 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
         let rtype = self
             .type_visitor()
             .get_rustc_place_type(place, self.bv.current_span);
+        let target_type = self
+            .type_visitor()
+            .get_path_rustc_type(&target_path, self.bv.current_span);
+        if !utils::is_concrete(target_type.kind()) {
+            let source_type = self
+                .type_visitor()
+                .get_path_rustc_type(&rpath, self.bv.current_span);
+            if utils::is_concrete(source_type.kind()) {
+                debug!(
+                    "changing {:?} from {:?} to {:?}",
+                    target_path, target_type, source_type
+                );
+                self.type_visitor_mut()
+                    .set_path_rustc_type(target_path.clone(), source_type);
+            }
+        }
         self.bv
             .copy_or_move_elements(target_path, rpath, rtype, false);
     }
@@ -1545,6 +1561,22 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
         let rtype = self
             .type_visitor()
             .get_rustc_place_type(place, self.bv.current_span);
+        let target_type = self
+            .type_visitor()
+            .get_path_rustc_type(&target_path, self.bv.current_span);
+        if !utils::is_concrete(target_type.kind()) {
+            let source_type = self
+                .type_visitor()
+                .get_path_rustc_type(&rpath, self.bv.current_span);
+            if utils::is_concrete(source_type.kind()) {
+                debug!(
+                    "changing {:?} from {:?} to {:?}",
+                    target_path, target_type, source_type
+                );
+                self.type_visitor_mut()
+                    .set_path_rustc_type(target_path.clone(), source_type);
+            }
+        }
         self.bv
             .copy_or_move_elements(target_path, rpath, rtype, true);
     }


### PR DESCRIPTION
## Description

Track concrete types across move/copy instructions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
