### PR TITLE
Check path prefixes when checking a subcomponent of an abstract local

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -154,6 +154,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
             || file_name.starts_with("json-rpc/src") // expected a type, but found another kind
             || file_name.starts_with("json-rpc/types/src") // stack overflow
+            || file_name.starts_with("language/compiler/src") // out of memory
             || file_name.starts_with("language/diem-tools/diem-events-fetcher/src") // crash
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
             || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
@@ -173,6 +174,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/tools/move-coverage/src") // out of memory
             || file_name.starts_with("language/tools/move-unit-test/src") // non termination
             || file_name.starts_with("language/tools/read-write-set/src")  // non termination
+            || file_name.starts_with("language/tools/resource-viewer/src") // out of memory
             || file_name.starts_with("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("mempool/src") // out of memory
             || file_name.starts_with("network/src") // could not fully normalize 
@@ -203,7 +205,6 @@ impl MiraiCallbacks {
                 || file_name.starts_with("crypto/crypto-derive/src")
                 || file_name.starts_with("diem-node/src")
                 || file_name.starts_with("language/bytecode-verifier/src")
-                || file_name.starts_with("language/compiler/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/diem-framework/src")
                 || file_name.starts_with("language/diem-framework/releases/src")
@@ -217,7 +218,6 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
                 || file_name.starts_with("move-prover/errmapgen/src")
                 || file_name.starts_with("language/tools/move-explain/src")
-                || file_name.starts_with("language/tools/resource-viewer/src")
                 || file_name.starts_with("language/tools/vm-genesis/src")
                 || file_name.starts_with("network/builder/src")
                 || file_name.starts_with("network/discovery/src")

--- a/checker/tests/run-pass/tag_result.rs
+++ b/checker/tests/run-pass/tag_result.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for adding tags to Result structs
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+use mirai_annotations::*;
+
+struct SecretTaintKind<const MASK: TagPropagationSet> {}
+
+type SecretTaint = SecretTaintKind<TAG_PROPAGATION_ALL>;
+
+fn get_abs_vec_val() -> Result<Vec<u8>, ()> {
+    result!()
+}
+
+pub fn test1() -> Result<(), ()> {
+    let x: Result<Vec<u8>, ()> = get_abs_vec_val();
+    add_tag!(&x, SecretTaint);
+    let y = x?;
+    verify!(has_tag!(&y, SecretTaint));
+    Ok(())
+}
+
+pub fn test2() {
+    let x: Result<i32, ()> = Ok(42);
+    add_tag!(&x, SecretTaint);
+    let y = x.or(Err(()));
+    verify!(does_not_have_tag!(&y, SecretTaint)); // tag does not flow to y
+    if let Ok(z) = y {
+        verify!(has_tag!(&z, SecretTaint)); // but it does flow to y.Ok
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Tags do not propagate (in the heap model) to the subcomponents of abstract structured values (such as parameter and locals initialized with abstract!). Hence when checking for the presence of a tag on such a subcomponent, the checking logic has to check a succession of shorter path prefixes until it finds the tag or reaches the root. This logic was broken in the case where the subcomponent path is a reference to a local that is a copy of some other local or parameter. The fix is to use a canonicalized path for the prefix generation.

Fixes #902 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

