### PR TITLE
Add support for generator types

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -871,14 +871,15 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                         .specialize_generic_argument_type(closure_ty, &map);
                 }
                 match specialized_closure_ty.kind() {
-                    TyKind::Closure(def_id, substs) | TyKind::FnDef(def_id, substs) => {
+                    TyKind::Closure(def_id, substs)
+                    | TyKind::Generator(def_id, substs, _)
+                    | TyKind::FnDef(def_id, substs) => {
                         return extract_func_ref(self.visit_function_reference(
                             *def_id,
                             specialized_closure_ty,
                             Some(substs),
                         ));
                     }
-                    //todo: what about generators?
                     TyKind::Ref(_, ty, _) => {
                         let specialized_closure_ty =
                             self.type_visitor().specialize_generic_argument_type(
@@ -3293,8 +3294,8 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                         .update_value_at(base_path.clone(), func_val);
                 }
                 TyKind::Opaque(def_id, ..) => {
-                    //todo: what about generators?
-                    if let TyKind::Closure(def_id, generic_args) =
+                    if let TyKind::Closure(def_id, generic_args)
+                    | TyKind::Generator(def_id, generic_args, _) =
                         self.bv.tcx.type_of(*def_id).kind()
                     {
                         let func_const =

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1183,7 +1183,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                 );
                 actual_argument_types.insert(0, closure_ref_ty);
             }
-            //todo: could this be a generator?
             if let TyKind::Closure(def_id, substs) = closure_ty.kind() {
                 argument_map = self.type_visitor().get_generic_arguments_map(
                     *def_id,

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -167,6 +167,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
             || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
             || file_name.starts_with("language/diem-vm/src") // Sorts Bool and Int are incompatible
+            || file_name.starts_with("language/move-vm/types/src") // Unexpected representation of upvar types
             || file_name.starts_with("language/move-lang/src") // non termination
             || file_name.starts_with("language/move-model/src") // non termination
             || file_name.starts_with("language/move-prover/src") // Sorts Int and <null> are incompatible


### PR DESCRIPTION
## Description

Add code to deal with TyKind::Generator. This makes MIRAI more robust when it runs over code that has async functions and generators.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
