### PR TITLE
Support weak updates of paths that end in fields, etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2461,6 +2461,22 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                 return Rc::new(FALSE);
             }
 
+            (
+                Expression::HeapBlock {
+                    abstract_address: a1,
+                    ..
+                },
+                Expression::HeapBlock {
+                    abstract_address: a2,
+                    ..
+                },
+            ) => {
+                return if *a1 == *a2 {
+                    Rc::new(TRUE)
+                } else {
+                    Rc::new(FALSE)
+                };
+            }
             // [(join == val)] -> if !interval(join).intersect(interval(val)) { false } else { unknown == val }
             // [(widened == val)] -> if !interval(widened).intersect(interval(val)) { false } else { unknown == val }
             (Expression::Join { path, .. }, _) | (Expression::WidenedJoin { path, .. }, _) => {


### PR DESCRIPTION
## Description

Support weak updates of paths that end in fields, etc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
