### PR TITLE
Move some slice initializer logic to environment.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "lock_api"

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -178,6 +178,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/move-prover/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("language/move-prover/boogie-backend/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
+            || file_name.starts_with("language/move-prover/mutation") // stack overflow
             || file_name.starts_with("language/move-stdlib/src") // stack overflow
             || file_name.starts_with("language/move-prover/interpreter/src") // stack overflow
             || file_name.starts_with("language/move-prover/lab/src")  // stack overflow
@@ -205,6 +206,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("secure/storage/vault/src") // stack overflow
             || file_name.starts_with("secure/storage/src") // stack overflow
             || file_name.starts_with("state-sync/src") // Z3 encoding
+            || file_name.starts_with("state-sync/state-sync-v1/src") // Z3 encoding
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value
             || file_name.starts_with("storage/diemsum/src") // out of memory
@@ -234,13 +236,11 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/move-prover/bytecode/src")
                 || file_name.starts_with("language/move-prover/docgen/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
-                || file_name.starts_with("language/move-prover/mutation")
                 || file_name.starts_with("move-prover/errmapgen/src")
                 || file_name.starts_with("network/builder/src")
                 || file_name.starts_with("network/simple-onchain-discovery/src")
                 || file_name.starts_with("sdk/src")
                 || file_name.starts_with("secure/net/src")
-                || file_name.starts_with("state-sync/state-sync-v1")
                 || file_name.starts_with("storage/schemadb/src")
                 || file_name.starts_with("storage/storage-client/src")
                 || file_name.starts_with("types/src"))


### PR DESCRIPTION
## Description

A baby step towards a unified logic for handling left hand paths when storing a simple value to the environment as well as when copying or moving a structured value.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
