### PR TITLE
Infer the types of function arguments in the caller context

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -713,7 +713,7 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
     pub fn get_function_constant_args(
         &self,
         actual_args: &[(Rc<Path>, Rc<AbstractValue>)],
-    ) -> Vec<(Rc<Path>, Rc<AbstractValue>)> {
+    ) -> Vec<(Rc<Path>, Ty<'tcx>, Rc<AbstractValue>)> {
         let mut result = vec![];
         for (path, value) in self.bv.current_environment.value_map.iter() {
             if let Expression::CompileTimeConstant(ConstantDomain::Function(..)) = &value.expression
@@ -722,7 +722,10 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                     if (*path) == *arg_path || path.is_rooted_by(arg_path) {
                         let param_path_root = Path::new_parameter(i + 1);
                         let param_path = path.replace_root(arg_path, param_path_root);
-                        result.push((param_path, value.clone()));
+                        let ty = self
+                            .type_visitor()
+                            .get_path_rustc_type(&path, self.bv.current_span);
+                        result.push((param_path, ty, value.clone()));
                         break;
                     } else {
                         match &arg_val.expression {
@@ -739,7 +742,10 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                                             Path::new_deref(param_path_root, deref_type);
                                     }
                                     let param_path = path.replace_root(ipath, param_path_root);
-                                    result.push((param_path, value.clone()));
+                                    let ty = self
+                                        .type_visitor()
+                                        .get_path_rustc_type(&path, self.bv.current_span);
+                                    result.push((param_path, ty, value.clone()));
                                     break;
                                 }
                             }
@@ -759,7 +765,10 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                         &value.expression
                     {
                         let param_path = Path::new_parameter(i + 1);
-                        result.push((param_path, value.clone()));
+                        let ty = self
+                            .type_visitor()
+                            .get_path_rustc_type(&path, self.bv.current_span);
+                        result.push((param_path, ty, value.clone()));
                     }
                 }
             }

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -163,7 +163,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
     #[logfn_inputs(TRACE)]
     pub fn visit_body(
         &mut self,
-        function_constant_args: &[(Rc<Path>, Rc<AbstractValue>)],
+        function_constant_args: &[(Rc<Path>, Ty<'tcx>, Rc<AbstractValue>)],
         parameter_types: &[Ty<'tcx>],
     ) -> Summary {
         let diag_level = self.cv.options.diag_level;
@@ -183,10 +183,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
 
         // Add parameter values that are function constants.
         // Also add entries for closure fields.
-        for (path, val) in function_constant_args.iter() {
-            let path_ty = self
-                .type_visitor()
-                .get_path_rustc_type(path, self.current_span);
+        for (path, path_ty, val) in function_constant_args.iter() {
             self.type_visitor_mut()
                 .add_any_closure_fields_for(path_ty, &path, &mut first_state);
             first_state.value_map.insert_mut(path.clone(), val.clone());
@@ -238,7 +235,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 if !function_constant_args.is_empty() {
                     if let Some(mut env) = self.exit_environment.clone() {
                         // Remove function constants so that they do not show up as side-effects.
-                        for (p, _) in function_constant_args {
+                        for (p, _, _) in function_constant_args {
                             env.value_map.remove_mut(p);
                         }
                         self.exit_environment = Some(env);

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -43,7 +43,7 @@ pub struct CallVisitor<'call, 'block, 'analysis, 'compilation, 'tcx> {
     pub cleanup: Option<mir::BasicBlock>,
     pub destination: Option<(mir::Place<'tcx>, mir::BasicBlock)>,
     pub environment_before_call: Environment,
-    pub function_constant_args: &'call [(Rc<Path>, Rc<AbstractValue>)],
+    pub function_constant_args: &'call [(Rc<Path>, Ty<'tcx>, Rc<AbstractValue>)],
     pub initial_type_cache: Option<Rc<HashMap<Rc<Path>, Ty<'tcx>>>>,
 }
 
@@ -270,14 +270,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
     #[logfn_inputs(TRACE)]
     fn get_function_constant_signature(
         &mut self,
-        func_args: &[(Rc<Path>, Rc<AbstractValue>)],
+        func_args: &[(Rc<Path>, Ty<'tcx>, Rc<AbstractValue>)],
     ) -> Option<Rc<Vec<Rc<FunctionReference>>>> {
         if func_args.is_empty() {
             return None;
         }
         let vec: Vec<Rc<FunctionReference>> = func_args
             .iter()
-            .filter_map(|(_, v)| self.block_visitor.get_func_ref(v))
+            .filter_map(|(_, _, v)| self.block_visitor.get_func_ref(v))
             .collect();
         if vec.is_empty() {
             return None;


### PR DESCRIPTION
## Description

Infer the types of function arguments in the caller context since the callee may refer to the path roots via trait types that do not permit the inference of the function argument type. We need such types in case the function is actually a closure and the callee might update it.

An alternative to this fix would be to just ignore such paths, since the callee would not use them, but this seems ugly and brittle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
