### PR TITLE
Support p[i] = expr where expr is not structured

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -493,7 +493,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                     };
                     if result_type != ExpressionType::NonPrimitive {
                         self.current_environment
-                            .update_value_at(path, result.clone());
+                            .strong_update_value_at(path, result.clone());
                     }
                     result
                 })
@@ -509,7 +509,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 };
                 if result_type != ExpressionType::NonPrimitive {
                     self.current_environment
-                        .update_value_at(path, result.clone());
+                        .strong_update_value_at(path, result.clone());
                 }
                 result
             }

--- a/checker/tests/run-pass/ascii_set.rs
+++ b/checker/tests/run-pass/ascii_set.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that uses computed constants.
+
+use mirai_annotations::*;
+
+pub struct AsciiSet {
+    mask: [Chunk; ASCII_RANGE_LEN / BITS_PER_CHUNK],
+}
+
+type Chunk = u32;
+
+const ASCII_RANGE_LEN: usize = 0x80;
+
+const BITS_PER_CHUNK: usize = 8 * std::mem::size_of::<Chunk>();
+
+impl AsciiSet {
+    /// Called with UTF-8 bytes rather than code points.
+    /// Not used for non-ASCII bytes.
+    const fn contains(&self, byte: u8) -> bool {
+        let chunk = self.mask[byte as usize / BITS_PER_CHUNK];
+        let mask = 1 << (byte as usize % BITS_PER_CHUNK);
+        (chunk & mask) != 0
+    }
+
+    pub const fn add(&self, byte: u8) -> Self {
+        let mut mask = self.mask;
+        mask[byte as usize / BITS_PER_CHUNK] |= 1 << (byte as usize % BITS_PER_CHUNK);
+        AsciiSet { mask }
+    }
+}
+
+pub fn t1() {
+    let s = AsciiSet { mask: [0, 0, 0, 0] };
+    let s1 = s.add(1);
+    verify!(s1.contains(1));
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

Also deals with potentially aliasing of p[i] when updating p[j].

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

