### PR TITLE
Make tag checks aware of expression structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -153,6 +153,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("consensus/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("consensus/consensus-types/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("crypto/crypto/src") // stack overflow
             || file_name.starts_with("execution/db-bootstrapper/src") // out of memory
             || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
             || file_name.starts_with("json-rpc/src") // expected a type, but found another kind
@@ -204,7 +205,6 @@ impl MiraiCallbacks {
                 || file_name.starts_with("config/management/genesis/src")
                 || file_name.starts_with("config/management/network-address-encryption/src")
                 || file_name.starts_with("config/seed-peer-generator/src")
-                || file_name.starts_with("crypto/crypto/src")
                 || file_name.starts_with("crypto/crypto-derive/src")
                 || file_name.starts_with("diem-node/src")
                 || file_name.starts_with("language/bytecode-verifier/src")

--- a/checker/tests/run-pass/constant_time_taint.rs
+++ b/checker/tests/run-pass/constant_time_taint.rs
@@ -67,11 +67,9 @@ pub fn test5(v: &[i32; 4]) {
     let mut i = 0;
     while i < 4 {
         if i % 2 != 0 {
-            // todo: improve the precision of lookup_weak_value
             if v[i] > 0 {
             } else {
             }
-            //~ the branch condition may have a ConstantTimeTaintKind tag
         }
         i = i + 1;
     }
@@ -83,8 +81,17 @@ fn work_on_non_secret(non_secret: i32) {
     }
 }
 
-pub fn main() {
+pub fn test6() {
     let non_secret = 99991;
     verify!(does_not_have_tag!(&non_secret, ConstantTimeTaint));
     work_on_non_secret(non_secret);
 }
+
+pub fn test7(mut message: Vec<u8>) {
+    precondition!(does_not_have_tag!(&message, ConstantTimeTaint));
+    for m in 0..message.len() - 1 {
+        message[m] = message[m] + 1;
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When making a tag check expression, look into the structure of the operand of the check and simplify away any sub expressions for which the tag check is known.

Fixes #913 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
