### PR TITLE
Path::Offset, <&(&(<hb>))[0]>.deref, may alias Path::HeapBlock, hb

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -139,6 +139,13 @@ impl From<BoolDomain> for AbstractValue {
     }
 }
 
+impl From<i128> for AbstractValue {
+    #[logfn_inputs(TRACE)]
+    fn from(cv: i128) -> AbstractValue {
+        make_value(Expression::CompileTimeConstant(ConstantDomain::I128(cv)))
+    }
+}
+
 impl From<u128> for AbstractValue {
     #[logfn_inputs(TRACE)]
     fn from(cv: u128) -> AbstractValue {

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -155,9 +155,9 @@ impl MiraiCallbacks {
             || file_name.starts_with("config/management/network-address-encryption/src") // stack overflow
             || file_name.starts_with("config/management/operational/src") // crash
             || file_name.starts_with("config/seed-peer-generator/src") // stack overflow
-            || file_name.starts_with("consensus/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("consensus/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
             || file_name.starts_with("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
-            || file_name.starts_with("consensus/consensus-types/src") // Sorts Int and <null> are incompatible
+            || file_name.starts_with("consensus/consensus-types/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
             || file_name.starts_with("crypto/crypto/src") // stack overflow
             || file_name.starts_with("crypto/crypto-derive/src") // out of memory
             || file_name.starts_with("diem-node/src") // out of memory
@@ -168,16 +168,14 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/compiler/src") // out of memory
             || file_name.starts_with("language/diem-framework/src") // expect reference target to have a value
             || file_name.starts_with("language/diem-framework/releases/src") // non termination
-            || file_name.starts_with("language/diem-tools/df-cli/src") // Sorts <null> and Int are incompatible
             || file_name.starts_with("language/diem-tools/diem-events-fetcher/src") // crash
             || file_name.starts_with("language/diem-tools/diem-validator-interface") // stack overflow
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
             || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
-            || file_name.starts_with("language/diem-vm/src") // Sorts Bool and Int are incompatible
+            || file_name.starts_with("language/diem-vm/src") // 'Not a type: DefIndex(3132)
             || file_name.starts_with("language/move-vm/types/src") // Unexpected representation of upvar types
             || file_name.starts_with("language/move-lang/src") // non termination
             || file_name.starts_with("language/move-model/src") // non termination
-            || file_name.starts_with("language/move-prover/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("language/move-prover/boogie-backend/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
             || file_name.starts_with("language/move-prover/mutation") // stack overflow
@@ -208,13 +206,12 @@ impl MiraiCallbacks {
             || file_name.starts_with("secure/storage/github/src") // stack overflow
             || file_name.starts_with("secure/storage/vault/src") // stack overflow
             || file_name.starts_with("secure/storage/src") // stack overflow
-            || file_name.starts_with("state-sync/src") // Z3 encoding
-            || file_name.starts_with("state-sync/state-sync-v1/src") // Z3 encoding
+            || file_name.starts_with("state-sync/state-sync-v1/src") // Unexpected representation of upvar types
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value
             || file_name.starts_with("storage/diemsum/src") // out of memory
             || file_name.starts_with("storage/inspector/src/") // out of memory
-            || file_name.starts_with("types/src") //Sorts Int and <null> are incompatible
+            || file_name.starts_with("types/src") // (ite (= 1 0) 1 (ite (= 1 TOP) 1 0)) at position 1 does not match declaration
             || file_name.starts_with("vm-validator/src")
         {
             return true;
@@ -229,9 +226,11 @@ impl MiraiCallbacks {
                 || file_name.starts_with("execution/executor/src")
                 || file_name.starts_with("language/bytecode-verifier/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
-                || file_name.starts_with("language/diem-vm/src")
+                || file_name.starts_with("language/compiler/ir-to-bytecode/syntax/src")
+                || file_name.starts_with("language/diem-tools/df-cli/src")
                 || file_name.starts_with("language/move-binary-format/src")
                 || file_name.starts_with("language/move-core/types/src")
+                || file_name.starts_with("language/move-prover/src")
                 || file_name.starts_with("language/move-prover/abigen/src")
                 || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
                 || file_name.starts_with("language/move-prover/bytecode/src")
@@ -241,9 +240,9 @@ impl MiraiCallbacks {
                 || file_name.starts_with("network/simple-onchain-discovery/src")
                 || file_name.starts_with("sdk/src")
                 || file_name.starts_with("secure/net/src")
+                || file_name.starts_with("state-sync/src")
                 || file_name.starts_with("storage/schemadb/src")
-                || file_name.starts_with("storage/storage-client/src")
-                || file_name.starts_with("types/src"))
+                || file_name.starts_with("storage/storage-client/src"))
         {
             return true;
         }

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -134,9 +134,28 @@ impl Environment {
                                         // conditional on path_are_equal
                                         let conditional_value = paths_are_equal
                                             .conditional_expression(value.clone(), v.clone());
-                                        debug!("conditional_value {:?}", conditional_value);
                                         self.strong_update_value_at(p.clone(), conditional_value);
                                     }
+                                }
+                            }
+                        }
+                        if let PathEnum::HeapBlock { .. } = &p.value {
+                            let paths_are_equal = qualifier.equals(p);
+                            match paths_are_equal.as_bool_if_known() {
+                                Some(true) => {
+                                    // p is known to be an alias of path, so just update it
+                                    self.strong_update_value_at(p.clone(), value.clone());
+                                }
+                                Some(false) => {
+                                    // p is known not to be an alias of path
+                                    continue;
+                                }
+                                None => {
+                                    // p might be an alias of, so weaken its value by making it
+                                    // conditional on path_are_equal
+                                    let conditional_value = paths_are_equal
+                                        .conditional_expression(value.clone(), v.clone());
+                                    self.strong_update_value_at(p.clone(), conditional_value);
                                 }
                             }
                         }

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -282,6 +282,26 @@ impl Path {
             | (PathEnum::HeapBlock { value: v1 }, PathEnum::HeapBlock { value: v2 }) => {
                 v1.equals(v2.clone())
             }
+            (PathEnum::HeapBlock { value: v1 }, PathEnum::Offset { value: v2 })
+            | (PathEnum::Offset { value: v2 }, PathEnum::HeapBlock { value: v1 }) => {
+                if let Expression::Offset {
+                    left: l2,
+                    right: r2,
+                } = &v2.expression
+                {
+                    if let Expression::Reference(p2) = &l2.expression {
+                        if let PathEnum::HeapBlock { value: v2 } = &p2.value {
+                            v1.equals(v2.clone()).and(r2.equals(Rc::new(0_i128.into())))
+                        } else {
+                            Rc::new(abstract_value::FALSE)
+                        }
+                    } else {
+                        Rc::new(abstract_value::FALSE)
+                    }
+                } else {
+                    unreachable!("path offset must wrap expression offset");
+                }
+            }
             (PathEnum::Offset { value: v1 }, PathEnum::Offset { value: v2 }) => {
                 if let (
                     Expression::Offset {

--- a/checker/tests/run-pass/offset.rs
+++ b/checker/tests/run-pass/offset.rs
@@ -81,8 +81,8 @@ pub fn t8() {
             *a2 = 222;
             i += 1;
         }
-        verify!(*a1 == 111);
-        //todo: figure out how to verify this
+        verify!(*a1 == 111); //~ possible false verification condition
+                             //todo: figure out how to verify this
         verify!(*a2 == 222); //~ possible false verification condition
     }
 }


### PR DESCRIPTION
## Description

MIR allows you to write to *(&p[0])  and then read it back via *p, so MIRAI canonicalizes the former to the latter. When looking for aliased paths, the unknown path *(&p[i]) must thus become a potential alias for *p.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem