### PR TITLE
Rename update_value_at to strong_update_value_at

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -414,7 +414,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                     self.block_visitor
                         .bv
                         .current_environment
-                        .update_value_at(target_path, value.clone());
+                        .strong_update_value_at(target_path, value.clone());
                 }
             }
             self.use_entry_condition_as_exit_condition();
@@ -513,7 +513,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                     self.block_visitor
                         .bv
                         .current_environment
-                        .update_value_at(target_path, return_value);
+                        .strong_update_value_at(target_path, return_value);
                 } else {
                     assume_unreachable!();
                 }
@@ -602,7 +602,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         self.block_visitor
                             .bv
                             .current_environment
-                            .update_value_at(target_path, result);
+                            .strong_update_value_at(target_path, result);
                         self.use_entry_condition_as_exit_condition();
                         return true;
                     }
@@ -688,7 +688,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         self.block_visitor
                             .bv
                             .current_environment
-                            .update_value_at(target_path_discr, target_discr_value);
+                            .strong_update_value_at(target_path_discr, target_discr_value);
                         self.use_entry_condition_as_exit_condition();
                         return true;
                     } else {
@@ -1272,7 +1272,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             self.block_visitor
                 .bv
                 .current_environment
-                .update_value_at(path, abstract_value);
+                .strong_update_value_at(path, abstract_value);
             let exit_condition = self
                 .block_visitor
                 .bv
@@ -1548,12 +1548,15 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
         let destination = &self.destination;
         if let Some((place, _)) = destination {
             let target_path = self.block_visitor.visit_rh_place(place);
-            self.block_visitor.bv.current_environment.update_value_at(
-                target_path.clone(),
-                result.unwrap_or_else(|| {
-                    AbstractValue::make_typed_unknown(ExpressionType::Bool, target_path)
-                }),
-            );
+            self.block_visitor
+                .bv
+                .current_environment
+                .strong_update_value_at(
+                    target_path.clone(),
+                    result.unwrap_or_else(|| {
+                        AbstractValue::make_typed_unknown(ExpressionType::Bool, target_path)
+                    }),
+                );
         } else {
             assume_unreachable!("expected the function call has a destination");
         }
@@ -1830,7 +1833,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         self.block_visitor
                             .bv
                             .current_environment
-                            .update_value_at(target_path, rval);
+                            .strong_update_value_at(target_path, rval);
                     }
                     _ => {
                         let source_path = Path::get_as_path(self.actual_args[2].1.clone());
@@ -2004,7 +2007,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
         self.block_visitor
             .bv
             .current_environment
-            .update_value_at(layout_path, layout);
+            .strong_update_value_at(layout_path, layout);
 
         // Signal to the caller that there is no return result
         abstract_value::BOTTOM.into()
@@ -2082,7 +2085,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             self.block_visitor
                 .bv
                 .current_environment
-                .update_value_at(target_path, discriminant_value);
+                .strong_update_value_at(target_path, discriminant_value);
         }
         self.use_entry_condition_as_exit_condition();
     }
@@ -2195,12 +2198,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
         self.block_visitor
             .bv
             .current_environment
-            .update_value_at(layout_path.clone(), new_length_layout);
+            .strong_update_value_at(layout_path.clone(), new_length_layout);
         let layout_path2 = Path::new_layout(layout_path);
         self.block_visitor
             .bv
             .current_environment
-            .update_value_at(layout_path2, layout_param);
+            .strong_update_value_at(layout_path2, layout_param);
 
         // Return the original heap block reference as the result
         self.actual_args[0].1.clone()
@@ -2254,11 +2257,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             self.block_visitor
                 .bv
                 .current_environment
-                .update_value_at(path0, modulo_result);
+                .strong_update_value_at(path0, modulo_result);
             self.block_visitor
                 .bv
                 .current_environment
-                .update_value_at(path1, overflow_flag);
+                .strong_update_value_at(path1, overflow_flag);
             AbstractValue::make_typed_unknown(target_type, target_path)
         } else {
             assume_unreachable!();
@@ -2528,7 +2531,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             self.block_visitor
                 .bv
                 .current_environment
-                .update_value_at(dest_pattern, source_value);
+                .strong_update_value_at(dest_pattern, source_value);
         } else if let Expression::CompileTimeConstant(ConstantDomain::U128(count)) =
             &count_value.expression
         {
@@ -2544,7 +2547,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                     self.block_visitor
                         .bv
                         .current_environment
-                        .update_value_at(dest_field, field_value);
+                        .strong_update_value_at(dest_field, field_value);
                     if elem_size == 0 {
                         break;
                     }
@@ -2904,9 +2907,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                             self.block_visitor
                                 .bv
                                 .current_environment
-                                .update_value_at(rpath.clone(), rvalue.clone());
+                                .strong_update_value_at(rpath.clone(), rvalue.clone());
                         }
-                        pre_environment.update_value_at(rpath, rvalue);
+                        pre_environment.strong_update_value_at(rpath, rvalue);
                     }
                     check_for_early_return!(self.block_visitor.bv);
                 }
@@ -2947,7 +2950,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                 self.block_visitor
                     .bv
                     .current_environment
-                    .update_value_at(target_path, result);
+                    .strong_update_value_at(target_path, result);
             }
         }
     }

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -58,7 +58,7 @@ impl Environment {
 
     /// Updates the path to value map so that the given path now points to the given value.
     #[logfn_inputs(TRACE)]
-    pub fn update_value_at(&mut self, path: Rc<Path>, value: Rc<AbstractValue>) {
+    pub fn strong_update_value_at(&mut self, path: Rc<Path>, value: Rc<AbstractValue>) {
         self.value_map.insert_mut(path, value);
     }
 


### PR DESCRIPTION
## Description

Rename update_value_at to strong_update_value_at, to prepare for the introduction of a revamped update_value_at that also does weak updates if the target path is potential alias for other paths. (Even after canonicalization, paths involving run-time computations might alias other paths and the values associated with these paths need to get weakened to account for the possibility that the update might affect them.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
