### PR TITLE
Generalize union field assignment

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -5711,6 +5711,8 @@ impl AbstractValueTrait for Rc<AbstractValue> {
     fn unsigned_modulo(&self, num_bits: u8) -> Rc<AbstractValue> {
         if let Expression::CompileTimeConstant(c) = &self.expression {
             Rc::new(c.unsigned_modulo(num_bits).into())
+        } else if num_bits == 128 {
+            self.try_to_retype_as(&ExpressionType::U128)
         } else {
             let power_of_two = Rc::new(ConstantDomain::U128(1 << num_bits).into());
             let unsigned = self.try_to_retype_as(&ExpressionType::U128);

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -147,6 +147,7 @@ impl MiraiCallbacks {
             || file_name.contains("client/faucet/src") // non termination
             || file_name.contains("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.contains("config/management/operational/src") // crash
+            || file_name.contains("consensus/src") // Sorts Int and <null> are incompatible
             || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.contains("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
             || file_name.contains("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
@@ -189,7 +190,6 @@ impl MiraiCallbacks {
                 || file_name.contains("config/management/genesis/src")
                 || file_name.contains("config/management/network-address-encryption/src")
                 || file_name.contains("config/seed-peer-generator/src")
-                || file_name.contains("consensus/src")
                 || file_name.contains("crypto/crypto/src")
                 || file_name.contains("crypto/crypto-derive/src")
                 || file_name.contains("diem-node/src")

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -617,7 +617,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
     /// Returns the type of the field with the given ordinal.
     /// Ignores any transparent wrappers during the lookup.
     #[logfn_inputs(TRACE)]
-    fn get_field_type(
+    pub fn get_field_type(
         &self,
         def: &'tcx AdtDef,
         substs: SubstsRef<'tcx>,

--- a/checker/tests/run-pass/union_field_assignment.rs
+++ b/checker/tests/run-pass/union_field_assignment.rs
@@ -1,0 +1,146 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that assignments to one field of a union result in updates of all
+// the union fields, transmuting as necessary.
+
+use mirai_annotations::*;
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, PartialEq)]
+pub struct __m128i(i64, i64);
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub union vec128_storage {
+    u32x4: [u32; 4],
+    u64x2: [u64; 2],
+    u128x1: [u128; 1],
+    sse2: __m128i,
+}
+
+fn get_union1(u32x4: [u32; 4]) -> vec128_storage {
+    vec128_storage { u32x4 }
+}
+
+pub fn t1() {
+    let u64x2 = [1, 0, 2, 0];
+    let u = get_union1(u64x2);
+    unsafe {
+        verify!(u.u32x4[0] == 1);
+        verify!(u.u32x4[1] == 0);
+        verify!(u.u32x4[2] == 2);
+        verify!(u.u32x4[3] == 0);
+        verify!(u.u64x2[0] == 1);
+        verify!(u.u64x2[1] == 2);
+        verify!(u.u128x1[0] == (2u128 << 64) + 1);
+        verify!(u.sse2 == __m128i(1, 2));
+    }
+}
+
+fn get_union2(u64x2: [u64; 2]) -> vec128_storage {
+    vec128_storage { u64x2 }
+}
+
+pub fn t2() {
+    let u64x2 = [1, 2];
+    let u = get_union2(u64x2);
+    unsafe {
+        verify!(u.u32x4[0] == 1);
+        verify!(u.u32x4[1] == 0);
+        verify!(u.u32x4[2] == 2);
+        verify!(u.u32x4[3] == 0);
+        verify!(u.u64x2[0] == 1);
+        verify!(u.u64x2[1] == 2);
+        verify!(u.u128x1[0] == (2u128 << 64) + 1);
+        verify!(u.sse2 == __m128i(1, 2));
+    }
+}
+
+fn get_union3(u128x1: [u128; 1]) -> vec128_storage {
+    vec128_storage { u128x1 }
+}
+
+pub fn t3() {
+    let u128x1 = [(2u128 << 64) + 1];
+    let u = get_union3(u128x1);
+    unsafe {
+        verify!(u.u32x4[0] == 1);
+        verify!(u.u32x4[1] == 0);
+        verify!(u.u32x4[2] == 2);
+        verify!(u.u32x4[3] == 0);
+        verify!(u.u64x2[0] == 1);
+        verify!(u.u64x2[1] == 2);
+        verify!(u.u128x1[0] == (2u128 << 64) + 1);
+        verify!(u.sse2 == __m128i(1, 2));
+    }
+}
+
+fn get_union4(sse2: __m128i) -> vec128_storage {
+    vec128_storage { sse2 }
+}
+
+pub fn t4() {
+    let sse2 = __m128i(1, 2);
+    let u = get_union4(sse2);
+    unsafe {
+        verify!(u.u32x4[0] == 1);
+        verify!(u.u32x4[1] == 0);
+        verify!(u.u32x4[2] == 2);
+        verify!(u.u32x4[3] == 0);
+        verify!(u.u64x2[0] == 1);
+        verify!(u.u64x2[1] == 2);
+        verify!(u.u128x1[0] == (2u128 << 64) + 1);
+        verify!(u.sse2 == sse2);
+    }
+}
+
+pub union U1 {
+    x: u32,
+    y: [u8; 4],
+}
+
+pub fn t5() {
+    let u = U1 { x: 257 };
+    unsafe {
+        verify!(u.x == 257);
+        verify!(u.y[0] == 1);
+        verify!(u.y[1] == 1);
+        verify!(u.y[2] == 0);
+        verify!(u.y[3] == 0);
+    }
+}
+
+pub fn t6() {
+    let u = U1 { y: [1, 1, 0, 0] };
+    unsafe {
+        verify!(u.x == 257);
+        verify!(u.y[0] == 1);
+        verify!(u.y[1] == 1);
+        verify!(u.y[2] == 0);
+        verify!(u.y[3] == 0);
+    }
+}
+
+pub union U2 {
+    pub x: u64,
+    pub y: [u8; 4],
+}
+
+pub fn t7() {
+    let _u = U2 { y: [1, 1, 0, 0] }; //~ The union is not fully initialized by this assignment
+}
+
+pub union U3 {
+    pub x: (u32, u32),
+    pub y: u32,
+}
+
+pub fn t8() {
+    let _u = U3 { y: 1 }; //~ The union is not fully initialized by this assignment
+}
+pub fn main() {}


### PR DESCRIPTION
## Description

Properly implement assignments to union fields by updating all fields of a union with appropriately transmuted values. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

