### PR TITLE
Discard layout pseudo field when copying from heap to local storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8190d9cdacf6ee1b080605fd719b58d80a9fcbcea64db6744b26f743da02e447"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -2445,6 +2445,11 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 .filter(|(p, _)| p.is_rooted_by(&source_path))
             {
                 check_for_early_return!(self);
+                if matches!(&value.expression, Expression::HeapBlockLayout { .. })
+                    && !target_path.is_rooted_by_non_local_structure()
+                {
+                    continue;
+                }
                 let qualified_path = path
                     .replace_root(&source_path, target_path.clone())
                     .canonicalize(&self.current_environment);


### PR DESCRIPTION
## Description

Discard layout pseudo field when copying from heap to local storage. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem