### PR TITLE
Tweaks for analyzing tests

### DIFF
--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -136,9 +136,6 @@ impl Options {
         if matches.is_present("single_func") {
             self.single_func = matches.value_of("single_func").map(|s| s.to_string());
         }
-        if matches.is_present("test_only") {
-            self.test_only = true;
-        }
         if matches.is_present("diag") {
             self.diag_level = match matches.value_of("diag").unwrap() {
                 "default" => DiagLevel::Default,
@@ -147,6 +144,12 @@ impl Options {
                 "paranoid" => DiagLevel::Paranoid,
                 _ => assume_unreachable!(),
             };
+        }
+        if matches.is_present("test_only") {
+            self.test_only = true;
+            if self.diag_level != DiagLevel::Paranoid {
+                self.diag_level = DiagLevel::Library;
+            }
         }
         if matches.is_present("constant_time") {
             self.constant_time_tag_name = matches.value_of("constant_time").map(|s| s.to_owned());


### PR DESCRIPTION
## Description

Don't assume that test functions have implicit precondition that prevent them from failing.

When mirai is invoked with a --print=... flag, don't add stuff to the command line because we don't need them in this case and cargo gets upset when it sees things it did not see before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
ran MIRAI over bytecode-verifier-tests in --test_only mode
