### PR TITLE
Always use return type supplied by summary

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2788,7 +2788,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             let result_type = self
                 .type_visitor()
                 .get_type_from_index(function_summary.return_type_index);
-            if utils::is_concrete(result_type.kind()) {
+            if !result_type.is_never() {
                 self.type_visitor_mut()
                     .set_path_rustc_type(target_path.clone(), result_type);
             }


### PR DESCRIPTION
## Description

Always use return type supplied by summary, even if is not concrete because it may be better than the one tracked by the rustc type system and thus enable some virtual method calls to resolve to known function calls.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
