### PR TITLE
Do not re-path widened values that simply move

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "lock_api"

--- a/checker/src/environment.rs
+++ b/checker/src/environment.rs
@@ -518,6 +518,17 @@ impl Environment {
             if let Some(val) = y.get_widened_subexpression(p) {
                 return val;
             }
+            if let (
+                Expression::WidenedJoin { path: p1, .. },
+                Expression::WidenedJoin { path: p2, .. },
+            ) = (&x.expression, &y.expression)
+            {
+                if p1.eq(p2) || p2.eq(p) {
+                    return x.clone();
+                } else if p1.eq(p) {
+                    return y.clone();
+                }
+            }
             x.join(y.clone()).widen(p)
         })
     }

--- a/checker/tests/run-pass/move_widen.rs
+++ b/checker/tests/run-pass/move_widen.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that copies widened values
+
+use mirai_annotations::*;
+
+pub fn t1(n: u32) {
+    let mut i: u32 = 0;
+    let mut j: u32 = 0;
+    while i < n {
+        //todo: fix this
+        verify!(i == j); //~ possible false verification condition
+        i += 1;
+        j = i;
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When a widened value is moved or copied from location p1 to location p2, the widening of the environment in the next loop iteration should not create a widened value with path p2 from the join of the previous and current values, because the values at p1 and p2 will then appear to be possibly distinct.

This is a hack rather than a complete solution to the problem. In the long run it may be necessary to decouple widened values from paths. Right now this makes debugging a bit easier.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

