### PR TITLE
Avoid calling canonicalize on left hand qualified paths

### DIFF
--- a/checker/tests/run-pass/tag_vectors.rs
+++ b/checker/tests/run-pass/tag_vectors.rs
@@ -80,8 +80,7 @@ pub mod propagation_for_vectors {
         for foo in bar.iter() {
             add_tag!(foo, SecretTaint);
         }
-        //todo: fix tracking of tags in heap when iterators are involved
-        verify!(has_tag!(&bar[0], SecretTaint)); //~ provably false verification condition
+        verify!(has_tag!(&bar[0], SecretTaint));
     }
 
     pub fn test8() {


### PR DESCRIPTION
## Description

Left hand paths that represent fixed memory locations must be canonicalized with care because a lh path to a field containing a pointer cannot just become a path to the thing the pointer points to, since an assignment to this path updates the pointer itself and not thing being pointed to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
