### PR TITLE
Minor tweaks

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2269,6 +2269,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 consequent.dereference(target_type.clone()),
                 alternate.dereference(target_type),
             ),
+            Expression::HeapBlock { .. } => self.clone(),
             Expression::Join { path, left, right } => left
                 .dereference(target_type.clone())
                 .join(right.dereference(target_type), path),

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -3349,6 +3349,8 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                 mir::ProjectionElem::Subslice { .. } => {}
             }
             result = Path::new_qualified(result, Rc::new(selector));
+            self.type_visitor_mut()
+                .set_path_rustc_type(result.clone(), ty);
         }
         result
     }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -317,6 +317,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                     }
                 }
                 Expression::InitialParameterValue { path, .. }
+                | Expression::Join { path, .. }
                 | Expression::Variable { path, .. }
                 | Expression::WidenedJoin { path, .. } => {
                     self.get_path_rustc_type(path, current_span)


### PR DESCRIPTION
## Description

Make dereferencing a heap block an identity operation.
Cache types of intermediate paths during path construction.
Use the join path to get the type of a join operation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
