### PR TITLE
Make path canonicalization a bit less hacky

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,9 +399,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -5380,6 +5380,35 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 1,
             ),
             Expression::InitialParameterValue { path, var_type } => {
+                // If the root of path is itself an initial parameter value that is passed by value,
+                // the refined value must also be an initial parameter value.
+                // To ensure this we shield the root from refinement.
+                let param_root_ordinal = path.get_parameter_root_ordinal();
+                if let Some(ordinal) = param_root_ordinal {
+                    if let Some((_, arg_value)) = args.get(ordinal - 1) {
+                        if let Expression::InitialParameterValue { path: arg_path, .. } =
+                            &arg_value.expression
+                        {
+                            if let PathEnum::QualifiedPath { selector, .. } = &arg_path.value {
+                                if **selector == PathSelector::Deref {
+                                    let dummy_root = Path::new_local(999_999, 0);
+                                    let refined_dummy_root = Path::new_local(fresh + 999_999, 0);
+                                    let param_root = Path::new_parameter(ordinal);
+                                    let refined_path = path
+                                        .replace_root(&param_root, dummy_root)
+                                        .refine_parameters_and_paths(
+                                            args, result, pre_env, post_env, fresh,
+                                        )
+                                        .replace_root(&refined_dummy_root, arg_path.clone());
+                                    return AbstractValue::make_initial_parameter_value(
+                                        var_type.clone(),
+                                        refined_path,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
                 let refined_path =
                     path.refine_parameters_and_paths(args, result, pre_env, pre_env, fresh);
                 if let PathEnum::Computed { value } | PathEnum::Offset { value } =


### PR DESCRIPTION
## Description

Move the code for dealing with the special case of refining call by values struct paths that show up in function summaries. The result is less hacky and hopefully easier to debug.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
