### PR TITLE
Add support for output of Datalog relations in Soufflé format

### DIFF
--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -60,7 +60,8 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
                         "type_map_output_path": Path to store mapping from edge type indexes to strings.
                         "type_relations_path": Path to a file storing type relations to be imported for datalog output.
                         "reductions": A list of reductions to perform on the call graph.
-                        "included_crates": A list of crates to include in the call graph. If empty, all crates are included."#))
+                        "included_crates": A list of crates to include in the call graph. If empty, all crates are included.
+                        "datalog_backend": Choice of Datalog output format. Differential Datalog and Souffle are supported."#))
 }
 
 /// Represents options passed to MIRAI.

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -54,7 +54,7 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .long("call_graph_config")
         .takes_value(true)
         .help("Path call graph config.")
-        .long_help(r#"Path to a JSON file that configures call graph output. Please see documentation/CallGraph.md for details."#))
+        .long_help(r#"Path to a JSON file that configures call graph output. Please see the documentation for details (https://github.com/facebookexperimental/MIRAI/blob/main/documentation/CallGraph.md)."#))
 }
 
 /// Represents options passed to MIRAI.

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -54,14 +54,7 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
         .long("call_graph_config")
         .takes_value(true)
         .help("Path call graph config.")
-        .long_help(r#"Path to a JSON configuration file that optionally specifies:
-                        "dot_output_path": Path to store the call graph in dot format for displaying with graphviz.
-                        "ddlog_output_path": Path to store datalog input relations representing the call graph.
-                        "type_map_output_path": Path to store mapping from edge type indexes to strings.
-                        "type_relations_path": Path to a file storing type relations to be imported for datalog output.
-                        "reductions": A list of reductions to perform on the call graph.
-                        "included_crates": A list of crates to include in the call graph. If empty, all crates are included.
-                        "datalog_backend": Choice of Datalog output format. Differential Datalog and Souffle are supported."#))
+        .long_help(r#"Path to a JSON file that configures call graph output. Please see documentation/CallGraph.md for details."#))
 }
 
 /// Represents options passed to MIRAI.

--- a/checker/tests/call_graph/fnptr.rs
+++ b/checker/tests/call_graph/fnptr.rs
@@ -23,7 +23,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_clean.rs
+++ b/checker/tests/call_graph/fnptr_clean.rs
@@ -28,7 +28,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": ["Clean"],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_deduplicate.rs
+++ b/checker/tests/call_graph/fnptr_deduplicate.rs
@@ -24,7 +24,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": ["Deduplicate"],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_dom.rs
+++ b/checker/tests/call_graph/fnptr_dom.rs
@@ -24,7 +24,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_dom_loop.rs
+++ b/checker/tests/call_graph/fnptr_dom_loop.rs
@@ -31,7 +31,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_dom_loop_souffle.rs
+++ b/checker/tests/call_graph/fnptr_dom_loop_souffle.rs
@@ -33,7 +33,9 @@ pub fn main() {
 {
     "reductions": [],
     "included_crates": [],
-    "datalog_backend": "Souffle"
+    "datalog_config": {
+        "datalog_backend": "Souffle"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_dom_loop_souffle.rs
+++ b/checker/tests/call_graph/fnptr_dom_loop_souffle.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Linear call graph with function pointer calls, single type, dominance, and a loop.
+// Using the Soufflé datalog backend.
+
+fn fn1(x: u32, fn2: &fn(u32) -> u32, fn3: &fn(u32) -> u32) -> u32 {
+    let y = fn2(x);
+    fn3(y)
+}
+fn fn2(x: u32) -> u32 {
+    x + 2
+}
+fn fn3(x: u32) -> u32 {
+    fn4(x)
+}
+fn fn4(x: u32) -> u32 {
+    if x > 1 {
+        fn3(x - 1)
+    } else {
+        x
+    }
+}
+pub fn main() {
+    let x = 1;
+    fn1(x, &(fn2 as fn(u32) -> u32), &(fn3 as fn(u32) -> u32));
+}
+
+/* CONFIG
+{
+    "reductions": [],
+    "included_crates": [],
+    "datalog_backend": "Souffle"
+}
+*/
+
+/* EXPECTED:DOT
+digraph {
+    0 [ label = "\"fnptr_dom_loop_souffle::main\"" ]
+    1 [ label = "\"fnptr_dom_loop_souffle::fn1\"" ]
+    2 [ label = "\"fnptr_dom_loop_souffle::fn2\"" ]
+    3 [ label = "\"fnptr_dom_loop_souffle::fn3\"" ]
+    4 [ label = "\"fnptr_dom_loop_souffle::fn4\"" ]
+    0 -> 1 [ ]
+    0 -> 1 [ ]
+    1 -> 2 [ ]
+    1 -> 3 [ ]
+    3 -> 4 [ ]
+    4 -> 3 [ ]
+}
+*/
+
+/* EXPECTED:SOUFFLE
+2,30,0,1
+1,0,1
+2,1,2
+3,1,3
+4,3,4
+5,4,30,0
+1,1
+2,0
+3,0
+4,0
+5,0
+*/
+
+/* EXPECTED:TYPEMAP
+{
+  "0": "u32",
+  "1": "&fn(u32) -> u32"
+}
+*/

--- a/checker/tests/call_graph/fnptr_fold.rs
+++ b/checker/tests/call_graph/fnptr_fold.rs
@@ -26,7 +26,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": ["Fold"],
-    "included_crates": ["fnptr_fold"]
+    "included_crates": ["fnptr_fold"],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_loop.rs
+++ b/checker/tests/call_graph/fnptr_loop.rs
@@ -27,7 +27,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/fnptr_slice.rs
+++ b/checker/tests/call_graph/fnptr_slice.rs
@@ -24,7 +24,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [{"Slice": "fn1"}],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/replace_croot.rs
+++ b/checker/tests/call_graph/replace_croot.rs
@@ -18,7 +18,10 @@ pub fn fn1() -> u32 {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static.rs
+++ b/checker/tests/call_graph/static.rs
@@ -23,7 +23,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_clean.rs
+++ b/checker/tests/call_graph/static_clean.rs
@@ -28,7 +28,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": ["Clean"],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_deduplicate.rs
+++ b/checker/tests/call_graph/static_deduplicate.rs
@@ -24,7 +24,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": ["Deduplicate"],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_dom.rs
+++ b/checker/tests/call_graph/static_dom.rs
@@ -25,7 +25,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_dom_loop.rs
+++ b/checker/tests/call_graph/static_dom_loop.rs
@@ -32,7 +32,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_fold.rs
+++ b/checker/tests/call_graph/static_fold.rs
@@ -25,7 +25,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": ["Fold"],
-    "included_crates": ["static_fold"]
+    "included_crates": ["static_fold"],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_loop.rs
+++ b/checker/tests/call_graph/static_loop.rs
@@ -27,7 +27,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_no_args.rs
+++ b/checker/tests/call_graph/static_no_args.rs
@@ -17,7 +17,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_slice.rs
+++ b/checker/tests/call_graph/static_slice.rs
@@ -24,7 +24,10 @@ pub fn main() {
 /* CONFIG
 {
     "reductions": [{"Slice": "fn1"}],
-    "included_crates": []
+    "included_crates": [],
+    "datalog_config": {
+        "datalog_backend": "DifferentialDatalog"
+    }
 }
 */
 

--- a/checker/tests/call_graph/static_souffle.rs
+++ b/checker/tests/call_graph/static_souffle.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Linear call graph with static calls, single type, no dominance, no loops.
+// Using the Soufflé datalog backend.
+
+fn fn1(x: u32) -> u32 {
+    fn2(x)
+}
+fn fn2(x: u32) -> u32 {
+    fn3(x)
+}
+fn fn3(x: u32) -> u32 {
+    x
+}
+pub fn main() {
+    let x = 1;
+    fn1(x);
+}
+
+/* CONFIG
+{
+    "reductions": [],
+    "included_crates": [],
+    "datalog_backend": "Souffle"
+}
+*/
+
+/* EXPECTED:DOT
+digraph {
+    0 [ label = "\"static_souffle::main\"" ]
+    1 [ label = "\"static_souffle::fn1\"" ]
+    2 [ label = "\"static_souffle::fn2\"" ]
+    3 [ label = "\"static_souffle::fn3\"" ]
+    0 -> 1 [ ]
+    1 -> 2 [ ]
+    2 -> 3 [ ]
+}
+*/
+
+/* EXPECTED:SOUFFLE
+0,0,1
+1,1,2
+2,2,30,0
+1,0
+2,0
+*/
+
+/* EXPECTED:TYPEMAP
+{
+  "0": "u32"
+}
+*/

--- a/checker/tests/call_graph/static_souffle.rs
+++ b/checker/tests/call_graph/static_souffle.rs
@@ -25,7 +25,9 @@ pub fn main() {
 {
     "reductions": [],
     "included_crates": [],
-    "datalog_backend": "Souffle"
+    "datalog_config": {
+        "datalog_backend": "Souffle"
+    }
 }
 */
 

--- a/documentation/CallGraph.md
+++ b/documentation/CallGraph.md
@@ -62,9 +62,6 @@ at that path using the following schema:
 ```
 {
     "dot_output_path": "path/to/graph.dot",
-    "ddlog_output_path": "path/to/graph.dat" | "path/to/datalog/",
-    "type_map_output_path": "path/to/types.json",
-    "type_relations_path": "path/to/type_relations.json",
     "reductions": [
         {"Slice": "function name"},
         "Fold",
@@ -72,28 +69,36 @@ at that path using the following schema:
         "Deduplicate",
     ],
     "included_crates": ["crate_name"],
-    "datalog_backend": "DifferentialDatalog" | "Souffle"
+    "datalog_config": {
+        "ddlog_output_path": "path/to/graph.dat" | "path/to/datalog/",
+        "type_map_output_path": "path/to/types.json",
+        "type_relations_path": "path/to/type_relations.json",
+        "datalog_backend": "DifferentialDatalog" | "Souffle"
+    },
 }
 ```
 
 Below, we explain each field in detail:
 - `"dot_output_path"`: (**Optional**) Path where dot output of graph will be saved,
 if provided. See the section below on "Dot output".
-- `"ddlog_output_path"`: (**Optional**) Path where Datalog output of graph will be
-saved, if provided. See the section below on "Datalog output".
-- `"type_map_output_path"`: (**Optional**) Path where type map output of graph will
-be saved, if provided. See the section below on "Type Map output".
-- `"type_relations_path"`: (**Optional**) Path to file where manually-added type
-relations will read from. See the section below on "Type relations"
 - `"reductions"`: Possibly empty list of reductions to apply to the call graph. 
 See the subsection below on "Graph reductions".
 - `"included_crates"`: List of crate names to _include_ in the graph, 
 if the `Fold` reduction is used. Can be empty if the `Fold` reduction is not being used.
-- `"datalog_backend"`: (**Optional**) The Datalog output backend to use. Currently 
+- `"datalog_config"`: (**Optional**) Configuration for Datalog output (see below).
+If left unspecified, no Datalog output will be generated.
+
+Datalog configuration:
+- `"ddlog_output_path"`: Path where Datalog output of graph will be
+saved. See the section below on "Datalog output".
+- `"type_map_output_path"`: Path where type map output of graph will
+be saved. See the section below on "Type Map output".
+- `"type_relations_path"`: (**Optional**) Path to file where manually-added type
+relations will read from, if provided. See the section below on "Type relations"
+- `"datalog_backend"`: The Datalog output backend to use. Currently 
 [Differential Datalog](https://github.com/vmware/differential-datalog) and
-[Soufflé](https://souffle-lang.github.io/) are supported.
-If left unspecified, Differential Datalog will be used. Note that if Soufflé is used
-`"ddlog_output_path"` should be the path to a *directory* rather than a file.
+[Soufflé](https://souffle-lang.github.io/) are supported. Note that if Soufflé is 
+used `"ddlog_output_path"` should be the path to a *directory* rather than a file.
 
 ### Graph reductions
 

--- a/documentation/CallGraph.md
+++ b/documentation/CallGraph.md
@@ -62,7 +62,7 @@ at that path using the following schema:
 ```
 {
     "dot_output_path": "path/to/graph.dot",
-    "ddlog_output_path": "path/to/graph.dat",
+    "ddlog_output_path": "path/to/graph.dat" | "path/to/datalog/",
     "type_map_output_path": "path/to/types.json",
     "type_relations_path": "path/to/type_relations.json",
     "reductions": [
@@ -71,7 +71,8 @@ at that path using the following schema:
         "Clean",
         "Deduplicate",
     ],
-    "included_crates": ["crate_name"]
+    "included_crates": ["crate_name"],
+    "datalog_backend": "DifferentialDatalog" | "Souffle"
 }
 ```
 
@@ -84,9 +85,15 @@ saved, if provided. See the section below on "Datalog output".
 be saved, if provided. See the section below on "Type Map output".
 - `"type_relations_path"`: (**Optional**) Path to file where manually-added type
 relations will read from. See the section below on "Type relations"
-- `"reductions"`: Possibly empty list of reductions to apply to the call graph. See the subsection below on "Graph reductions".
+- `"reductions"`: Possibly empty list of reductions to apply to the call graph. 
+See the subsection below on "Graph reductions".
 - `"included_crates"`: List of crate names to _include_ in the graph, 
 if the `Fold` reduction is used. Can be empty if the `Fold` reduction is not being used.
+- `"datalog_backend"`: (**Optional**) The Datalog output backend to use. Currently 
+[Differential Datalog](https://github.com/vmware/differential-datalog) and
+[Soufflé](https://souffle-lang.github.io/) are supported.
+If left unspecified, Differential Datalog will be used. Note that if Soufflé is used
+`"ddlog_output_path"` should be the path to a *directory* rather than a file.
 
 ### Graph reductions
 
@@ -148,7 +155,7 @@ The call graph generator also supports
 Datalog is a logic programming language that can be used, in conjunction with the
 generated call graph, to write an analysis that operates on the call graph.
 
-Here is an example of the Datalog output for the prior graph:
+Here is an example of the Differential Datalog output for the prior graph:
 ```
 start;
 insert Edge(0,0,1);
@@ -286,3 +293,52 @@ Reachable{.node1 = 2, .node2 = 3}
 
 As we can see, there is an output relation for every pair of nodes `n1`, `n2`
 such that `n2` is reachable from `n1`.
+
+This example could also be done with [Soufflé](https://souffle-lang.github.io/) 
+Datalog with minor changes to the syntax:
+```
+.decl Edge(id: number, node1: number, node2: number)
+.input Edge(io=file, delimiter=",")
+.decl EdgeType(id: number, type_id: number)
+.input EdgeType(io=file, delimiter=",")
+
+.decl Reachable(node1: number, node2: number)
+Reachable(node1, node2) :- Edge(_, node1, node2).
+Reachable(node1, node3) :- Edge(_, node1, node2), Reachable(node2, node3).
+
+.output Reachable(io=file, delimiter=",")
+```
+
+The input relations will also need to be formatted differently;
+each relation need to be placed into a separate file titled by the relation:
+- `Edge.facts`
+    ```
+    0,0,1
+    1,1,2
+    2,2,3
+    ```
+- `EdgeType.facts`
+    ```
+    0,0
+    1,0
+    2,0
+    ```
+
+To run the analysis with Soufflé: `souffle reachable.dl`. The output will
+be stored into a file called `Reachable.csv` and will match the results
+we saw before.
+
+An interesting feature of Soufflé is the ability to see proof trees for the
+output. To do this, first run Soufflé's explain command:
+`souffle -t explain reachable`. Then, a particular output relation can be
+explained:
+```
+Enter command > explain Reachable(1,3)
+              Edge(2, 2, 3)   
+              -----------(R1) 
+Edge(1, 1, 2) Reachable(2, 3) 
+--------------------------(R2)
+       Reachable(1, 3)        
+```
+
+We can see how `Reachable(1, 3)` was derived transitively.


### PR DESCRIPTION
## Description

This PR generalizes the Datalog output of call graph generator such that multiple "Datalog backends" that produce output for different variants of Datalog can be written and used.

The motivation behind this is support for the [Soufflé](https://souffle-lang.github.io/) flavor of Datalog, which has been implemented as a new backend and can be selected via the call graph generator's configuration file.

Documentation for these configuration changes, as well as an example of using Soufflé, has been added to the `CallGraph.md` documentation file.

Finally, this PR also restructures the call graph configuration file schema so that all Datalog-config options are grouped together in a separate, optional struct. This ensures that all required Datalog options are given if Datalog output is desired.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

Two tests have been added that replicate previous test results, but use the Soufflé backend.

## Checklist:

- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

