### PR TITLE
Fix bug in summarization of Vec::append

### DIFF
--- a/checker/tests/run-pass/vec_append.rs
+++ b/checker/tests/run-pass/vec_append.rs
@@ -8,10 +8,20 @@
 
 use mirai_annotations::*;
 
-pub fn main() {
+pub fn t1() {
     let mut v1: Vec<i32> = Vec::new();
     let mut v2: Vec<i32> = Vec::new();
     v2.push(1);
     v1.append(&mut v2);
     verify!(v1.len() == 1);
 }
+
+pub fn t2() {
+    let mut v1: Vec<u64> = vec![0];
+    let mut v2: Vec<u64> = vec![3];
+    v1.append(&mut v2);
+    verify!(v1.len() == 2);
+    verify!(v1[1] == 3); //~ possible false verification condition
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

The summary for Vec::append had a post condition that refined to false in the call context, leading to erroneous "this statement is unreachable" diagnostics for statements following append. The root cause seems to be a typo in the simplification rule:
`[(x || (y && !z)) || (y && z)))] -> x || y`

While debugging this I also found it convenient to add some more simplification rules:
```
[((c == x) || y) && (c != x)] -> y
[(x || (c == y)) && (c != y)] -> x
[((x || (y && !z)) || a) || (y && z)] -> (x || y) || a
```
Also fixed is a case where x && !x simplifies to x && false instead of just false.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
