### PR TITLE
Make the exclusion list checks a bit more precise

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -143,39 +143,41 @@ impl MiraiCallbacks {
 
     fn is_excluded(&self, file_name: &str) -> bool {
         // Exclude crates that contain code that causes MIRAI to crash or not terminate within 2 hours
-        if file_name.contains("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
-            || file_name.contains("client/faucet/src") // non termination
-            || file_name.contains("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
-            || file_name.contains("config/management/operational/src") // crash
-            || file_name.contains("consensus/src") // Sorts Int and <null> are incompatible
-            || file_name.contains("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
-            || file_name.contains("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
-            || file_name.contains("json-rpc/src") // expected a type, but found another kind
-            || file_name.contains("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
-            || file_name.contains("language/diem-tools/writeset-transaction-generator/src") // stack overflow
-            || file_name.contains("language/diem-vm/src") // Sorts Bool and Int are incompatible
-            || file_name.contains("language/move-lang/src") // non termination
-            || file_name.contains("language/move-model/src") // non termination
-            || file_name.contains("language/move-prover/src") // Sorts Int and <null> are incompatible
-            || file_name.contains("language/move-prover/boogie-backend/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
-            || file_name.contains("language/move-prover/bytecode/src") // non termination
-            || file_name.contains("language/move-prover/interpreter/src") // index out of bounds: the len is 0 but the index is 0
-            || file_name.contains("language/move-stdlib/src") // stack overflow
-            || file_name.contains("language/move-prover/lab/src")  // stack overflow
-            || file_name.contains("language/tools/move-bytecode-viewer/src") // out of memory
-            || file_name.contains("language/tools/move-cli/src") // non termination
-            || file_name.contains("language/tools/move-coverage/src") // out of memory
-            || file_name.contains("language/tools/move-unit-test/src") // non termination
-            || file_name.contains("language/tools/read-write-set/src")  // non termination
-            || file_name.contains("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
-            || file_name.contains("mempool/src") // out of memory
-            || file_name.contains("network/src") // could not fully normalize 
-            || file_name.contains("network/builder/src") // could not fully normalize
-            || file_name.contains("sdk/client/src") // non termination
-            || file_name.contains("state-sync/src") // Z3 encoding
-            || file_name.contains("storage/backup/backup-cli/src") // out of memory
-            || file_name.contains("storage/diemdb/src") // expect reference target to have a value
-            || file_name.contains("types/src")
+        if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
+            || file_name.starts_with("client/faucet/src") // non termination
+            || file_name.starts_with("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
+            || file_name.starts_with("config/management/operational/src") // crash
+            || file_name.starts_with("consensus/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("consensus/consensus-types/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
+            || file_name.starts_with("json-rpc/src") // expected a type, but found another kind
+            || file_name.starts_with("json-rpc/types/src") // stack overflow
+            || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
+            || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
+            || file_name.starts_with("language/diem-vm/src") // Sorts Bool and Int are incompatible
+            || file_name.starts_with("language/move-lang/src") // non termination
+            || file_name.starts_with("language/move-model/src") // non termination
+            || file_name.starts_with("language/move-prover/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("language/move-prover/boogie-backend/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
+            || file_name.starts_with("language/move-prover/bytecode/src") // non termination
+            || file_name.starts_with("language/move-prover/interpreter/src") // index out of bounds: the len is 0 but the index is 0
+            || file_name.starts_with("language/move-stdlib/src") // stack overflow
+            || file_name.starts_with("language/move-prover/lab/src")  // stack overflow
+            || file_name.starts_with("language/tools/move-bytecode-viewer/src") // out of memory
+            || file_name.starts_with("language/tools/move-cli/src") // non termination
+            || file_name.starts_with("language/tools/move-coverage/src") // out of memory
+            || file_name.starts_with("language/tools/move-unit-test/src") // non termination
+            || file_name.starts_with("language/tools/read-write-set/src")  // non termination
+            || file_name.starts_with("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
+            || file_name.starts_with("mempool/src") // out of memory
+            || file_name.starts_with("network/src") // could not fully normalize 
+            || file_name.starts_with("network/builder/src") // could not fully normalize
+            || file_name.starts_with("sdk/client/src") // non termination
+            || file_name.starts_with("state-sync/src") // Z3 encoding
+            || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
+            || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value
+            || file_name.starts_with("types/src")
         //Sorts Int and <null> are incompatible
         {
             return true;
@@ -183,46 +185,46 @@ impl MiraiCallbacks {
 
         // Exclude crates that currently slow down testing too much
         if self.options.diag_level == DiagLevel::Default
-            && (file_name.contains("client/swiss-knife/src")
-                || file_name.contains("common/metrics/src")
-                || file_name.contains("common/num-variants/src")
-                || file_name.contains("common/rate-limiter/src")
-                || file_name.contains("config/src")
-                || file_name.contains("config/management/src")
-                || file_name.contains("config/management/genesis/src")
-                || file_name.contains("config/management/network-address-encryption/src")
-                || file_name.contains("config/seed-peer-generator/src")
-                || file_name.contains("crypto/crypto/src")
-                || file_name.contains("crypto/crypto-derive/src")
-                || file_name.contains("diem-node/src")
-                || file_name.contains("language/bytecode-verifier/src")
-                || file_name.contains("language/compiler/src")
-                || file_name.contains("language/compiler/ir-to-bytecode/src")
-                || file_name.contains("language/diem-framework/src")
-                || file_name.contains("language/diem-framework/releases/src")
-                || file_name.contains("language/diem-tools/diem-validator-interface")
-                || file_name.contains("language/diem-vm/src")
-                || file_name.contains("language/move-prover/abigen/src")
-                || file_name.contains("language/move-prover/boogie-backend-exp/src")
-                || file_name.contains("language/move-prover/bytecode/src")
-                || file_name.contains("language/move-prover/docgen/src")
-                || file_name.contains("language/move-prover/interpreter/src")
-                || file_name.contains("language/move-prover/interpreter/crypto/src")
-                || file_name.contains("move-prover/errmapgen/src")
-                || file_name.contains("language/tools/resource-viewer/src")
-                || file_name.contains("language/tools/vm-genesis/src")
-                || file_name.contains("network/builder/src")
-                || file_name.contains("network/discovery/src")
-                || file_name.contains("network/simple-onchain-discovery/src")
-                || file_name.contains("sdk/src")
-                || file_name.contains("secure/key-manager/src")
-                || file_name.contains("secure/net/src")
-                || file_name.contains("secure/storage/src")
-                || file_name.contains("secure/storage/vault/src")
-                || file_name.contains("storage/schemadb/src")
-                || file_name.contains("storage/storage-client/src")
-                || file_name.contains("types/src")
-                || file_name.contains("vm-validator/src"))
+            && (file_name.starts_with("client/swiss-knife/src")
+                || file_name.starts_with("common/metrics/src")
+                || file_name.starts_with("common/num-variants/src")
+                || file_name.starts_with("common/rate-limiter/src")
+                || file_name.starts_with("config/src")
+                || file_name.starts_with("config/management/src")
+                || file_name.starts_with("config/management/genesis/src")
+                || file_name.starts_with("config/management/network-address-encryption/src")
+                || file_name.starts_with("config/seed-peer-generator/src")
+                || file_name.starts_with("crypto/crypto/src")
+                || file_name.starts_with("crypto/crypto-derive/src")
+                || file_name.starts_with("diem-node/src")
+                || file_name.starts_with("language/bytecode-verifier/src")
+                || file_name.starts_with("language/compiler/src")
+                || file_name.starts_with("language/compiler/ir-to-bytecode/src")
+                || file_name.starts_with("language/diem-framework/src")
+                || file_name.starts_with("language/diem-framework/releases/src")
+                || file_name.starts_with("language/diem-tools/diem-validator-interface")
+                || file_name.starts_with("language/diem-vm/src")
+                || file_name.starts_with("language/move-prover/abigen/src")
+                || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
+                || file_name.starts_with("language/move-prover/bytecode/src")
+                || file_name.starts_with("language/move-prover/docgen/src")
+                || file_name.starts_with("language/move-prover/interpreter/src")
+                || file_name.starts_with("language/move-prover/interpreter/crypto/src")
+                || file_name.starts_with("move-prover/errmapgen/src")
+                || file_name.starts_with("language/tools/resource-viewer/src")
+                || file_name.starts_with("language/tools/vm-genesis/src")
+                || file_name.starts_with("network/builder/src")
+                || file_name.starts_with("network/discovery/src")
+                || file_name.starts_with("network/simple-onchain-discovery/src")
+                || file_name.starts_with("sdk/src")
+                || file_name.starts_with("secure/key-manager/src")
+                || file_name.starts_with("secure/net/src")
+                || file_name.starts_with("secure/storage/src")
+                || file_name.starts_with("secure/storage/vault/src")
+                || file_name.starts_with("storage/schemadb/src")
+                || file_name.starts_with("storage/storage-client/src")
+                || file_name.starts_with("types/src")
+                || file_name.starts_with("vm-validator/src"))
         {
             return true;
         }


### PR DESCRIPTION
## Description

Make the exclusion list checks a bit more precise to prevent strings like "types/src" from excluding crates that are actually fine to analyze.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem