### PR TITLE
More work to deal with *&Struct vs *&Struct.field0 confusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if",
 ]
@@ -652,9 +652,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -144,18 +144,15 @@ impl MiraiCallbacks {
 
     fn is_excluded(&self, file_name: &str) -> bool {
         // Exclude crates that contain code that causes MIRAI to crash
-        if file_name.starts_with("client/assets-proof/src") // Sort mismatch at argument #2 for function (declare-fun + (Int Int) Int) supplied sort is <null> 
-            || file_name.starts_with("consensus/consensus-types/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
-            || file_name.starts_with("language/bytecode-verifier/src") // Unexpected representation of upvar types tuple Param(<upvars>/#4)
+        if file_name.starts_with("consensus/consensus-types/src") // (ite (= 1 0) 1 (ite a!1 1 0))) at position 1 does not match declaration
             || file_name.starts_with("language/diem-framework/src") // expect reference target to have a value
             || file_name.starts_with("language/diem-tools/transaction-replay/src") // 'Not a type: DefIndex(3082)'
             || file_name.starts_with("language/move-prover/boogie-backend/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
             || file_name.starts_with("language/move-prover/docgen/src") //  Unexpected representation of upvar types tuple Param(<upvars>/
             || file_name.starts_with("language/tools/move-coverage/src") // out of memory
             || file_name.starts_with("language/transaction-builder/generator/src") // entered unreachable code', checker/src/type_visitor.rs:783:25
-            || file_name.starts_with("network/netcore/src") // operator is applied to arguments of the wrong sort
-            || file_name.starts_with("types/src")
-        // (ite (= 1 0) 1 (ite (= 1 TOP) 1 0)) at position 1 does not match declaration
+            || file_name.starts_with("network/netcore/src")
+        // operator is applied to arguments of the wrong sort
         {
             return true;
         }
@@ -169,6 +166,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("execution/execution-correctness/src") // unreachable: checker/src/body_visitor.rs:1213:38
             || file_name.starts_with("language/compiler/src") // out of memory
             || file_name.starts_with("language/diem-framework/releases/src") // non termination
+            || file_name.starts_with("language/diem-tools/df-cli/src") // out of memory
             || file_name.starts_with("language/diem-vm/src") // 'Not a type: DefIndex(3132)
             || file_name.starts_with("language/move-lang/src") // non termination
             || file_name.starts_with("language/move-model/src") // non termination
@@ -176,7 +174,11 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/tools/move-bytecode-viewer/src") // out of memory
             || file_name.starts_with("language/tools/move-cli/src") // non termination
             || file_name.starts_with("language/tools/move-package/src") // expect reference target to have a value
+            || file_name.starts_with("language/move-prover/src") // non termination
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
+            || file_name.starts_with("language/move-prover/lab/src") // out of memory
+            || file_name.starts_with("language/move-prover/mutation/src") // out of memory
+            || file_name.starts_with("language/move-stdlib/src") // out of memory
             || file_name.starts_with("language/tools/move-unit-test/src") // non termination
             || file_name.starts_with("language/tools/read-write-set/src")  // non termination
             || file_name.starts_with("language/tools/vm-genesis/src") // Unexpected representation of upvar types
@@ -194,9 +196,10 @@ impl MiraiCallbacks {
             return true;
         }
 
-        // Exclude crates that currently slow down testing too much
+        // Conditionally exclude crates that currently slow down testing too much
         if self.options.diag_level == DiagLevel::Default
-            && (file_name.starts_with("common/num-variants/src")
+            && (file_name.starts_with("client/assets-proof/src")
+                || file_name.starts_with("common/num-variants/src")
                 || file_name.starts_with("common/rate-limiter/src")
                 || file_name.starts_with("config/src")
                 || file_name.starts_with("config/management/src")
@@ -207,21 +210,17 @@ impl MiraiCallbacks {
                 || file_name.starts_with("execution/db-bootstrapper/src")
                 || file_name.starts_with("execution/executor/src")
                 || file_name.starts_with("json-rpc/types/src")
+                || file_name.starts_with("language/bytecode-verifier/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/syntax/src")
-                || file_name.starts_with("language/diem-tools/df-cli/src")
                 || file_name.starts_with("language/diem-tools/diem-validator-interface")
                 || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src")
                 || file_name.starts_with("language/move-binary-format/src")
                 || file_name.starts_with("language/move-core/types/src")
-                || file_name.starts_with("language/move-prover/src")
                 || file_name.starts_with("language/move-prover/abigen/src")
                 || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
                 || file_name.starts_with("language/move-prover/interpreter/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
-                || file_name.starts_with("language/move-prover/lab/src")
-                || file_name.starts_with("language/move-prover/mutation")
-                || file_name.starts_with("language/move-stdlib/src")
                 || file_name.starts_with("language/tools/disassembler/src")
                 || file_name.starts_with("move-prover/errmapgen/src")
                 || file_name.starts_with("config/management/network-address-encryption/src")
@@ -236,8 +235,9 @@ impl MiraiCallbacks {
                 || file_name.starts_with("secure/storage/vault/src")
                 || file_name.starts_with("state-sync/src")
                 || file_name.starts_with("state-sync/inter-component/event-notifications/src")
-                || file_name.starts_with("storage/storage-client/src"))
-            || file_name.starts_with("vm-validator/src")
+                || file_name.starts_with("storage/storage-client/src")
+                || file_name.starts_with("types/src")
+                || file_name.starts_with("vm-validator/src"))
         {
             return true;
         }

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -531,6 +531,11 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                             if let TyKind::Adt(def, substs) = t.kind() {
                                 let substs =
                                     self.specialize_substs(substs, &self.generic_argument_map);
+                                if !def.is_enum() {
+                                    // Could be a *&S vs *&S.Field_0 confusion
+                                    t = self.get_field_type(def, substs, 0);
+                                    continue;
+                                }
                                 if *ordinal < def.variants.len() {
                                     let variant = &def.variants[VariantIdx::new(*ordinal)];
                                     let field_tys =


### PR DESCRIPTION
## Description

More work to deal with *&Struct vs *&Struct.field0 confusion. Also cleanup some code in transfer_and_refine_parameters and update exclusion list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem