### PR TITLE
Miscellaneous tweaks

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -187,7 +187,7 @@ impl Debug for PathEnum {
             PathEnum::LocalVariable {
                 ordinal,
                 type_index,
-            } => f.write_fmt(format_args!("local_{}: {}", ordinal, type_index)),
+            } => f.write_fmt(format_args!("local_{}({})", ordinal, type_index)),
             PathEnum::Offset { value } => f.write_fmt(format_args!("<{:?}>", value)),
             PathEnum::Parameter { ordinal } => f.write_fmt(format_args!("param_{}", ordinal)),
             PathEnum::Result => f.write_str("result"),

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -604,11 +604,13 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
         let ty = self.remove_transparent_wrappers(ty);
         match &ty.kind() {
             TyKind::Array(t, _) => *t,
-            TyKind::RawPtr(TypeAndMut { ty: t, .. }) | TyKind::Ref(_, t, _) => match t.kind() {
-                TyKind::Array(t, _) => *t,
-                TyKind::Slice(t) => *t,
-                _ => t,
-            },
+            TyKind::RawPtr(TypeAndMut { ty: t, .. }) | TyKind::Ref(_, t, _) => {
+                match self.remove_transparent_wrappers(t).kind() {
+                    TyKind::Array(t, _) => *t,
+                    TyKind::Slice(t) => *t,
+                    _ => t,
+                }
+            }
             TyKind::Slice(t) => *t,
             _ => ty,
         }


### PR DESCRIPTION
## Description

Only transmute values when source and target types are different.
Make local variable type index more visually distinct from field numbers when formatting paths.
Look inside transparent wrappers when getting the element type of a reference type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
