### PR TITLE
Use the type that MIRAI infers for result, in summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -5253,7 +5253,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         //do not use false path conditions to refine things
         checked_precondition!(path_condition.as_bool_if_known().is_none());
         if depth >= k_limits::MAX_REFINE_DEPTH {
-            debug!("max refine depth exceeded during refine_with");
+            trace!("max refine depth exceeded during refine_with");
             return self.clone();
         }
         // In this context path_condition is true

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -245,10 +245,17 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                     }
                 }
 
-                let return_type = self.type_visitor().specialize_generic_argument_type(
-                    self.mir.return_ty(),
-                    &self.type_visitor().generic_argument_map,
-                );
+                let return_type = if matches!(self.cv.options.diag_level, DiagLevel::Paranoid) {
+                    //todo: in the future either ensure that this is unnecessary for soundness
+                    //or do this for DiagLevel::Verify as well.
+                    self.type_visitor().specialize_generic_argument_type(
+                        self.mir.return_ty(),
+                        &self.type_visitor().generic_argument_map,
+                    )
+                } else {
+                    self.type_visitor()
+                        .get_path_rustc_type(&Path::new_result(), self.current_span)
+                };
                 let return_type_index = self.type_visitor().get_index_for(return_type);
 
                 result = summaries::summarize(


### PR DESCRIPTION
## Description

Rather than use the return type inferred by the Rust compiler, use the one tracked by MIRAI. This more often results in a concrete type that can then be used to resolve methods that use the return value as self argument.

This can be unsound in methods that return different concrete types depending on some condition, so the old behavior is retained in paranoid mode. (It really should be the case for verify mode, but the loss of precision is currently unacceptable even in verify mode.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
