### PR TITLE
More fixes to path type inference

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -693,7 +693,7 @@ impl AbstractValue {
         path: Rc<Path>,
     ) -> Rc<AbstractValue> {
         Rc::new(make_value(Expression::InitialParameterValue {
-            path,
+            path: path.remove_initial_value_wrapper(),
             var_type,
         }))
     }


### PR DESCRIPTION
## Description

Undoing a previous fix, generalizing the struct reference fix and better canonicalizing old paths.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
