### PR TITLE
Add tests for tag propagation on an empty struct

### DIFF
--- a/checker/tests/run-pass/tag_empty_struct.rs
+++ b/checker/tests/run-pass/tag_empty_struct.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for adding and checking tags on empty structs
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[macro_use]
+extern crate mirai_annotations;
+
+pub mod propagation_on_empty_struct {
+    use mirai_annotations::TagPropagationSet;
+
+    struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+    const SECRET_TAINT: TagPropagationSet = tag_propagation_set!();
+
+    type SecretTaint = SecretTaintKind<SECRET_TAINT>;
+
+    pub struct Foo { }
+
+    pub fn test1() {
+        let foo = Foo { };
+        add_tag!(&foo, SecretTaint);
+        verify!(has_tag!(&foo, SecretTaint));
+    }
+
+    pub fn test2() {
+        let foo = Foo { };
+        add_tag!(&foo, SecretTaint);
+        call2(foo);
+    }
+
+    fn call2(foo: Foo) {
+        // TODO: This should pass
+        verify!(has_tag!(&foo, SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test3() {
+        let foo = Foo { };
+        add_tag!(&foo, SecretTaint);
+        call3(foo); //~related location
+    }
+
+    fn call3(foo: Foo) {
+        // TODO: This should pass
+        precondition!(has_tag!(&foo, SecretTaint)); //~unsatisfied precondition
+    }
+
+    pub fn test4() {
+        let foo = Foo { };
+        add_tag!(&foo, SecretTaint);
+        call4(&foo);
+    }
+
+    fn call4(foo: &Foo) {
+        // TODO: This should pass
+        verify!(has_tag!(foo, SecretTaint)); //~possible false verification condition
+    }
+
+    pub fn test5() {
+        let foo = Foo { };
+        add_tag!(&foo, SecretTaint);
+        call5(&foo);
+    }
+
+    fn call5(foo: &Foo) {
+        precondition!(has_tag!(foo, SecretTaint));
+    }   
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Added tests for tag propagation when tags are added to a struct that does not have any fields (an empty struct). Several tests are marked with "TODO" to indicate that the expectation that they should pass.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

