### PR TITLE
HeapBlock expressions are structured values, not pointers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "lock_api"

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -934,7 +934,7 @@ impl Expression {
             Expression::BitAnd { left, .. } => left.expression.infer_type(),
             Expression::BitNot { result_type, .. } => result_type.clone(),
             Expression::BitOr { left, .. } => left.expression.infer_type(),
-            Expression::HeapBlock { .. } => ThinPointer,
+            Expression::HeapBlock { .. } => NonPrimitive,
             Expression::HeapBlockLayout { .. } => NonPrimitive,
             Expression::IntrinsicBinary { left, name, .. } => match name {
                 KnownNames::StdIntrinsicsCopysignf32

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -775,10 +775,7 @@ impl PathRefinement for Rc<Path> {
             // If we used self instead, then what would we do if we encounter another
             // path that also binds to value &p?
             if val.expression.infer_type() == ExpressionType::ThinPointer {
-                if matches!(
-                    &val.expression,
-                    Expression::HeapBlock { .. } | Expression::Offset { .. }
-                ) {
+                if matches!(&val.expression, Expression::Offset { .. }) {
                     return Path::get_as_path(val.clone());
                 }
                 return Path::new_computed(val.clone());


### PR DESCRIPTION
## Description

HeapBlock expressions started out as being both pointers and structures at the same time, which wasn't the best idea ever and this was fixed a while ago. Unfortunately some outdated code got left behind. Removing it with this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
