### PR TITLE
Fix handling of promoted constants that are references to references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -145,6 +145,7 @@ impl MiraiCallbacks {
         // Exclude crates that contain code that causes MIRAI to crash or not terminate within 2 hours
         if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
             || file_name.starts_with("client/faucet/src") // non termination
+            || file_name.starts_with("common/bitvec/src") // stack overflow
             || file_name.starts_with("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("config/management/src") // crash
             || file_name.starts_with("config/management/operational/src") // crash

--- a/checker/tests/run-pass/ref_equality.rs
+++ b/checker/tests/run-pass/ref_equality.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks if references can be compared
+
+use mirai_annotations::*;
+
+pub fn main() {
+    let a = &1;
+    verify!(a == &1);
+}


### PR DESCRIPTION
## Description

Fix handling of promoted constants that are references to references.

Fixes #614

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
