### PR TITLE
Fix bugs in Z3 encoding

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -143,84 +143,61 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(&self, file_name: &str) -> bool {
-        // Exclude crates that contain code that causes MIRAI to crash or not terminate within 2 hours
-        if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null>
-            || file_name.starts_with("client/faucet/src") // non termination
-            || file_name.starts_with("client/swiss-knife/src") // out of memory
-            || file_name.starts_with("common/bitvec/src") // stack overflow
-            || file_name.starts_with("common/metrics/src") // z3 encoding
-            || file_name.starts_with("common/debug-interface/src") // stack overflow
-            || file_name.starts_with("common/rate-limiter/src") // z3 encoding
-            || file_name.starts_with("config/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
-            || file_name.starts_with("config/management/genesis/src") // stack overflow
-            || file_name.starts_with("config/management/src") // crash
-            || file_name.starts_with("config/management/network-address-encryption/src") // stack overflow
-            || file_name.starts_with("config/management/operational/src") // crash
-            || file_name.starts_with("config/seed-peer-generator/src") // stack overflow
-            || file_name.starts_with("consensus/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
-            || file_name.starts_with("consensus/safety-rules/src") // Sorts Int and <null> are incompatible
+        // Exclude crates that contain code that causes MIRAI to crash
+        if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null> 
             || file_name.starts_with("consensus/consensus-types/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
             || file_name.starts_with("crypto/crypto/src") // stack overflow
-            || file_name.starts_with("crypto/crypto-derive/src") // out of memory
-            || file_name.starts_with("diem-node/src") // out of memory
-            || file_name.starts_with("execution/db-bootstrapper/src") // out of memory
-            || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
-            || file_name.starts_with("json-rpc/src") // expected a type, but found another kind
             || file_name.starts_with("json-rpc/types/src") // stack overflow
             || file_name.starts_with("language/bytecode-verifier/src") // Unexpected representation of upvar types tuple Param(<upvars>/#4)
-            || file_name.starts_with("language/compiler/src") // out of memory
-            || file_name.starts_with("language/compiler/bytecode-source-map/src") // stack overflow
             || file_name.starts_with("language/compiler/ir-to-bytecode/src") // stack overflow
             || file_name.starts_with("language/diem-framework/src") // expect reference target to have a value
-            || file_name.starts_with("language/diem-framework/releases/src") // non termination
-            || file_name.starts_with("language/diem-tools/df-cli/src") // stack overflow
-            || file_name.starts_with("language/diem-tools/diem-events-fetcher/src") // crash
-            || file_name.starts_with("language/diem-tools/diem-validator-interface") // stack overflow
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
-            || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src") // stack overflow
-            || file_name.starts_with("language/diem-vm/src") // 'Not a type: DefIndex(3132)
-            || file_name.starts_with("language/move-vm/types/src") // Unexpected representation of upvar types
-            || file_name.starts_with("language/move-lang/src") // non termination
-            || file_name.starts_with("language/move-model/src") // non termination
             || file_name.starts_with("language/move-prover/boogie-backend/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
-            || file_name.starts_with("language/move-prover/bytecode/src") // non termination
             || file_name.starts_with("language/move-prover/mutation") // stack overflow
             || file_name.starts_with("language/move-stdlib/src") // stack overflow
             || file_name.starts_with("language/move-prover/src") // stack overflow
             || file_name.starts_with("language/move-prover/docgen/src") //  Unexpected representation of upvar types tuple Param(<upvars>/
             || file_name.starts_with("language/move-prover/interpreter/src") // stack overflow
             || file_name.starts_with("language/move-prover/lab/src")  // stack overflow
-            || file_name.starts_with("language/tools/disassembler/src") // out of memory
+            || file_name.starts_with("language/tools/move-coverage/src") // out of memory
+            || file_name.starts_with("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
+            || file_name.starts_with("network/netcore/src") // operator is applied to arguments of the wrong sort
+            || file_name.starts_with("types/src")
+        // (ite (= 1 0) 1 (ite (= 1 TOP) 1 0)) at position 1 does not match declaration
+        {
+            return true;
+        }
+
+        // Exclude crates that crash and also take longer than 2 minutes to analyze, or don't terminate
+        if file_name.starts_with("client/faucet/src") // non termination
+            || file_name.starts_with("config/management/operational/src") // crash
+            || file_name.starts_with("consensus/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
+            || file_name.starts_with("crypto/crypto-derive/src") // out of memory
+            || file_name.starts_with("json-rpc/src") // expected a type, but found another kind
+            || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
+            || file_name.starts_with("language/compiler/src") // out of memory
+            || file_name.starts_with("language/diem-framework/releases/src") // non termination
+            || file_name.starts_with("language/diem-vm/src") // 'Not a type: DefIndex(3132)
+            || file_name.starts_with("language/move-lang/src") // non termination
+            || file_name.starts_with("language/move-model/src") // non termination
             || file_name.starts_with("language/tools/genesis-viewer/src/main.rs") // out of memory
-            || file_name.starts_with("language/tools/move-bytecode-utils/src") // non termination
             || file_name.starts_with("language/tools/move-bytecode-viewer/src") // out of memory
             || file_name.starts_with("language/tools/move-cli/src") // non termination
-            || file_name.starts_with("language/tools/move-coverage/src") // out of memory
-            || file_name.starts_with("language/tools/move-explain/src") // out of memory
             || file_name.starts_with("language/tools/move-package/src") // expect reference target to have a value
+            || file_name.starts_with("language/move-prover/bytecode/src") // non termination
             || file_name.starts_with("language/tools/move-unit-test/src") // non termination
             || file_name.starts_with("language/tools/read-write-set/src")  // non termination
-            || file_name.starts_with("language/tools/resource-viewer/src") // out of memory
-            || file_name.starts_with("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("language/tools/vm-genesis/src") // Unexpected representation of upvar types
             || file_name.starts_with("mempool/src") // out of memory
-            || file_name.starts_with("network/src") // could not fully normalize 
-            || file_name.starts_with("network/builder/src") // could not fully normalize
-            || file_name.starts_with("network/discovery/src")  // stack overflow
-            || file_name.starts_with("network/netcore/src") // operator is applied to arguments of the wrong sort
+            || file_name.starts_with("network/src")
+            || file_name.starts_with("network/builder/src") // compiler/rustc_traits/src/normalize_erasing_regions.rs:54:32:
             || file_name.starts_with("sdk/client/src") // non termination
-            || file_name.starts_with("secure/key-manager/src") // stack overflow
-            || file_name.starts_with("secure/storage/github/src") // stack overflow
-            || file_name.starts_with("secure/storage/vault/src") // stack overflow
-            || file_name.starts_with("secure/storage/src") // stack overflow
             || file_name.starts_with("state-sync/state-sync-v1/src") // Unexpected representation of upvar types
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
-            || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value
+            || file_name.starts_with("storage/diemdb/src") // expect reference target to have a value local_1(41) Some({result: &(local_1(41))})
             || file_name.starts_with("storage/diemsum/src") // out of memory
-            || file_name.starts_with("storage/inspector/src/") // out of memory
-            || file_name.starts_with("storage/schemadb/src") // z3 encoding
-            || file_name.starts_with("types/src") // (ite (= 1 0) 1 (ite (= 1 TOP) 1 0)) at position 1 does not match declaration
-            || file_name.starts_with("vm-validator/src")
+            || file_name.starts_with("storage/inspector/src/")
+        // out of memory
         {
             return true;
         }
@@ -228,22 +205,38 @@ impl MiraiCallbacks {
         // Exclude crates that currently slow down testing too much
         if self.options.diag_level == DiagLevel::Default
             && (file_name.starts_with("common/num-variants/src")
+                || file_name.starts_with("common/rate-limiter/src")
                 || file_name.starts_with("config/src")
+                || file_name.starts_with("config/management/src")
+                || file_name.starts_with("config/management/genesis/src")
+                || file_name.starts_with("config/seed-peer-generator/src")
+                || file_name.starts_with("common/debug-interface/src")
+                || file_name.starts_with("execution/db-bootstrapper/src")
                 || file_name.starts_with("execution/executor/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/syntax/src")
+                || file_name.starts_with("language/diem-tools/df-cli/src")
+                || file_name.starts_with("language/diem-tools/diem-validator-interface")
+                || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src")
                 || file_name.starts_with("language/move-binary-format/src")
                 || file_name.starts_with("language/move-core/types/src")
                 || file_name.starts_with("language/move-prover/abigen/src")
                 || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
-                || file_name.starts_with("language/move-prover/bytecode/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
+                || file_name.starts_with("language/tools/disassembler/src")
                 || file_name.starts_with("move-prover/errmapgen/src")
-                || file_name.starts_with("network/builder/src")
+                || file_name.starts_with("config/management/network-address-encryption/src")
+                || file_name.starts_with("network/discovery/src")
                 || file_name.starts_with("network/simple-onchain-discovery/src")
+                || file_name.starts_with("consensus/safety-rules/src")
                 || file_name.starts_with("sdk/src")
+                || file_name.starts_with("secure/key-manager/src")
                 || file_name.starts_with("secure/net/src")
+                || file_name.starts_with("secure/storage/src")
+                || file_name.starts_with("secure/storage/vault/src")
                 || file_name.starts_with("state-sync/src")
+                || file_name.starts_with("state-sync/inter-component/event-notifications/src")
                 || file_name.starts_with("storage/storage-client/src"))
+            || file_name.starts_with("vm-validator/src")
         {
             return true;
         }


### PR DESCRIPTION
## Description

Make the Z3 encoding more resilient in the face of type inference errors in the interpreter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem