### PR TITLE
Do not remove transparent wrappers from paths

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -158,6 +158,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("consensus/consensus-types/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("crypto/crypto/src") // stack overflow
+            || file_name.starts_with("crypto/crypto-derive/src") // out of memory
             || file_name.starts_with("diem-node/src") // out of memory
             || file_name.starts_with("execution/db-bootstrapper/src") // out of memory
             || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
@@ -183,6 +184,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/tools/move-bytecode-viewer/src") // out of memory
             || file_name.starts_with("language/tools/move-cli/src") // non termination
             || file_name.starts_with("language/tools/move-coverage/src") // out of memory
+            || file_name.starts_with("language/tools/move-explain/src") // out of memory
             || file_name.starts_with("language/tools/move-unit-test/src") // non termination
             || file_name.starts_with("language/tools/read-write-set/src")  // non termination
             || file_name.starts_with("language/tools/resource-viewer/src") // out of memory
@@ -213,7 +215,6 @@ impl MiraiCallbacks {
                 || file_name.starts_with("common/num-variants/src")
                 || file_name.starts_with("common/rate-limiter/src")
                 || file_name.starts_with("config/src")
-                || file_name.starts_with("crypto/crypto-derive/src")
                 || file_name.starts_with("language/bytecode-verifier/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/diem-framework/src")
@@ -224,7 +225,6 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/move-prover/bytecode/src")
                 || file_name.starts_with("language/move-prover/docgen/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
-                || file_name.starts_with("language/tools/move-explain/src")
                 || file_name.starts_with("language/tools/vm-genesis/src")
                 || file_name.starts_with("language/tools/move-bytecode-utils/src")
                 || file_name.starts_with("move-prover/errmapgen/src")

--- a/checker/tests/run-pass/to_owned.rs
+++ b/checker/tests/run-pass/to_owned.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test for transmutation of floating point numbers to integers
+
+use mirai_annotations::*;
+
+pub struct Identifier(Box<str>);
+
+// The transparent attribute is required for the test
+#[repr(transparent)]
+pub struct IdentStr(str);
+
+impl IdentStr {
+    pub fn to_owned(&self) -> Identifier {
+        Identifier(self.0.into())
+    }
+}
+
+pub fn t1() {
+    unsafe {
+        let id_str = std::mem::transmute::<&str, &IdentStr>("abc");
+        let id = id_str.to_owned();
+        verify!(id.0.len() == 3);
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Make down casting to an enum variant work when the enum type is marked transparent.

In general, try and avoid removing "transparent" wrappers because they are only transparent in particular situations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem