### PR TITLE
Clean up is_slice_pointer

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1936,7 +1936,10 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                             let target_type = self
                                 .type_visitor()
                                 .get_path_rustc_type(&target_path, self.bv.current_span);
-                            if self.type_visitor().is_slice_pointer(target_type.kind()) {
+                            if self
+                                .type_visitor()
+                                .is_slice_pointer_or_wraps_one(target_type.kind())
+                            {
                                 // convert the source thin pointer to a fat pointer if the target path is a slice pointer
                                 let thin_pointer_path = Path::new_field(target_path.clone(), 0);
                                 self.bv
@@ -3364,7 +3367,7 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                         // Deref the pointer at field 0 of the box
                         result = Path::new_field(result, 0);
                         ty = ty.boxed_ty();
-                    } else if type_visitor.is_slice_pointer_no_unwrap(ty.kind()) {
+                    } else if type_visitor.is_slice_pointer(ty.kind()) {
                         // Deref the thin pointer part of the slice pointer
                         ty = type_visitor.get_dereferenced_type(ty);
                         let thin_pointer_path = Path::new_field(result, 0);

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1206,13 +1206,6 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                             .set_path_rustc_type(path.clone(), deref_ty);
                     }
                     if self.type_visitor().is_slice_pointer(lh_type.kind()) {
-                        if let PathEnum::QualifiedPath { selector, .. } = &tpath.value {
-                            if matches!(selector.as_ref(), PathSelector::Field(0)) {
-                                // tpath = qualifier.0 and rvalue = &path, so thin pointer copy
-                                self.current_environment.update_value_at(tpath, rvalue);
-                                continue;
-                            }
-                        }
                         // transferring a (pointer, length) tuple.
                         self.copy_or_move_elements(tpath.clone(), path.clone(), lh_type, false);
                         continue;

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2429,8 +2429,10 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             if let Expression::HeapBlockLayout { length, .. } = &layout_val.expression {
                 return length.clone();
             }
-        } else if self.type_visitor().is_slice_pointer(t.kind()) {
-            let elem_t = self.type_visitor().get_element_type(t);
+        } else if self.type_visitor().is_slice_pointer_or_wraps_one(t.kind()) {
+            let elem_t = self
+                .type_visitor()
+                .get_element_type(self.type_visitor().remove_transparent_wrappers(t));
             if let Ok(ty_and_layout) = self.block_visitor.bv.tcx.layout_of(param_env.and(elem_t)) {
                 if !ty_and_layout.is_unsized() {
                     let elem_size_val: Rc<AbstractValue> =


### PR DESCRIPTION
## Description

Clean up the code using is_slice_pointer: Do some renames, use the unwrapping version less and remove some special cases that no longer appear to be needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
