### PR TITLE
Deal with indirect paths when passing in function constants

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -199,6 +199,7 @@ impl MiraiCallbacks {
                 || file_name.starts_with("consensus/safety-rules/src")
                 || file_name.starts_with("common/debug-interface/src")
                 || file_name.starts_with("crypto/crypto/src")
+                || file_name.starts_with("diem-node/src")
                 || file_name.starts_with("execution/db-bootstrapper/src")
                 || file_name.starts_with("execution/execution-correctness/src")
                 || file_name.starts_with("execution/executor/src")

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -12,7 +12,7 @@ use crate::{k_limits, utils};
 use log_derive::*;
 use mirai_annotations::*;
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{Ty, TyCtxt};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
@@ -28,6 +28,12 @@ use std::rc::Rc;
 pub struct Path {
     pub value: PathEnum,
     hash: u64,
+}
+
+#[derive(Debug)]
+pub enum PathOrFunction<'tcx> {
+    Path(Rc<Path>),
+    Function(Ty<'tcx>, Rc<AbstractValue>),
 }
 
 impl Debug for Path {

--- a/checker/tests/run-pass/smuggled_funcs.rs
+++ b/checker/tests/run-pass/smuggled_funcs.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// A test to see that functions accessed via fields and indirections are passed in during analysis
+
+use mirai_annotations::*;
+
+pub struct ContainsFunc {
+    pub func_ptr: fn() -> i32,
+}
+
+fn t1a(cf: &ContainsFunc) -> i32 {
+    (cf.func_ptr)()
+}
+
+pub fn t1() {
+    let cf = ContainsFunc { func_ptr: || 1 };
+    let r = t1a(&cf);
+    verify!(r == 1);
+}
+
+pub struct SmugglesFunc<'a> {
+    pub smuggle: &'a ContainsFunc,
+}
+
+fn t2a(sf: &SmugglesFunc) -> i32 {
+    (sf.smuggle.func_ptr)()
+}
+
+pub fn t2() {
+    let cf = ContainsFunc { func_ptr: || 1 };
+    let sf = SmugglesFunc { smuggle: &cf };
+    let r = t2a(&sf);
+    verify!(r == 1);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When a callee can access a function via an indirect path, such as a reference to a structure that contains a field that is reference to a structure that contains a field that is a pointer to a function, the existing logic of get_function_constant_args fails to include paths to those functions and the analysis of the callee ends up having an unresolved function call.

This PR rewrites the logic of get_function_constant_args to do a fixed point traversal of the local heap to find all paths from roots to functions, and then uses that information to give a more complete result from get_function_constant_args.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
