### PR TITLE
Propagate tags from heap blocks to containers via pointers

### DIFF
--- a/checker/tests/run-pass/tag_vectors.rs
+++ b/checker/tests/run-pass/tag_vectors.rs
@@ -22,7 +22,7 @@ pub mod propagation_for_vectors {
     type SecretTaint = SecretTaintKind<SECRET_TAINT>;
 
     pub struct Foo {
-        content: i32,
+        pub content: i32,
     }
 
     pub fn test1() {
@@ -80,6 +80,7 @@ pub mod propagation_for_vectors {
         for foo in bar.iter() {
             add_tag!(foo, SecretTaint);
         }
+        verify!(has_tag!(&bar, SecretTaint));
         verify!(has_tag!(&bar[0], SecretTaint));
     }
 


### PR DESCRIPTION
## Description

Propagate tags from heap blocks to containers via pointers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
