### PR TITLE
Use copy_field_bits when transmuting array slice pointers

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2379,18 +2379,17 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
     /// preconditions and add the post conditions to the exit condition guarding the post call target block.
     #[logfn_inputs(TRACE)]
     pub fn transfer_and_refine_into_current_environment(&mut self, function_summary: &Summary) {
-        trace!("def_id {:?}", self.callee_def_id);
-        trace!("summary {:?}", function_summary);
-        trace!("pre env {:?}", self.block_visitor.bv.current_environment);
-        trace!(
+        debug!("def_id {:?}", self.callee_def_id);
+        debug!("summary {:?}", function_summary);
+        debug!("pre env {:?}", self.block_visitor.bv.current_environment);
+        debug!(
             "target {:?} arguments {:?}",
-            self.destination,
-            self.actual_args
+            self.destination, self.actual_args
         );
         self.check_preconditions_if_necessary(function_summary);
         self.transfer_and_refine_normal_return_state(function_summary);
         self.add_post_condition_to_exit_conditions(function_summary);
-        trace!("post env {:?}", self.block_visitor.bv.current_environment);
+        debug!("post env {:?}", self.block_visitor.bv.current_environment);
     }
 
     /// If we are checking for errors and have not assumed the preconditions of the called function

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -833,7 +833,7 @@ impl PathRefinement for Rc<Path> {
                     Expression::Offset { left, right } if right.is_zero() => {
                         if let Expression::Reference(p) = &left.expression {
                             // *offset(&p, 0) becomes p
-                            if *selector.as_ref() == PathSelector::Deref {
+                            if **selector == PathSelector::Deref {
                                 return p.clone();
                             }
                         }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -257,6 +257,16 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
         }
     }
 
+    /// Returns true if the given type is a reference to the string type.
+    #[logfn_inputs(TRACE)]
+    pub fn is_string_pointer(&self, ty_kind: &TyKind<'tcx>) -> bool {
+        if let TyKind::Ref(_, target, _) = ty_kind {
+            matches!(target.kind(), TyKind::Str)
+        } else {
+            false
+        }
+    }
+
     /// Returns true if the given type is a reference (or raw pointer) that is not a slice pointer
     #[logfn_inputs(TRACE)]
     pub fn is_thin_pointer(&self, ty_kind: &TyKind<'tcx>) -> bool {
@@ -608,10 +618,12 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                 match self.remove_transparent_wrappers(t).kind() {
                     TyKind::Array(t, _) => *t,
                     TyKind::Slice(t) => *t,
+                    TyKind::Str => self.tcx.types.char,
                     _ => t,
                 }
             }
             TyKind::Slice(t) => *t,
+            TyKind::Str => self.tcx.types.char,
             _ => ty,
         }
     }


### PR DESCRIPTION
## Description

Tweak copy_and_transmute to use copy_field_bits when transmuting array slice pointers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
