### PR TITLE
Redirect copied parameter fields during get_function_constant_args

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -798,7 +798,8 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                     callee_param = Path::new_deref(callee_param, ExpressionType::NonPrimitive);
                     arg_path = path;
                 }
-                Expression::InitialParameterValue { path, .. } => {
+                Expression::InitialParameterValue { path, .. }
+                | Expression::Variable { path, .. } => {
                     arg_path = path;
                 }
                 _ => {}

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -149,6 +149,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("config/management/genesis/src") // out of memory
             || file_name.starts_with("config/management/operational/src") // non termination
             || file_name.starts_with("consensus/consensus-types/src") //  Sorts Bool and (_ BitVec 128) are incompatible
+            || file_name.starts_with("consensus/safety-rules/src") //  Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("crypto/crypto/src") // Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("crypto/crypto-derive/src") // out of memory
             || file_name.starts_with("execution/db-bootstrapper/src") // Sorts Int and <null> are incompatible

--- a/checker/src/constant_domain.rs
+++ b/checker/src/constant_domain.rs
@@ -57,10 +57,16 @@ impl Debug for ConstantDomain {
             ConstantDomain::Char(ch) if (*ch as u32) == 0 => f.write_fmt(format_args!("'null'")),
             ConstantDomain::Char(ch) => f.write_fmt(format_args!("'{}'", ch)),
             ConstantDomain::False => f.write_str("false"),
-            ConstantDomain::Function(func_ref) => f.write_fmt(format_args!(
-                "fn {}{}<{:?}>",
-                func_ref.summary_cache_key, func_ref.argument_type_key, func_ref.generic_arguments
-            )),
+            ConstantDomain::Function(func_ref) => {
+                if let Some(def_id) = func_ref.def_id {
+                    f.write_fmt(format_args!("{:?}", def_id))
+                } else {
+                    f.write_fmt(format_args!(
+                        "fn {}{}",
+                        func_ref.summary_cache_key, func_ref.argument_type_key
+                    ))
+                }
+            }
             ConstantDomain::I128(val) => val.fmt(f),
             ConstantDomain::F64(val) => (f64::from_bits(*val)).fmt(f),
             ConstantDomain::F32(val) => (f32::from_bits(*val)).fmt(f),


### PR DESCRIPTION
## Description

Function constants that are reachable via parameters can end up being reachable from paths that end up in Expression::Variable, so make get_function_constant_args deal with this.

Also tweak the debug output of function constants to make it easier to navigate through the entries of a local environment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem