### PR TITLE
Refine if loc { x } else { y } into x join y

### DIFF
--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -389,36 +389,6 @@ impl Path {
         }
     }
 
-    /// True if path qualifies a local, or another qualified path rooted by a local.
-    #[logfn_inputs(TRACE)]
-    pub fn is_rooted_by_local(&self) -> bool {
-        match &self.value {
-            PathEnum::Computed { value } => {
-                if let Expression::InitialParameterValue { path, .. }
-                | Expression::Reference(path)
-                | Expression::Variable { path, .. } = &value.expression
-                {
-                    return path.is_rooted_by_local();
-                }
-                false
-            }
-            PathEnum::Offset { value } => {
-                if let Expression::Offset { left, .. } = &value.expression {
-                    if let Expression::InitialParameterValue { path, .. }
-                    | Expression::Reference(path)
-                    | Expression::Variable { path, .. } = &left.expression
-                    {
-                        return path.is_rooted_by_local();
-                    }
-                }
-                false
-            }
-            PathEnum::QualifiedPath { qualifier, .. } => qualifier.is_rooted_by_local(),
-            PathEnum::LocalVariable { .. } => true,
-            _ => false,
-        }
-    }
-
     /// True if path qualifies an abstract heap block, string or static, or another qualified path
     /// rooted by an abstract heap block, string or static.
     #[logfn_inputs(TRACE)]


### PR DESCRIPTION
## Description

When refining if c { x } else { y } into x join y from a callee summary into a call site, check if c contains local callee state and that the refined version of c cannot be resolved using only call site (or caller) state. Such expression can arise if c contains information obtained from the environment by the callee. Join expressions are smaller and widen better, so this should improve performance as well as precision.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
