### PR TITLE
Make sure that the option parser determines default values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -149,6 +149,8 @@ impl MiraiCallbacks {
             || file_name.contains("config/management/operational/src") // crash
             || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.contains("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
+            || file_name.contains("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
+            || file_name.contains("language/diem-tools/writeset-transaction-generator/src") // stack overflow
             || file_name.contains("language/diem-vm/src") // Sorts Bool and Int are incompatible
             || file_name.contains("language/move-lang/src") // non termination
             || file_name.contains("language/move-model/src") // non termination
@@ -160,12 +162,14 @@ impl MiraiCallbacks {
             || file_name.contains("language/move-prover/lab/src")  // stack overflow
             || file_name.contains("language/tools/move-bytecode-viewer/src") // out of memory
             || file_name.contains("language/tools/move-coverage/src") // out of memory
+            || file_name.contains("language/tools/move-unit-test/src") // non termination
             || file_name.contains("language/tools/read-write-set/src")  // non termination
             || file_name.contains("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.contains("mempool/src") // out of memory
             || file_name.contains("network/src") // could not fully normalize 
             || file_name.contains("network/builder/src") // could not fully normalize
             || file_name.contains("sdk/client/src") // non termination
+            || file_name.contains("state-sync/src") // Z3 encoding
             || file_name.contains("storage/backup/backup-cli/src") // out of memory
             || file_name.contains("storage/diemdb/src") // expect reference target to have a value
             || file_name.contains("types/src")
@@ -196,8 +200,6 @@ impl MiraiCallbacks {
                 || file_name.contains("language/diem-framework/src")
                 || file_name.contains("language/diem-framework/releases/src")
                 || file_name.contains("language/diem-tools/diem-validator-interface")
-                || file_name.contains("language/diem-tools/transaction-replay/src")
-                || file_name.contains("language/diem-tools/writeset-transaction-generator/src")
                 || file_name.contains("language/diem-vm/src")
                 || file_name.contains("language/move-prover/abigen/src")
                 || file_name.contains("language/move-prover/boogie-backend-exp/src")
@@ -206,7 +208,6 @@ impl MiraiCallbacks {
                 || file_name.contains("language/move-prover/interpreter/src")
                 || file_name.contains("move-prover/errmapgen/src")
                 || file_name.contains("language/tools/move-cli/src")
-                || file_name.contains("language/tools/move-unit-test/src")
                 || file_name.contains("language/tools/resource-viewer/src")
                 || file_name.contains("language/tools/vm-genesis/src")
                 || file_name.contains("network/builder/src")
@@ -216,7 +217,6 @@ impl MiraiCallbacks {
                 || file_name.contains("secure/net/src")
                 || file_name.contains("secure/storage/src")
                 || file_name.contains("secure/storage/vault/src")
-                || file_name.contains("state-sync/src")
                 || file_name.contains("storage/schemadb/src")
                 || file_name.contains("storage/storage-client/src")
                 || file_name.contains("types/src")

--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -46,11 +46,7 @@ fn main() {
 
     // Get any options specified via the MIRAI_FLAGS environment variable
     let mut options = Options::default();
-    let rustc_args = if env::var("MIRAI_FLAGS").is_ok() {
-        options.parse_from_str(&env::var("MIRAI_FLAGS").ok().unwrap())
-    } else {
-        vec![]
-    };
+    let rustc_args = options.parse_from_str(&env::var("MIRAI_FLAGS").unwrap_or_default());
     info!("MIRAI options from environment: {:?}", options);
 
     // Let arguments supplied on the command line override the environment variable.

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -154,14 +154,15 @@ fn invoke_driver(
 ) -> usize {
     // Read MIRAI options from file content.
     let mut options = Options::default();
-    options.diag_level = DiagLevel::Paranoid;
+    options.parse_from_str(""); // get defaults
+    options.diag_level = DiagLevel::Paranoid; // override default
     options.max_analysis_time_for_body = 40;
     let mut rustc_args = vec![]; // any arguments after `--` for rustc
     {
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();
         let options_re = Regex::new(r"(?m)^\s*//\s*MIRAI_FLAGS\s(?P<flags>.*)$").unwrap();
         if let Some(captures) = options_re.captures(&file_content) {
-            rustc_args = options.parse_from_str(&captures["flags"]);
+            rustc_args = options.parse_from_str(&captures["flags"]); // override based on test source
         }
     }
 

--- a/rebuild_std.sh
+++ b/rebuild_std.sh
@@ -15,7 +15,7 @@ cargo build
 touch standard_contracts/src/lib.rs
 RUSTFLAGS="-Z force-overflow-checks=off" cargo build --lib -p mirai-standard-contracts
 touch standard_contracts/src/lib.rs
-RUSTFLAGS="-Z force-overflow-checks=off" RUSTC_WRAPPER=target/debug/mirai RUST_BACKTRACE=1 MIRAI_LOG=warn MIRAI_START_FRESH=true MIRAI_SHARE_PERSISTENT_STORE=true MIRAI_FlAGS="--diag=paranoid" cargo build --lib -p mirai-standard-contracts
+RUSTFLAGS="-Z force-overflow-checks=off" RUSTC_WRAPPER=target/debug/mirai RUST_BACKTRACE=1 MIRAI_LOG=warn MIRAI_START_FRESH=true MIRAI_SHARE_PERSISTENT_STORE=true MIRAI_FLAGS="--diag=paranoid" cargo build --lib -p mirai-standard-contracts
 
 # collect the summary store into a tar file
 cd target/debug/deps

--- a/validate.sh
+++ b/validate.sh
@@ -21,7 +21,7 @@ cargo build
 touch standard_contracts/src/lib.rs
 RUSTFLAGS="-Z force-overflow-checks=off" cargo build --lib -p mirai-standard-contracts
 touch standard_contracts/src/lib.rs
-RUSTFLAGS="-Z force-overflow-checks=off" RUSTC_WRAPPER=target/debug/mirai RUST_BACKTRACE=1 MIRAI_LOG=warn MIRAI_START_FRESH=true MIRAI_SHARE_PERSISTENT_STORE=true MIRAI_FlAGS="--diag=paranoid" cargo build --lib -p mirai-standard-contracts
+RUSTFLAGS="-Z force-overflow-checks=off" RUSTC_WRAPPER=target/debug/mirai RUST_BACKTRACE=1 MIRAI_LOG=warn MIRAI_START_FRESH=true MIRAI_SHARE_PERSISTENT_STORE=true MIRAI_FLAGS="--diag=paranoid" cargo build --lib -p mirai-standard-contracts
 
 # collect the summary store into a tar file
 cd target/debug/deps


### PR DESCRIPTION
## Description

Make sure that the option parser always determines default option values, so that there is only one source of the truth on this.

Fix case error in scripts to build the standard contracts.

Update the exclusion list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem