### PR TITLE
Make sure that widening does not go away during refinement.

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -572,6 +572,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         other: Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> Rc<AbstractValue> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            return AbstractValue::make_typed_unknown(
+                ExpressionType::Bool,
+                Path::new_computed(TOP.into()),
+            );
+        }
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
@@ -3149,6 +3155,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         other: Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> Rc<AbstractValue> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            return AbstractValue::make_typed_unknown(
+                ExpressionType::Bool,
+                Path::new_computed(TOP.into()),
+            );
+        }
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
@@ -4043,6 +4055,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         other: Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> Rc<AbstractValue> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            return AbstractValue::make_typed_unknown(
+                ExpressionType::Bool,
+                Path::new_computed(TOP.into()),
+            );
+        }
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
@@ -4100,6 +4118,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         other: Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> Rc<AbstractValue> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            return AbstractValue::make_typed_unknown(
+                ExpressionType::Bool,
+                Path::new_computed(TOP.into()),
+            );
+        }
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
@@ -4228,6 +4252,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         other: Rc<AbstractValue>,
         target_type: ExpressionType,
     ) -> Rc<AbstractValue> {
+        if self.is_bottom() || self.is_top() || other.is_bottom() || other.is_top() {
+            return AbstractValue::make_typed_unknown(
+                ExpressionType::Bool,
+                Path::new_computed(TOP.into()),
+            );
+        }
         if let (Expression::CompileTimeConstant(v1), Expression::CompileTimeConstant(v2)) =
             (&self.expression, &other.expression)
         {
@@ -5224,9 +5254,17 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     AbstractValue::make_typed_unknown(var_type.clone(), refined_path)
                 }
             }
-            Expression::WidenedJoin { path, operand, .. } => operand
-                .refine_parameters_and_paths(args, result, pre_env, post_env, fresh)
-                .widen(&path.refine_parameters_and_paths(args, result, pre_env, post_env, fresh)),
+            Expression::WidenedJoin { path, operand } => {
+                let refined_operand =
+                    operand.refine_parameters_and_paths(args, result, pre_env, post_env, fresh);
+                if matches!(refined_operand.expression, Expression::WidenedJoin { .. }) {
+                    refined_operand.widen(
+                        &path.refine_parameters_and_paths(args, result, pre_env, post_env, fresh),
+                    )
+                } else {
+                    AbstractValue::make_typed_unknown(operand.expression.infer_type(), path.clone())
+                }
+            }
         }
     }
 

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -146,6 +146,7 @@ impl MiraiCallbacks {
         if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
             || file_name.starts_with("client/faucet/src") // non termination
             || file_name.starts_with("common/bitvec/src") // stack overflow
+            || file_name.starts_with("common/debug-interface/src") // stack overflow
             || file_name.starts_with("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("config/management/src") // crash
             || file_name.starts_with("config/management/operational/src") // crash
@@ -182,6 +183,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("network/src") // could not fully normalize 
             || file_name.starts_with("network/builder/src") // could not fully normalize
             || file_name.starts_with("sdk/client/src") // non termination
+            || file_name.starts_with("secure/storage/github/src") // stack overflow
             || file_name.starts_with("state-sync/src") // Z3 encoding
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value

--- a/checker/tests/run-pass/factorial.rs
+++ b/checker/tests/run-pass/factorial.rs
@@ -11,7 +11,7 @@ fn fact(n: u8) -> u128 {
         1
     } else {
         let n1fac = fact(n - 1);
-        (n as u128) * n1fac
+        (n as u128) * n1fac //~ possible attempt to multiply with overflow
     }
 }
 

--- a/checker/tests/run-pass/fibonacci.rs
+++ b/checker/tests/run-pass/fibonacci.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks for widening in recursive loops
+
+use mirai_annotations::*;
+
+fn fib(x: u64) -> u64 {
+    match x {
+        0 => 0,
+        1 => 1,
+        _ => fib(x - 1) + fib(x - 2), //~ possible attempt to add with overflow
+    }
+}
+
+pub fn main() {
+    let x = fib(6);
+    verify!(x == 8); //~ possible false verification condition
+}


### PR DESCRIPTION
## Description

Widened joins that arise during recursive loops can collapse into constants during refinement, but if the join has been widened, the refined result cannot be the constant arising from the join.

Also add logic to make sure that overflow checks on expressions where operand are top or bottom, do not simplify into constants.

Fixes #440 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

