### PR TITLE
A ref to a string side a transparent wrapper is also a slice pointer

### DIFF
--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -26,7 +26,7 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .short("t")
         .takes_value(false)
         .help("Focus analysis on #[test] methods.")
-        .long_help("Only #[test] methods and their usage are analyzed. This must be used together with the rustc --test option.")) //todo: just set the --test option, dammit
+        .long_help("Only #[test] methods and their usage are analyzed. This must be used together with the rustc --test option.")) 
     .arg(Arg::with_name("diag")
         .long("diag")
         .possible_values(&["default", "verify", "library", "paranoid"])

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -249,7 +249,8 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
             TyKind::RawPtr(TypeAndMut { ty: target, .. }) | TyKind::Ref(_, target, _) => {
                 trace!("target type {:?}", target.kind());
                 // Pointers to sized arrays are thin pointers.
-                matches!(target.kind(), TyKind::Slice(..) | TyKind::Str)
+                let t = self.remove_transparent_wrappers(target);
+                matches!(t.kind(), TyKind::Slice(..) | TyKind::Str)
             }
             _ => false,
         }


### PR DESCRIPTION
## Description

&str is a slice (fat) pointer, whereas &x where x is a struct is a thin pointer. Except when it is not. That is, if the struct is marked as transparent and has a single field which is of type str, then &x is just &str.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
