### PR TITLE
Generalize simplification pattern

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -1043,9 +1043,9 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                         if y.eq(&other) || z.eq(&other) {
                             return x.and(other);
                         }
-                        // [(x && (y || z)) && !y] -> (x && z) && !y
+                        // [(x && (y || z)) && !a] -> (x && z) && !a if y => a
                         if let Expression::LogicalNot { operand: y2 } = &other.expression {
-                            if y.eq(y2) {
+                            if y.implies(y2) {
                                 return x.and(z.clone()).and(other);
                             }
                         }
@@ -2835,6 +2835,12 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         // y && x => x
         if let Expression::And { left, right } = &self.expression {
             return left.implies(other) || right.implies(other);
+        }
+
+        // x => x || y
+        // x => y || x
+        if let Expression::Or { left, right } = &other.expression {
+            return self.implies(left) || self.implies(right);
         }
         false
     }

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -148,8 +148,11 @@ impl MiraiCallbacks {
             || file_name.starts_with("common/bitvec/src") // stack overflow
             || file_name.starts_with("common/debug-interface/src") // stack overflow
             || file_name.starts_with("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
+            || file_name.starts_with("config/management/genesis/src") // stack overflow
             || file_name.starts_with("config/management/src") // crash
+            || file_name.starts_with("config/management/network-address-encryption/src") // stack overflow
             || file_name.starts_with("config/management/operational/src") // crash
+            || file_name.starts_with("config/seed-peer-generator/src") // stack overflow
             || file_name.starts_with("consensus/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("consensus/consensus-types/src") // Sorts Int and <null> are incompatible
@@ -160,6 +163,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("json-rpc/types/src") // stack overflow
             || file_name.starts_with("language/compiler/src") // out of memory
             || file_name.starts_with("language/diem-tools/diem-events-fetcher/src") // crash
+            || file_name.starts_with("language/diem-tools/diem-validator-interface") // stack overflow
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
             || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
             || file_name.starts_with("language/diem-vm/src") // Sorts Bool and Int are incompatible
@@ -183,14 +187,18 @@ impl MiraiCallbacks {
             || file_name.starts_with("mempool/src") // out of memory
             || file_name.starts_with("network/src") // could not fully normalize 
             || file_name.starts_with("network/builder/src") // could not fully normalize
+            || file_name.starts_with("network/discovery/src")  // stack overflow
             || file_name.starts_with("sdk/client/src") // non termination
+            || file_name.starts_with("secure/key-manager/src") // stack overflow
             || file_name.starts_with("secure/storage/github/src") // stack overflow
+            || file_name.starts_with("secure/storage/vault/src") // stack overflow
+            || file_name.starts_with("secure/storage/src") // stack overflow
             || file_name.starts_with("state-sync/src") // Z3 encoding
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value
             || file_name.starts_with("storage/diemsum/src") // out of memory
-            || file_name.starts_with("types/src")
-        //Sorts Int and <null> are incompatible
+            || file_name.starts_with("types/src") //Sorts Int and <null> are incompatible
+            || file_name.starts_with("vm-validator/src")
         {
             return true;
         }
@@ -202,16 +210,12 @@ impl MiraiCallbacks {
                 || file_name.starts_with("common/num-variants/src")
                 || file_name.starts_with("common/rate-limiter/src")
                 || file_name.starts_with("config/src")
-                || file_name.starts_with("config/management/genesis/src")
-                || file_name.starts_with("config/management/network-address-encryption/src")
-                || file_name.starts_with("config/seed-peer-generator/src")
                 || file_name.starts_with("crypto/crypto-derive/src")
                 || file_name.starts_with("diem-node/src")
                 || file_name.starts_with("language/bytecode-verifier/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/diem-framework/src")
                 || file_name.starts_with("language/diem-framework/releases/src")
-                || file_name.starts_with("language/diem-tools/diem-validator-interface")
                 || file_name.starts_with("language/diem-vm/src")
                 || file_name.starts_with("language/move-prover/abigen/src")
                 || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
@@ -223,18 +227,13 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/tools/move-explain/src")
                 || file_name.starts_with("language/tools/vm-genesis/src")
                 || file_name.starts_with("network/builder/src")
-                || file_name.starts_with("network/discovery/src")
                 || file_name.starts_with("network/simple-onchain-discovery/src")
                 || file_name.starts_with("sdk/src")
-                || file_name.starts_with("secure/key-manager/src")
                 || file_name.starts_with("secure/net/src")
-                || file_name.starts_with("secure/storage/src")
                 || file_name.starts_with("storage/inspector/src/")
-                || file_name.starts_with("secure/storage/vault/src")
                 || file_name.starts_with("storage/schemadb/src")
                 || file_name.starts_with("storage/storage-client/src")
-                || file_name.starts_with("types/src")
-                || file_name.starts_with("vm-validator/src"))
+                || file_name.starts_with("types/src"))
         {
             return true;
         }


### PR DESCRIPTION
## Description

Generalize 
`[(x && (y || z)) && !y] -> (x && z) && !y `
to  
`[(x && (y || z)) && !a] -> (x && z) && !a if y => a`

Update exclusion list in callbacks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
