### PR TITLE
Minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,9 +439,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2248,9 +2248,12 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
     fn visit_discriminant(&mut self, path: Rc<Path>, place: &mir::Place<'tcx>) {
         let discriminant_path = Path::new_discriminant(self.visit_rh_place(place))
             .canonicalize(&self.bv.current_environment);
+        let discriminant_type = self
+            .type_visitor()
+            .get_path_rustc_type(&discriminant_path, self.bv.current_span);
         let discriminant_value = self
             .bv
-            .lookup_path_and_refine_result(discriminant_path, self.bv.tcx.types.u128);
+            .lookup_path_and_refine_result(discriminant_path, discriminant_type);
         self.bv.update_value_at(path, discriminant_value);
     }
 

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -2402,8 +2402,9 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
         // be saddled with removing it. This case corresponds to no_children being true.
         if target_type == ExpressionType::NonPrimitive || target_type == ExpressionType::Function {
             // First look at paths that are rooted in rpath.
-            let value_map = self.current_environment.value_map.clone();
-            for (path, value) in value_map
+            let env = self.current_environment.clone();
+            for (path, value) in env
+                .value_map
                 .iter()
                 .filter(|(p, _)| p.is_rooted_by(&source_path))
             {
@@ -2415,7 +2416,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 }
                 let qualified_path = path
                     .replace_root(&source_path, target_path.clone())
-                    .canonicalize(&self.current_environment);
+                    .canonicalize(&env);
                 if move_elements {
                     trace!("moving child {:?} to {:?}", value, qualified_path);
                     self.current_environment.value_map =

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -167,6 +167,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/move-prover/src") // non termination
             || file_name.starts_with("language/move-prover/boogie-backend/src") // non termination
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
+            || file_name.starts_with("language/move-prover/interpreter/crypto/src") // Sorts (_ BitVec 128) and Bool are incompatible
             || file_name.starts_with("language/move-prover/lab/src") // out of memory
             || file_name.starts_with("language/move-prover/mutation/src") // out of memory
             || file_name.starts_with("language/move-stdlib/src") // out of memory
@@ -180,8 +181,9 @@ impl MiraiCallbacks {
             || file_name.starts_with("sdk/client/src") // non termination
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemsum/src") // out of memory
-            || file_name.starts_with("storage/inspector/src/")
-        // out of memory
+            || file_name.starts_with("storage/inspector/src/") // out of memory
+            || file_name.starts_with("types/src")
+        // Sorts (_ BitVec 128) and Bool are incompatible
         {
             return true;
         }


### PR DESCRIPTION
## Description

Fix the type of the discriminant of an enum when obtaining it via the MIR discriminant operator.
Ensure that path normalization is not disturbed by updates that happen during the process of copying/moving a structure .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem