### PR TITLE
Add CLI flag for setting max analysis time

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ string which can contain any of the following flags:
    functions that may contain such errors. With `library` it will require explicit preconditions.
    With `paranoid` it will flag any issue that may be an error.
 - `--single_func <name>`: the name of a specific function you want to analyze.
+- `--body_analysis_timeout <seconds>`: the maximum number of seconds to spend analyzing a function body.
 - `--`: any arguments after this marker are passed on to rustc.
 
 You can get some insight into the inner workings of MIRAI by setting the verbosity level of log output to one of 

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -167,6 +167,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
         parameter_types: &[Ty<'tcx>],
     ) -> Summary {
         let diag_level = self.cv.options.diag_level;
+        let max_analysis_time_for_body = self.cv.options.max_analysis_time_for_body;
         if cfg!(DEBUG) {
             let mut stdout = std::io::stdout();
             stdout.write_fmt(format_args!("{:?}", self.def_id)).unwrap();
@@ -196,7 +197,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
         fixed_point_visitor.visit_blocks();
 
         let elapsed_time_in_seconds = fixed_point_visitor.bv.start_instant.elapsed().as_secs();
-        if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+        if elapsed_time_in_seconds >= max_analysis_time_for_body {
             fixed_point_visitor
                 .bv
                 .report_timeout(elapsed_time_in_seconds);
@@ -207,7 +208,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
             ..Summary::default()
         };
         if !fixed_point_visitor.bv.analysis_is_incomplete
-            || (elapsed_time_in_seconds < k_limits::MAX_ANALYSIS_TIME_FOR_BODY
+            || (elapsed_time_in_seconds < max_analysis_time_for_body
                 && diag_level == DiagLevel::Paranoid)
         {
             // Now traverse the blocks again, doing checks and emitting diagnostics.
@@ -223,7 +224,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 *entry -= 1;
             }
             let elapsed_time_in_seconds = self.start_instant.elapsed().as_secs();
-            if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+            if elapsed_time_in_seconds >= max_analysis_time_for_body {
                 self.report_timeout(elapsed_time_in_seconds);
             } else {
                 // Now create a summary of the body that can be in-lined into call sites.

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -6,9 +6,6 @@
 // Somewhat arbitrary constants used to limit things in the abstract interpreter that may
 // take too long or use too much memory.
 
-/// The maximum number of seconds that MIRAI is willing to analyze a function body for.
-pub const MAX_ANALYSIS_TIME_FOR_BODY: u64 = 40;
-
 /// The maximum number of elements in a byte array that will be individually tracked.
 pub const MAX_BYTE_ARRAY_LENGTH: usize = 100;
 

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -34,7 +34,7 @@ extern crate log;
 
 /// If the currently analyzed function has been marked as angelic because was discovered
 /// to do something that cannot be analyzed, or if the time taken to analyze the current
-/// function exceeded k_limits::MAX_ANALYSIS_TIME_FOR_BODY, break out of the current loop.
+/// function exceeded options.max_analysis_time_for_body, break out of the current loop.
 /// When a timeout happens, currently analyzed function is marked as angelic.
 macro_rules! check_for_early_break {
     ($sel:expr) => {
@@ -42,7 +42,7 @@ macro_rules! check_for_early_break {
             break;
         }
         let elapsed_time_in_seconds = $sel.start_instant.elapsed().as_secs();
-        if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+        if elapsed_time_in_seconds >= $sel.cv.options.max_analysis_time_for_body {
             $sel.analysis_is_incomplete = true;
             break;
         }
@@ -51,7 +51,7 @@ macro_rules! check_for_early_break {
 
 /// If the currently analyzed function has been marked as angelic because was discovered
 /// to do something that cannot be analyzed, or if the time taken to analyze the current
-/// function exceeded k_limits::MAX_ANALYSIS_TIME_FOR_BODY, return to the caller.
+/// function exceeded options.max_analysis_time_for_body, return to the caller.
 /// When a timeout happens, currently analyzed function is marked as angelic.
 macro_rules! check_for_early_return {
     ($sel:expr) => {
@@ -59,7 +59,7 @@ macro_rules! check_for_early_return {
             return;
         }
         let elapsed_time_in_seconds = $sel.start_instant.elapsed().as_secs();
-        if elapsed_time_in_seconds >= k_limits::MAX_ANALYSIS_TIME_FOR_BODY {
+        if elapsed_time_in_seconds >= $sel.cv.options.max_analysis_time_for_body {
             $sel.analysis_is_incomplete = true;
             return;
         }

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -155,6 +155,7 @@ fn invoke_driver(
     // Read MIRAI options from file content.
     let mut options = Options::default();
     options.diag_level = DiagLevel::Paranoid;
+    options.max_analysis_time_for_body = 40;
     let mut rustc_args = vec![]; // any arguments after `--` for rustc
     {
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();


### PR DESCRIPTION
## Description

This PR adds a new command line flag, `--body_analysis_timeout` which replaces the hardcoded constant `k_limits::MAX_ANALYSIS_TIME_FOR_BODY`. This change allows the timeout to be set without requiring a rebuild of MIRAI.
The default value of this flag has been set to 40 seconds; matching the previous default.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

The integration test suite has been updated to include the `body_analysis_timeout = 40` default value in its setup. The test suite passes.

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

