### PR TITLE
Always use x.eq(y) instead of *x == *y to compare abstract values

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -2693,7 +2693,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
     /// Updates the path to value map in self.current_environment so that the given path now points
     /// to the given value. Also update any paths that might alias path to now point to a weaker
     /// abstract value that includes all of the concrete values that value might be at runtime.
-    #[logfn_inputs(DEBUG)]
+    #[logfn_inputs(TRACE)]
     pub fn update_value_at(&mut self, path: Rc<Path>, value: Rc<AbstractValue>) {
         if let PathEnum::QualifiedPath {
             qualifier,


### PR DESCRIPTION
## Description

Code cleanup:
Always use x.eq(y) instead of *x == *y to compare abstract values.
Make make_typed_binary consistent with make_binary when it comes to losing precision.
Expand and clarify comments explaining how predecessor joins work at loop anchors.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
