### PR TITLE
Include more paths in result of get_function_constant_args

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -187,7 +187,8 @@ impl MiraiCallbacks {
 
         // Conditionally exclude crates that currently slow down testing too much because they take longer than 2 minutes to analyze
         if self.options.diag_level == DiagLevel::Default
-            && (file_name.starts_with("client/assets-proof/src")
+            && (file_name.starts_with("api/src")
+                || file_name.starts_with("client/assets-proof/src")
                 || file_name.starts_with("common/num-variants/src")
                 || file_name.starts_with("common/rate-limiter/src")
                 || file_name.starts_with("config/src")

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -30,9 +30,9 @@ pub struct Path {
     hash: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PathOrFunction<'tcx> {
-    Path(Rc<Path>),
+    Path(Rc<Path>, bool),
     Function(Ty<'tcx>, Rc<AbstractValue>),
 }
 

--- a/checker/tests/run-pass/smuggled_funcs.rs
+++ b/checker/tests/run-pass/smuggled_funcs.rs
@@ -8,15 +8,15 @@
 use mirai_annotations::*;
 
 pub struct ContainsFunc {
-    pub func_ptr: fn() -> i32,
+    pub func: fn() -> i32,
 }
 
 fn t1a(cf: &ContainsFunc) -> i32 {
-    (cf.func_ptr)()
+    (cf.func)()
 }
 
 pub fn t1() {
-    let cf = ContainsFunc { func_ptr: || 1 };
+    let cf = ContainsFunc { func: || 1 };
     let r = t1a(&cf);
     verify!(r == 1);
 }
@@ -26,13 +26,33 @@ pub struct SmugglesFunc<'a> {
 }
 
 fn t2a(sf: &SmugglesFunc) -> i32 {
-    (sf.smuggle.func_ptr)()
+    (sf.smuggle.func)()
 }
 
 pub fn t2() {
-    let cf = ContainsFunc { func_ptr: || 1 };
+    let cf = ContainsFunc { func: || 1 };
     let sf = SmugglesFunc { smuggle: &cf };
     let r = t2a(&sf);
+    verify!(r == 1);
+}
+
+pub struct ContainsFuncRef<'a> {
+    pub func_ref: &'a dyn Fn() -> i32,
+}
+
+pub struct SmugglesFuncRef<'a> {
+    pub smuggle: &'a ContainsFuncRef<'a>,
+}
+
+fn t3a(sf: &SmugglesFuncRef) -> i32 {
+    (sf.smuggle.func_ref)()
+}
+
+pub fn t3() {
+    let f = || 1;
+    let cf = ContainsFuncRef { func_ref: &|| f() };
+    let sf = SmugglesFuncRef { smuggle: &cf };
+    let r = t3a(&sf);
     verify!(r == 1);
 }
 


### PR DESCRIPTION
## Description

The current logic trims candidate paths too aggressively by only looking at their roots. Fix this and deal with the newly uncovered problem of self referential paths that lead to recursive loops.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
