### PR TITLE
Use actual argument types when inferring fun const paths

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1176,7 +1176,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             }
         }
 
-        let function_constant_args = self.block_visitor.get_function_constant_args(&actual_args);
+        let function_constant_args = self
+            .block_visitor
+            .get_function_constant_args(&actual_args, &actual_argument_types);
         let callee_func_ref = self.block_visitor.get_func_ref(&callee);
 
         if let Some(func_ref) = &callee_func_ref {


### PR DESCRIPTION
## Description

Use actual argument types when inferring function const paths in order to get the structure of mutable closures.

Mostly just an optimization. Also helps with debugging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
