### PR TITLE
Canonicalize Slice of Offset, to ConstantSlice when possible

### DIFF
--- a/checker/tests/run-pass/write_bytes.rs
+++ b/checker/tests/run-pass/write_bytes.rs
@@ -71,4 +71,21 @@ pub fn t5() {
     verify!(t.1 == 0xfefe);
 }
 
+fn foo3(a: &mut [u8], n: usize) {
+    a[0] = 99;
+    unsafe {
+        let b = &mut a[1..];
+        let ptr = b.as_mut_ptr();
+        std::ptr::write_bytes(ptr, 0xfe, n);
+    }
+}
+
+pub fn t6() {
+    let mut a = [1u8, 2u8, 3u8];
+    foo3(&mut a[0..3], 2);
+    verify!(a[0] == 99);
+    verify!(a[1] == 0xfe);
+    verify!(a[2] == 0xfe);
+}
+
 pub fn main() {}


### PR DESCRIPTION
## Description

Canonicalize Slice of Offset, to ConstantSlice when when the count value of the Slice and the right hand value of the Offset are compile time constants. Also add support for initializing ConstantSlice paths with a simple value.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
