### PR TITLE
Simplify inline_indirectly_called_function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
 
 [[package]]
 name = "proc-macro2"

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -146,12 +146,14 @@ impl MiraiCallbacks {
         // Exclude crates that crash or don't terminate. All of these currently take longer than 2 minutes to analyze.
         if file_name.starts_with("client/faucet/src") // non termination
             || file_name.starts_with("config/src") // Sorts Bool and (_ BitVec 128) are incompatible
+            || file_name.starts_with("config/management/src") // Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("config/management/genesis/src") // out of memory
             || file_name.starts_with("config/management/operational/src") // non termination
             || file_name.starts_with("consensus/consensus-types/src") //  Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("consensus/safety-rules/src") //  Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("crypto/crypto/src") // Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("crypto/crypto-derive/src") // out of memory
+            || file_name.starts_with("execution/execution-correctness/src") // Sorts (_ BitVec 128) and Bool are incompatible
             || file_name.starts_with("execution/db-bootstrapper/src") // Sorts Int and <null> are incompatible
             || file_name.starts_with("language/compiler/src") // out of memory
             || file_name.starts_with("language/diem-framework/src") // non termination
@@ -184,8 +186,10 @@ impl MiraiCallbacks {
             || file_name.starts_with("network/builder/src") // non termination
             || file_name.starts_with("sdk/src") // Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("sdk/client/src") // non termination
+            || file_name.starts_with("secure/key-manager/src") // Sorts (_ BitVec 128) and Bool are incompatible
             || file_name.starts_with("secure/storage/src") // Sorts Bool and (_ BitVec 128) are incompatible
             || file_name.starts_with("secure/storage/vault/src") // Sorts Bool and (_ BitVec 128) are incompatible
+            || file_name.starts_with("state-sync/state-sync-v1/src") // Sorts (_ BitVec 128) and Bool are incompatible
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemsum/src") // out of memory
             || file_name.starts_with("storage/inspector/src/") // out of memory

--- a/checker/src/known_names.rs
+++ b/checker/src/known_names.rs
@@ -108,7 +108,6 @@ pub enum KnownNames {
     StdPanickingBeginPanicFmt,
     StdPtrSwapNonOverlapping,
     StdSliceCmpMemcmp,
-    StdSyncOnceCallOnce,
 }
 
 /// An analysis lifetime cache that contains a map from def ids to known names.
@@ -402,28 +401,6 @@ impl KnownNamesCache {
                 .unwrap_or(KnownNames::None)
         };
 
-        let get_known_name_for_sync_once_namespace =
-            |mut def_path_data_iter: Iter<'_>| match path_data_elem_as_disambiguator(
-                def_path_data_iter.next(),
-            ) {
-                Some(2) => get_path_data_elem_name(def_path_data_iter.next())
-                    .map(|n| match n.as_str().deref() {
-                        "call_once" => KnownNames::StdSyncOnceCallOnce,
-                        _ => KnownNames::None,
-                    })
-                    .unwrap_or(KnownNames::None),
-                _ => KnownNames::None,
-            };
-
-        let get_known_name_for_sync_namespace = |mut def_path_data_iter: Iter<'_>| {
-            get_path_data_elem_name(def_path_data_iter.next())
-                .map(|n| match n.as_str().deref() {
-                    "once" => get_known_name_for_sync_once_namespace(def_path_data_iter),
-                    _ => KnownNames::None,
-                })
-                .unwrap_or(KnownNames::None)
-        };
-
         let get_known_name_for_known_crate = |mut def_path_data_iter: Iter<'_>| {
             get_path_data_elem_name(def_path_data_iter.next())
                 .map(|n| match n.as_str().deref() {
@@ -451,7 +428,6 @@ impl KnownNamesCache {
                     "mirai_verify" => KnownNames::MiraiVerify,
                     "raw_vec" => get_known_name_for_raw_vec_namespace(def_path_data_iter),
                     "slice" => get_known_name_for_slice_namespace(def_path_data_iter),
-                    "sync" => get_known_name_for_sync_namespace(def_path_data_iter),
                     _ => KnownNames::None,
                 })
                 .unwrap_or(KnownNames::None)


### PR DESCRIPTION
## Description

Clarify and simplify the logic of inline_indirectly_called_function, particularly with regards to call_once and the situation where it indirectly calls a function that refers to its closure via a reference. This has been problematic because call_once consumes the callee (closure) argument and can call both functions that do the same and functions that merely borrow the argument.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

