### PR TITLE
Always check path prefixes when checking for propagating tags

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1433,15 +1433,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             let mut check_result =
                 AbstractValue::make_tag_check(tag_field_value, tag, checking_presence);
 
-            // If the tag can be propagated through sub-components, and source_path is rooted by a function parameter,
-            // we need to check the tag on the values that can contain source_path as a sub-component. Note that if
-            // source_path is rooted by a local variable, MIRAI has already propagated the tag to source_path when the
-            // tag was added to the value that contains source_path as a sub-component.
-            // Operationally, source_path is a qualified path and we check if any of its prefix has the tag (when checking_presence = true),
-            // or if all of its prefixes does not have the tag (when checking_presence = false).
-            if tag.is_propagated_by(TagPropagation::SubComponent)
-                && source_path.is_rooted_by_parameter()
-            {
+            // If the tag can be propagated through sub-components we need to check the tag on the
+            // values that can contain source_path as a sub-component.
+            // Operationally, source_path is a qualified path and we check if any of its prefixes
+            // has the tag (when checking_presence = true), or if all of its prefixes does not have
+            // the tag (when checking_presence = false).
+            if tag.is_propagated_by(TagPropagation::SubComponent) {
                 let mut path_prefix = &source_path;
                 while let PathEnum::QualifiedPath { qualifier, .. } = &path_prefix.value {
                     path_prefix = qualifier;

--- a/checker/tests/run-pass/tag_vector_calls.rs
+++ b/checker/tests/run-pass/tag_vector_calls.rs
@@ -32,7 +32,7 @@ pub mod propagation_for_vector_calls {
     }
 
     fn call1(bar: Vec<Foo>) {
-        // TODO: This should pass
+        // A failed verify! does not promote to a precondition.
         verify!(has_tag!(&bar, SecretTaint)); //~possible false verification condition
     }
 
@@ -55,7 +55,7 @@ pub mod propagation_for_vector_calls {
     }
 
     fn call3(bar: Vec<Foo>) {
-        // TODO: This should pass
+        // A failed verify! does not promote to a precondition.
         verify!(has_tag!(&bar[0], SecretTaint)); //~possible false verification condition
     }
 
@@ -78,7 +78,7 @@ pub mod propagation_for_vector_calls {
     }
 
     fn call5(bar: Vec<Foo>) {
-        // TODO: This should pass
+        // A failed verify! does not promote to a precondition.
         verify!(has_tag!(&bar[0].content, SecretTaint)); //~possible false verification condition
     }
 
@@ -101,7 +101,7 @@ pub mod propagation_for_vector_calls {
     }
 
     fn call7(bar: Vec<Foo>) {
-        // TODO: This should pass due to SubComponent tag propagation
+        // A failed verify! does not promote to a precondition.
         verify!(has_tag!(&bar[0], SecretTaint)); //~possible false verification condition
     }
 
@@ -124,7 +124,7 @@ pub mod propagation_for_vector_calls {
     }
 
     fn call9(bar: Vec<Foo>) {
-        // TODO: This should pass due to SubComponent tag propagation
+        // A failed verify! does not promote to a precondition.
         verify!(has_tag!(&bar[0].content, SecretTaint)); //~possible false verification condition
     }
 

--- a/checker/tests/run-pass/tag_vectors.rs
+++ b/checker/tests/run-pass/tag_vectors.rs
@@ -49,8 +49,7 @@ pub mod propagation_for_vectors {
         let mut bar: Vec<Foo> = vec![];
         bar.push(Foo { content: 0 });
         add_tag!(&bar, SecretTaint);
-        // TODO: TagPropagation::SubComponent should apply to vectors
-        verify!(has_tag!(&bar[0], SecretTaint)); //~provably false verification condition
+        verify!(has_tag!(&bar[0], SecretTaint));
     }
 
     pub fn test5() {
@@ -65,14 +64,13 @@ pub mod propagation_for_vectors {
     }
 
     pub fn test6() {
-        // Iteration should not affect tag propagation on vector elements
         let mut bar: Vec<Foo> = vec![];
         bar.push(Foo { content: 0 });
         add_tag!(&bar[0], SecretTaint);
         for foo in bar.iter() {
             println!("{}", foo.content);
         }
-        verify!(has_tag!(&bar[0], SecretTaint)); //~provably false verification condition
+        verify!(has_tag!(&bar[0], SecretTaint));
     }
 
     pub fn test7() {


### PR DESCRIPTION
## Description

Remove an optimization that works for struct fields, but not index fields.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
