### PR TITLE
Avoid using higher order functions as analysis roots

### DIFF
--- a/checker/src/crate_visitor.rs
+++ b/checker/src/crate_visitor.rs
@@ -108,6 +108,12 @@ impl<'compilation, 'tcx> CrateVisitor<'compilation, 'tcx> {
                 } else if self.tcx.is_const_fn_raw(def_id) {
                     debug!("skipping function {} as it is a constant function", name);
                     continue;
+                } else if utils::is_higher_order_function(def_id, self.tcx) {
+                    debug!(
+                        "skipping function {} as it is a higher order function",
+                        name
+                    );
+                    continue;
                 } else {
                     info!("analyzing function {}", name);
                 }


### PR DESCRIPTION
## Description

Avoid using higher order functions as analysis roots. They are like generic functions in as much as they can't be precisely analyzed without knowing which functions are passed in as parameters.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
