### PR TITLE
Refine if loc { x } else { y } into x join y

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -150,6 +150,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("crypto/crypto-derive/src") // out of memory
             || file_name.starts_with("execution/db-bootstrapper/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("language/compiler/src") // out of memory
+            || file_name.starts_with("language/diem-framework/DPN/releases/src")  // non termination
             || file_name.starts_with("language/diem-framework/releases/src") // non termination
             || file_name.starts_with("language/diem-tools/df-cli/src") // out of memory
             || file_name.starts_with("language/diem-tools/writeset-transaction-generator/src")  // out of memory
@@ -161,6 +162,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/tools/move-cli/src") // non termination
             || file_name.starts_with("language/tools/move-package/src") // non termination
             || file_name.starts_with("language/move-prover/src") // non termination
+            || file_name.starts_with("language/move-prover/boogie-backend/src") // non termination
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
             || file_name.starts_with("language/move-prover/lab/src") // out of memory
             || file_name.starts_with("language/move-prover/mutation/src") // out of memory
@@ -204,15 +206,12 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/compiler/ir-to-bytecode/src")
                 || file_name.starts_with("language/compiler/ir-to-bytecode/syntax/src")
                 || file_name.starts_with("language/diem-framework/src")
-                || file_name.starts_with("language/diem-framework/DPN/releases/src")
                 || file_name.starts_with("language/diem-tools/diem-validator-interface")
                 || file_name.starts_with("language/diem-tools/transaction-replay/src")
                 || file_name.starts_with("language/move-binary-format/src")
                 || file_name.starts_with("language/move-core/types/src")
                 || file_name.starts_with("language/move-ir/types/src/")
                 || file_name.starts_with("language/move-prover/abigen/src")
-                || file_name.starts_with("language/move-prover/boogie-backend/src")
-                || file_name.starts_with("language/move-prover/boogie-backend-exp/src")
                 || file_name.starts_with("language/move-prover/docgen/src")
                 || file_name.starts_with("language/move-prover/interpreter/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")


### PR DESCRIPTION
## Description

Refine if loc { x } else { y } into x join y when incorporating a callee summary into a call site. Such expression can arise if loc contains information obtained from the environment by the callee. Join expressions are smaller and widen better, so this should improve performance as well as precision.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem