### PR TITLE
Stop path canonicalization reverting current state paths to pre-state paths

### DIFF
--- a/checker/tests/run-pass/pre_state.rs
+++ b/checker/tests/run-pass/pre_state.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that checks that pre-state can be used after modification.
+
+use mirai_annotations::*;
+
+pub struct Foo {
+    pub bar: *const i32,
+}
+
+impl Foo {
+    pub fn t1(&mut self) {
+        let s1 = self.bar;
+        self.bar = 1 as *const i32;
+        verify!(s1 == self.bar); //~ possible false verification condition
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

A path rooted in a parameter will have a dummy entry in the environment if accessed before being overwritten in the current state. 
Path canonicalization would find this entry and, if it was typed as pointer, treat it as an alias and thus turn the normal (current state) path into an initial parameter value (pre-state) path. This resulted in the update of the current state appearing like it is a value of the pre-state.

Added a check to the canonicalization function to prevent this from happening.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

