### PR TITLE
Track concrete types across explicit upcasts to non concrete types

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1839,6 +1839,16 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                     // path to the thin pointer infers to a type that is a slice pointer.
                     let value_map = self.bv.current_environment.value_map.clone();
                     let source_path = self.visit_lh_place(place);
+                    if !utils::is_concrete(ty.kind()) {
+                        let source_type = self
+                            .type_visitor()
+                            .get_path_rustc_type(&source_path, self.bv.current_span);
+                        if utils::is_concrete(source_type.kind()) {
+                            debug!("changing {:?} from {:?} to {:?}", path, ty, source_type);
+                            self.type_visitor_mut()
+                                .set_path_rustc_type(path.clone(), source_type);
+                        }
+                    }
                     for (p, value) in value_map
                         .iter()
                         .filter(|(p, _)| source_path == **p || p.is_rooted_by(&source_path))


### PR DESCRIPTION
## Description

Track concrete types across explicit upcasts to non concrete types. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem