### PR TITLE
The never type is concrete

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -157,6 +157,7 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-prover/bytecode/src") // non termination
             || file_name.contains("language/move-prover/interpreter/src") // index out of bounds: the len is 0 but the index is 0
             || file_name.contains("language/move-stdlib/src") // stack overflow
+            || file_name.contains("language/move-prover/lab/src")  // stack overflow
             || file_name.contains("language/tools/move-bytecode-viewer/src") // out of memory
             || file_name.contains("language/tools/move-coverage/src") // out of memory
             || file_name.contains("language/tools/read-write-set/src")  // non termination
@@ -204,7 +205,6 @@ impl MiraiCallbacks {
                 || file_name.contains("language/move-prover/docgen/src")
                 || file_name.contains("language/move-prover/interpreter/src")
                 || file_name.contains("move-prover/errmapgen/src")
-                || file_name.contains("language/move-prover/lab/src")
                 || file_name.contains("language/tools/move-cli/src")
                 || file_name.contains("language/tools/move-unit-test/src")
                 || file_name.contains("language/tools/resource-viewer/src")

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -424,7 +424,6 @@ pub fn is_concrete(ty: &TyKind<'_>) -> bool {
         | TyKind::Dynamic(..)
         | TyKind::Error(..)
         | TyKind::Infer(..)
-        | TyKind::Never
         | TyKind::Opaque(..)
         | TyKind::Param(..) => false,
         TyKind::Ref(_, ty, _) => is_concrete(ty.kind()),


### PR DESCRIPTION
## Description

The never type is actually concrete and since it can be used as a generic argument, this matters for method resolution.

Add a crate to the exclusion list because of a stack overflow. (Unrelated to the above change.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem (in normal as well as verify mode)
