### PR TITLE
Infer types on field paths rooted by str values

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -442,6 +442,21 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                                 }
                                 unreachable!("t.kind is a closure because of the guard");
                             }
+                            TyKind::Str => {
+                                match *ordinal {
+                                    0 => {
+                                        // Field 0 of a str is a raw pointer to char
+                                        return self.tcx.mk_ptr(rustc_middle::ty::TypeAndMut {
+                                            ty: self.tcx.types.char,
+                                            mutbl: rustc_hir::Mutability::Not,
+                                        });
+                                    }
+                                    1 => {
+                                        return self.tcx.types.usize;
+                                    }
+                                    _ => {}
+                                }
+                            }
                             TyKind::Tuple(types) => {
                                 if let Some(gen_arg) = types.get(*ordinal as usize) {
                                     return gen_arg.expect_ty();


### PR DESCRIPTION
## Description

Infer types on field paths rooted by str values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem