### PR TITLE
Allow address of struct to alias address of its field 0

### DIFF
--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -499,21 +499,13 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                                         _ => {}
                                     }
                                 }
-                                if *ordinal == 0
-                                    && matches!(
-                                        t.kind(),
-                                        TyKind::FnPtr(..) | TyKind::RawPtr(..) | TyKind::Ref(..)
-                                    )
-                                {
-                                    // If the qualifier is a thin pointer to something that
-                                    // does not have a field 0, it could be that qualifier.0
-                                    // is a bogus path that got constructed when transferring
-                                    // a returned fat pointer into a thin pointer target
-                                    // variable without an explicit cast.
-                                    // It is hard to detect this case before calling this
-                                    // routine, so we'll allow it to happen tell the caller
-                                    // to look out for it by returning this:
-                                    return self.tcx.types.never;
+                                if *ordinal == 0 {
+                                    // Taking the address of a struct returns the address of field 0
+                                    // and the type of the address is both *S and *F where S is the
+                                    // struct type and F is the type of field 0. If get here, it
+                                    // is because we tracked type F, whereas rustc used S.
+                                    // We therefore return F.
+                                    return t;
                                 }
                             }
                         }


### PR DESCRIPTION
## Description

MIRAI's type tracking has a hard time with &s where is a Struct S with field 0 of type F, behaving as if it has two types, &S as well as &F. This can cause a path that is the address of field 0 of struct to look for the type of the struct and find a cached entry for it that already reports it as being of type &F. Rather than logging an error in such situations, we now just return &F for the path when F is not a struct.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
