### PR TITLE
Fix indirect calls of closure via Fn trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "rpds"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387f58b714cda2b5042ef9e91819445f60189900b618475186b11d7876f6adb4"
+checksum = "054e417ded02a19ae192c8c89412eaec7d1c2cdd826aa412565761d86ca6315e"
 dependencies = [
  "archery",
  "serde",

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1173,7 +1173,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
         }
         let mut argument_map = self.callee_generic_argument_map.clone();
         if closure_ty.is_closure() {
-            if self.callee_known_name != KnownNames::StdSyncOnceCallOnce {
+            if self.callee_known_name == KnownNames::StdOpsFunctionFnOnceCallOnce
+                || self.callee_known_name == KnownNames::StdSyncOnceCallOnce
+            {
                 let closure_path = self.actual_args[0].0.clone();
                 let closure_reference = AbstractValue::make_reference(closure_path);
                 actual_args.insert(
@@ -1183,6 +1185,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         closure_reference,
                     ),
                 );
+                actual_argument_types.insert(0, closure_ref_ty);
+            } else {
+                actual_args.insert(0, self.actual_args[0].clone());
                 actual_argument_types.insert(0, closure_ref_ty);
             }
             if let TyKind::Closure(def_id, substs) = closure_ty.kind() {

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -204,6 +204,7 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/syntax/src")
                 || file_name.starts_with("language/diem-framework/src")
+                || file_name.starts_with("language/diem-framework/DPN/releases/src")
                 || file_name.starts_with("language/diem-tools/diem-validator-interface")
                 || file_name.starts_with("language/diem-tools/transaction-replay/src")
                 || file_name.starts_with("language/move-binary-format/src")


### PR DESCRIPTION
## Description

Always pass in the closure value for indirect calls, but adjust the internal MIRAI code path to deal with the signature difference between FnOnce and FnMut.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem