### PR TITLE
Simplify c1 == c2 join c3

### DIFF
--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -387,7 +387,7 @@ fn check_call_graph_output(
             fs::read_to_string(call_graph_config.get_type_map_path().unwrap())
         }
         CallGraphOutputType::Souffle => {
-            get_souffle_output(&Path::new(call_graph_config.get_ddlog_path().unwrap()))
+            get_souffle_output(Path::new(call_graph_config.get_ddlog_path().unwrap()))
         }
     };
     if let Ok(actual) = actual {

--- a/checker/tests/run-pass/offset.rs
+++ b/checker/tests/run-pass/offset.rs
@@ -81,8 +81,8 @@ pub fn t8() {
             *a2 = 222;
             i += 1;
         }
-        verify!(*a1 == 111); //~ possible false verification condition
-                             //todo: figure out how to verify this
+        verify!(*a1 == 111);
+        //todo: figure out how to verify this
         verify!(*a2 == 222); //~ possible false verification condition
     }
 }


### PR DESCRIPTION
## Description

Add a simplification rule that allows things like 0 == 1 join 2 to become just false. This is helpful when deciding whether a path such as p[i] can be an alias of a path such as p[0] when i is known to be the join of constant values.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
