### PR TITLE
Tweak code, exclude crate, add test

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -4764,7 +4764,6 @@ impl AbstractValueTrait for Rc<AbstractValue> {
 
     /// Constructs a switch value.
     #[logfn_inputs(TRACE)]
-    #[logfn(TRACE)]
     fn switch(
         &self,
         mut cases: Vec<(Rc<AbstractValue>, Rc<AbstractValue>)>,

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -651,6 +651,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
         };
         if summary.is_computed && !summary.side_effects.is_empty() {
             let side_effects = summary.side_effects.clone();
+            checked_assume!(self.fresh_variable_offset <= usize::MAX - 1_000_000); // expect to diverge before a call chain gets this deep
             self.fresh_variable_offset += 1_000_000;
             // Effects on the path
             let environment = self.current_environment.clone();

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -145,6 +145,7 @@ impl MiraiCallbacks {
         // Exclude crates that contain code that causes MIRAI to crash or not terminate within 2 hours
         if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
             || file_name.starts_with("client/faucet/src") // non termination
+            || file_name.starts_with("client/swiss-knife/src") // out of memory
             || file_name.starts_with("common/bitvec/src") // stack overflow
             || file_name.starts_with("common/debug-interface/src") // stack overflow
             || file_name.starts_with("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
@@ -206,8 +207,7 @@ impl MiraiCallbacks {
 
         // Exclude crates that currently slow down testing too much
         if self.options.diag_level == DiagLevel::Default
-            && (file_name.starts_with("client/swiss-knife/src")
-                || file_name.starts_with("common/metrics/src")
+            && (file_name.starts_with("common/metrics/src")
                 || file_name.starts_with("common/num-variants/src")
                 || file_name.starts_with("common/rate-limiter/src")
                 || file_name.starts_with("config/src")

--- a/checker/tests/run-pass/switch.rs
+++ b/checker/tests/run-pass/switch.rs
@@ -27,6 +27,22 @@ pub fn foo(foo: Foo) -> u32 {
     }
 }
 
+pub fn foo2(foo: Foo, too: u32) -> u32 {
+    use Foo::*;
+    match foo {
+        Zero => 0u32.wrapping_add(too),
+        One => 1u32.wrapping_add(too),
+        Two => 2u32.wrapping_add(too),
+        Three => 3u32.wrapping_add(too),
+        Four => 4u32.wrapping_add(too),
+        Five => 5u32.wrapping_add(too),
+    }
+}
+
 pub fn main() {
     verify!(foo(Foo::Five) == 5);
+    let too = abstract_value!(2);
+    if too > 1 && too < 10 {
+        verify!(foo2(Foo::Zero, too) > 1);
+    }
 }


### PR DESCRIPTION
## Description

Tweak code to silence some MIRAI on MIRAI diagnostics, exclude crate that causes MIRAI to diverge, add test code that was lying around on my shelf.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI on Diem
