### PR TITLE
Don't distribute deref into widen

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -3192,25 +3192,14 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                 ..
             } if **selector == PathSelector::Deref => {
                 if let PathEnum::Computed { value } = &qualifier.value {
-                    match &value.expression {
-                        Expression::Join { left, right, .. } => {
-                            let target_type = ExpressionType::from(ty.kind());
-                            let distributed_deref = left
-                                .dereference(target_type)
-                                .join(right.dereference(target_type));
-                            path = Path::get_as_path(distributed_deref);
-                            self.type_visitor_mut()
-                                .set_path_rustc_type(path.clone(), ty);
-                        }
-                        Expression::WidenedJoin { operand, .. } => {
-                            let target_type = ExpressionType::from(ty.kind());
-                            let distributed_deref =
-                                operand.dereference(target_type).widen(&place_path);
-                            path = Path::get_as_path(distributed_deref);
-                            self.type_visitor_mut()
-                                .set_path_rustc_type(path.clone(), ty);
-                        }
-                        _ => (),
+                    if let Expression::Join { left, right, .. } = &value.expression {
+                        let target_type = ExpressionType::from(ty.kind());
+                        let distributed_deref = left
+                            .dereference(target_type)
+                            .join(right.dereference(target_type));
+                        path = Path::get_as_path(distributed_deref);
+                        self.type_visitor_mut()
+                            .set_path_rustc_type(path.clone(), ty);
                     }
                 }
             }

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -83,8 +83,7 @@ impl Path {
             Expression::Offset { .. } => PathEnum::Offset { value }.into(),
             Expression::UninterpretedCall { path, .. }
             | Expression::InitialParameterValue { path, .. }
-            | Expression::Variable { path, .. }
-            | Expression::WidenedJoin { path, .. } => path.as_ref().clone(),
+            | Expression::Variable { path, .. } => path.as_ref().clone(),
             _ => PathEnum::Computed { value }.into(),
         })
     }


### PR DESCRIPTION
## Description

Don't distribute deref into widen since it such a transformation results in a value that is not a description of the runtime value at the path of the widen.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem