### PR TITLE
Simplify copy_and_transmute

### DIFF
--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -255,7 +255,8 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
                 db.clone().buffer(&mut diags)
             });
             if !expected_errors.check_messages(diags) {
-                self.session.fatal("test failed");
+                self.session
+                    .fatal(&format!("test failed: {}", self.file_name));
             }
         } else {
             let mut diagnostics: Vec<&mut DiagnosticBuilder<'_>> =


### PR DESCRIPTION
## Description

Simplify copy_and_transmute and make it not call non_patterned_copy_or_move_elements.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
