### PR TITLE
Add an option to print out statistics about analysis success

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -234,9 +234,15 @@ impl MiraiCallbacks {
     fn analyze_with_mirai<'tcx>(&mut self, compiler: &interface::Compiler, tcx: TyCtxt<'tcx>) {
         if self.options.test_only {
             if Self::is_test_excluded(&self.file_name) {
+                if self.options.statistics {
+                    println!("{}, not analyzed, 0", self.file_name);
+                }
                 return;
             }
         } else if self.is_excluded(&self.file_name) {
+            if self.options.statistics {
+                println!("{}, not analyzed, 0", self.file_name);
+            }
             return;
         }
 

--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -230,7 +230,14 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
     #[logfn_inputs(TRACE)]
     fn emit_or_check_diagnostics(&mut self) {
         self.session.diagnostic().reset_err_count();
-        if self.test_run {
+        if self.options.statistics {
+            let mut num_diags = 0;
+            self.diagnostics_for.values_mut().flatten().for_each(|db| {
+                db.cancel();
+                num_diags += 1;
+            });
+            print!("{}, analyzed, {}", self.file_name, num_diags);
+        } else if self.test_run {
             let mut expected_errors = expected_errors::ExpectedErrors::new(self.file_name);
             let mut diags = vec![];
             self.diagnostics_for.values_mut().flatten().for_each(|db| {

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -44,6 +44,12 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .default_value("40")
         .help("The maximum number of seconds that MIRAI will spend analyzing a function body.")
         .long_help("The default is 40 seconds."))
+    .arg(Arg::with_name("statistics")
+        .long("statistics")
+        .short("stats")
+        .takes_value(false)
+        .help("Just print out whether crates were analyzed, etc.")
+        .long_help("Just print out whether crates were analyzed and how many diagnostics were produced for each crate."))
 }
 
 /// Represents options passed to MIRAI.
@@ -54,6 +60,7 @@ pub struct Options {
     pub diag_level: DiagLevel,
     pub constant_time_tag_name: Option<String>,
     pub max_analysis_time_for_body: u64,
+    pub statistics: bool,
 }
 
 /// Represents diag level.
@@ -172,6 +179,9 @@ impl Options {
                 },
                 None => assume_unreachable!(),
             }
+        }
+        if matches.is_present("statistics") {
+            self.statistics = true;
         }
         args[rustc_args_start..].to_vec()
     }


### PR DESCRIPTION
## Description

Add an option to print out statistics about analysis success. The output logs each file that MIRAI is called to analyze, along with whether or not the file is on the exclusion list and if not, how may diagnostics were produced for the crate.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
RUSTFLAGS="-Z always_encode_mir" RUSTC_WRAPPER=mirai MIRAI_FLAGS="--diag=verify --statistics" cargo build -q

Saw output like this:
language/move-ir/types/src/lib.rs, not analyzed, 0
common/fallible/src/lib.rs, analyzed, 0
common/bounded-executor/src/lib.rs, analyzed, 0
common/temppath/src/lib.rs, analyzed, 2

Since the verify option has been specified, this means that fallible and bounded-executor were soundly analyzed and found to have no code points where runtime crashes may occur. temppath on the other hand, has two diagnostics, which are likely false positives.
