### PR TITLE
Reduce use of the path field from WidenedJoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -418,9 +418,12 @@ pub enum Expression {
     /// the path of this value. This models a variable that is assigned to from inside a loop
     /// body.
     WidenedJoin {
-        /// The path of the location where an indeterminate number of flows join together.
-        /// This is the same as the path in operand, and is repeated here for convenience in
-        /// pattern matches.
+        /// The path of a location where an indeterminate number of flows join together.
+        /// It is attached to a widened join at a join a point and then preserved in derived
+        /// values. If such a derived value returns to the join point as its new value, the
+        /// original value can be used so that the fix point loop converges.
+        /// The path does not provide identity and two widened joins with the same path
+        /// are not necessary the same value.
         path: Rc<Path>,
         /// The join of some of the flows to come together at this path.
         /// The first few iterations do joins. Once widening happens, further iterations

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -318,10 +318,7 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                     }
                 }
                 Expression::InitialParameterValue { path, .. }
-                | Expression::Variable { path, .. }
-                | Expression::WidenedJoin { path, .. } => {
-                    self.get_path_rustc_type(path, current_span)
-                }
+                | Expression::Variable { path, .. } => self.get_path_rustc_type(path, current_span),
                 _ => value.expression.infer_type().as_rustc_type(self.tcx),
             },
             PathEnum::LocalVariable {


### PR DESCRIPTION
## Description

The path field of a WidenJoin should be used only to determine if a loop variable reaches a fixed point. In particular, the path field should not be used as an indication that the widened value is the current value at that path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem