### PR TITLE
Call graph fixes for missing no-arg edge and duplicated croot node

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -288,12 +288,20 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
     #[logfn_inputs(TRACE)]
     pub fn get_function_summary(&mut self) -> Option<Summary> {
         self.try_to_devirtualize();
-        for ty in self.actual_argument_types.iter() {
+        if self.actual_argument_types.is_empty() {
             self.block_visitor.bv.cv.call_graph.add_edge(
                 self.block_visitor.bv.def_id,
                 self.callee_def_id,
-                ty.to_string().into_boxed_str(),
+                "".to_string().into_boxed_str(),
             );
+        } else {
+            for ty in self.actual_argument_types.iter() {
+                self.block_visitor.bv.cv.call_graph.add_edge(
+                    self.block_visitor.bv.def_id,
+                    self.callee_def_id,
+                    ty.to_string().into_boxed_str(),
+                );
+            }
         }
         if let Some(func_ref) = &self.callee_func_ref.clone() {
             // If the actual arguments include any function constants, collect them together

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -57,6 +57,7 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .long_help(r#"Path to a JSON configuration file that optionally specifies:
                         "dot_output_path": Path to store the call graph in dot format for displaying with graphviz.
                         "ddlog_output_path": Path to store datalog input relations representing the call graph.
+                        "type_map_output_path": Path to store mapping from edge type indexes to strings.
                         "type_relations_path": Path to a file storing type relations to be imported for datalog output.
                         "reductions": A list of reductions to perform on the call graph.
                         "included_crates": A list of crates to include in the call graph. If empty, all crates are included."#))

--- a/checker/tests/call_graph/replace_croot.rs
+++ b/checker/tests/call_graph/replace_croot.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Linear call graph with static calls, single type, no dominance, no loops.
+
+pub fn main() {
+    fn1();
+}
+
+pub fn fn1() -> u32 {
+    1
+}
+
+/* CONFIG
+{
+    "reductions": [],
+    "included_crates": []
+}
+*/
+
+/* EXPECTED:DOT
+digraph {
+    0 [ label = "\"replace_croot::main\"" ]
+    1 [ label = "\"replace_croot::fn1\"" ]
+    0 -> 1 [ ]
+}
+*/
+
+/* EXPECTED:DDLOG
+start;
+insert Edge(0,0,1);
+insert EdgeType(0,0);
+commit;
+*/
+
+/* EXPECTED:TYPEMAP
+{
+  "0": ""
+}
+*/

--- a/checker/tests/call_graph/replace_croot.rs
+++ b/checker/tests/call_graph/replace_croot.rs
@@ -4,7 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// Linear call graph with static calls, single type, no dominance, no loops.
+// Test case that ensures that a CROOT node is not duplicated if it
+// is analyzed by MIRAI after MIRAI analyzed its first call.
 
 pub fn main() {
     fn1();

--- a/checker/tests/call_graph/static_no_args.rs
+++ b/checker/tests/call_graph/static_no_args.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Linear call graph with static calls, single type, no dominance, no loops.
+
+fn fn1() -> u32 {
+    1
+}
+pub fn main() {
+    fn1();
+}
+
+/* CONFIG
+{
+    "reductions": [],
+    "included_crates": []
+}
+*/
+
+/* EXPECTED:DOT
+digraph {
+    0 [ label = "\"static_no_args::main\"" ]
+    1 [ label = "\"static_no_args::fn1\"" ]
+    0 -> 1 [ ]
+}
+*/
+
+/* EXPECTED:DDLOG
+start;
+insert Edge(0,0,1);
+insert EdgeType(0,0);
+commit;
+*/
+
+/* EXPECTED:TYPEMAP
+{
+  "0": ""
+}
+*/

--- a/checker/tests/call_graph/static_no_args.rs
+++ b/checker/tests/call_graph/static_no_args.rs
@@ -4,7 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// Linear call graph with static calls, single type, no dominance, no loops.
+// Test case that ensures that if a static call is made without
+// any arguments, an edge *is* added to the call graph.
 
 fn fn1() -> u32 {
     1


### PR DESCRIPTION
## Description

This PR fixes two bugs:
1. If a static call was made without any arguments, an edge was *not* added to the call graph.
2. If a public function had a definition that MIRAI reached (during analysis) after MIRAI already reached a call of that function, a *duplicate* node was added to the graph.

The fixes in this PR ensure that:
1. An edge does get added.
2. The node gets updated rather than a duplicate node being added.

Additionally, this PR adds missing help text for one of the call graph configuration options.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

Two test cases have been added that target these bugs. The test cases will fail unless the fixes are in place.

## Checklist:

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

