### PR TITLE
Add tests for tag analysis with vectors

### DIFF
--- a/checker/tests/run-pass/tag_vector_calls.rs
+++ b/checker/tests/run-pass/tag_vector_calls.rs
@@ -1,0 +1,144 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for adding tags to vectors and checking the tags in calls
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub mod propagation_for_vector_calls {
+    use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+    struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+    const SECRET_TAINT: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+    type SecretTaint = SecretTaintKind<SECRET_TAINT>;
+
+    pub struct Foo {
+        content: i32,
+    }
+
+    pub fn test1() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        call1(bar);
+    }
+
+    fn call1(bar: Vec<Foo>) {
+        // TODO: This should pass
+        verify!(has_tag!(&bar, SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test2() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        call2(bar);
+    }
+
+    fn call2(bar: Vec<Foo>) {
+        precondition!(has_tag!(&bar, SecretTaint));
+    }
+
+    pub fn test3() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0], SecretTaint);
+        call3(bar);
+    }
+
+    fn call3(bar: Vec<Foo>) {
+        // TODO: This should pass
+        verify!(has_tag!(&bar[0], SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test4() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0], SecretTaint);
+        call4(bar);
+    }
+
+    fn call4(bar: Vec<Foo>) {
+        precondition!(has_tag!(&bar[0], SecretTaint));
+    }
+
+    pub fn test5() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0].content, SecretTaint);
+        call5(bar);
+    }
+
+    fn call5(bar: Vec<Foo>) {
+        // TODO: This should pass
+        verify!(has_tag!(&bar[0].content, SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test6() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0].content, SecretTaint);
+        call6(bar); //~related location
+    }
+
+    fn call6(bar: Vec<Foo>) {
+        // TODO: This precondition should be satisfied
+        precondition!(has_tag!(&bar[0].content, SecretTaint)); //~possible unsatisfied precondition
+    }
+
+    pub fn test7() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        call7(bar);
+    }
+
+    fn call7(bar: Vec<Foo>) {
+        // TODO: This should pass due to SubComponent tag propagation
+        verify!(has_tag!(&bar[0], SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test8() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        call8(bar);
+    }
+
+    fn call8(bar: Vec<Foo>) {
+        precondition!(has_tag!(&bar[0], SecretTaint));
+    }
+
+    pub fn test9() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        call9(bar);
+    }
+
+    fn call9(bar: Vec<Foo>) {
+        // TODO: This should pass due to SubComponent tag propagation
+        verify!(has_tag!(&bar[0].content, SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test10() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        call10(bar);
+    }
+
+    fn call10(bar: Vec<Foo>) {
+        precondition!(has_tag!(&bar[0].content, SecretTaint));
+    }
+}
+
+pub fn main() {}

--- a/checker/tests/run-pass/tag_vectors.rs
+++ b/checker/tests/run-pass/tag_vectors.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for adding tags to vectors and vector elements
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub mod propagation_for_vectors {
+    use mirai_annotations::{TagPropagation, TagPropagationSet};
+
+    struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+    const SECRET_TAINT: TagPropagationSet = tag_propagation_set!(TagPropagation::SubComponent);
+
+    type SecretTaint = SecretTaintKind<SECRET_TAINT>;
+
+    pub struct Foo {
+        content: i32,
+    }
+
+    pub fn test1() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        verify!(has_tag!(&bar, SecretTaint));
+    }
+
+    pub fn test2() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0], SecretTaint);
+        verify!(has_tag!(&bar[0], SecretTaint));
+    }
+
+    pub fn test3() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0].content, SecretTaint);
+        // TODO: This should pass
+        verify!(has_tag!(&bar[0].content, SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test4() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        // TODO: TagPropagation::SubComponent should apply to vectors
+        verify!(has_tag!(&bar[0], SecretTaint)); //~provably false verification condition
+    }
+
+    pub fn test5() {
+        // Iteration should not affect tag propagation on vectors
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar, SecretTaint);
+        for foo in bar.iter() {
+            println!("{}", foo.content);
+        }
+        verify!(has_tag!(&bar, SecretTaint));
+    }
+
+    pub fn test6() {
+        // Iteration should not affect tag propagation on vector elements
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        add_tag!(&bar[0], SecretTaint);
+        for foo in bar.iter() {
+            println!("{}", foo.content);
+        }
+        verify!(has_tag!(&bar[0], SecretTaint));
+    }
+
+    pub fn test7() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        for foo in bar.iter() {
+            add_tag!(foo, SecretTaint);
+            println!("{}", foo.content);
+        }
+        // TODO: It should be possible to add tags during iteration
+        verify!(has_tag!(&bar[0], SecretTaint)); //~provably false verification condition
+    }
+
+    pub fn test8() {
+        let mut bar: Vec<Foo> = vec!();
+        bar.push(Foo { content: 0 });
+        for foo in bar.iter() {
+            add_tag!(foo, SecretTaint);
+            println!("{}", foo.content);
+        }
+        // TODO: It should be possible to check tags during iteration
+        for foo in bar.iter() {
+            verify!(has_tag!(foo, SecretTaint)); //~this is unreachable, mark it as such by using the verify_unreachable! macro
+            println!("{}", foo.content);
+        }
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Added tests that exercise tag analysis on vectors. These tests check tagging vectors directly, tagging elements of vectors, and tagging properties of elements of vectors. Checking tags within the same function body and within a separate call are both tested.

Several of the tests currently have issues and thus are marked with "TODO".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

