### PR TITLE
Tweaks

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1988,7 +1988,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
     /// Assign abstract values to the target fields that are consistent with the concrete values
     /// that will arise at runtime if the sequential (packed) bytes of the source fields are copied to the
     /// target fields on a little endian machine.
-    #[logfn_inputs(DEBUG)]
+    #[logfn_inputs(TRACE)]
     fn copy_field_bits(
         &mut self,
         source_fields: Vec<(Rc<Path>, Ty<'tcx>)>,

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2495,13 +2495,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                 .get_dereferenced_type(self.actual_argument_types[0])
                 .kind(),
         );
-        let dest_path = Path::new_deref(
-            Path::get_as_path(self.actual_args[0].1.clone()),
-            target_type,
-        )
-        .canonicalize(&self.block_visitor.bv.current_environment);
+        let dest_path = Path::new_deref(self.actual_args[0].0.clone(), target_type)
+            .canonicalize(&self.block_visitor.bv.current_environment);
         let dest_type = self.actual_argument_types[0];
-        let source_path = Path::get_as_path(self.actual_args[1].1.clone());
+        let source_path = self.actual_args[1]
+            .0
+            .canonicalize(&self.block_visitor.bv.current_environment);
         let byte_value = &self.actual_args[1].1;
         let count_value = self.actual_args[2].1.clone();
         let elem_type = self

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -167,11 +167,13 @@ impl MiraiCallbacks {
             || file_name.starts_with("json-rpc/types/src") // stack overflow
             || file_name.starts_with("language/compiler/src") // out of memory
             || file_name.starts_with("language/diem-framework/src") // expect reference target to have a value
+            || file_name.starts_with("language/diem-tools/df-cli/src") // Sorts <null> and Int are incompatible
             || file_name.starts_with("language/diem-tools/diem-events-fetcher/src") // crash
             || file_name.starts_with("language/diem-tools/diem-validator-interface") // stack overflow
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
             || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
             || file_name.starts_with("language/diem-vm/src") // Sorts Bool and Int are incompatible
+            || file_name.starts_with("language/move-binary-format/src") // Sorts <null> and Int are incompatible
             || file_name.starts_with("language/move-vm/types/src") // Unexpected representation of upvar types
             || file_name.starts_with("language/move-lang/src") // non termination
             || file_name.starts_with("language/move-model/src") // non termination
@@ -180,6 +182,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
             || file_name.starts_with("language/move-prover/mutation") // stack overflow
             || file_name.starts_with("language/move-stdlib/src") // stack overflow
+            || file_name.starts_with("language/move-prover/docgen/src") //  Unexpected representation of upvar types tuple Param(<upvars>/
             || file_name.starts_with("language/move-prover/interpreter/src") // stack overflow
             || file_name.starts_with("language/move-prover/lab/src")  // stack overflow
             || file_name.starts_with("language/tools/disassembler/src") // out of memory
@@ -227,14 +230,11 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/bytecode-verifier/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/diem-framework/releases/src")
-                || file_name.starts_with("language/diem-tools/df-cli/src")
                 || file_name.starts_with("language/diem-vm/src")
-                || file_name.starts_with("language/move-binary-format/src")
                 || file_name.starts_with("language/move-core/types/src")
                 || file_name.starts_with("language/move-prover/abigen/src")
                 || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
                 || file_name.starts_with("language/move-prover/bytecode/src")
-                || file_name.starts_with("language/move-prover/docgen/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
                 || file_name.starts_with("move-prover/errmapgen/src")
                 || file_name.starts_with("network/builder/src")

--- a/checker/tests/run-pass/write_bytes.rs
+++ b/checker/tests/run-pass/write_bytes.rs
@@ -88,4 +88,20 @@ pub fn t6() {
     verify!(a[2] == 0xfe);
 }
 
+fn foo4(a: &mut [u8], n: usize) {
+    a[n] = 99;
+    unsafe {
+        let ptr = a.as_mut_ptr();
+        std::ptr::write_bytes(ptr, 0xfe, n);
+    }
+}
+
+pub fn t7() {
+    let mut a = [1u8, 2u8, 3u8];
+    foo4(&mut a[0..3], 2);
+    verify!(a[0] == 0xfe);
+    verify!(a[1] == 0xfe);
+    verify!(a[2] == 99);
+}
+
 pub fn main() {}


### PR DESCRIPTION
## Description

Demote a DEBUG log to TRACE.
Use the argument paths already available, rather than make paths out of argument values.
Exclude more crates from the full test run because of crashes.
Add a test case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
