### PR TITLE
Tweak path canonicalization

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -1889,9 +1889,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
     fn handle_copy_non_overlapping(&mut self) {
         checked_assume!(self.actual_args.len() == 3);
         let source_path =
-            Path::new_deref(self.actual_args[0].0.clone(), ExpressionType::NonPrimitive);
+            Path::new_deref(self.actual_args[0].0.clone(), ExpressionType::NonPrimitive)
+                .canonicalize(&self.environment_before_call);
         let target_root =
-            Path::new_deref(self.actual_args[1].0.clone(), ExpressionType::NonPrimitive);
+            Path::new_deref(self.actual_args[1].0.clone(), ExpressionType::NonPrimitive)
+                .canonicalize(&self.environment_before_call);
         let count = self.actual_args[2].1.clone();
         let target_path = Path::new_slice(target_root, count);
         let collection_type = self.actual_argument_types[0];

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -172,6 +172,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/move-prover/src") // non termination
             || file_name.starts_with("language/move-prover/boogie-backend/src") // non termination
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
+            || file_name.starts_with("language/move-prover/docgen/src") // entered unreachable code', checker/src/type_visitor.rs:880
             || file_name.starts_with("language/move-prover/interpreter/src") // Sorts (_ BitVec 128) and Bool are incompatible
             || file_name.starts_with("language/move-prover/interpreter/crypto/src") // Sorts (_ BitVec 128) and Bool are incompatible
             || file_name.starts_with("language/move-prover/lab/src") // out of memory

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -806,7 +806,8 @@ impl PathRefinement for Rc<Path> {
     /// form, after removing indirections. This does not solve the alias problem entirely, but
     /// it reduces the problem to dealing with PathEnum::Computed and PathSelector::Index and
     /// PathSelector::Slice.
-    #[logfn_inputs(TRACE)]
+    #[logfn_inputs(DEBUG)]
+    #[logfn(DEBUG)]
     fn canonicalize(&self, environment: &Environment) -> Rc<Path> {
         if let Some(val) = environment.value_at(self) {
             // If self binds to value &p then self and path &p are equivalent paths.
@@ -835,7 +836,11 @@ impl PathRefinement for Rc<Path> {
                 }
                 return Path::new_computed(val.clone());
             }
-        };
+            // If the environment contains a value for (key) self, self must be canonical.
+            // At any rate, it makes no sense to turn it into another path that likely
+            // does not lead to the known value.
+            return self.clone();
+        }
 
         // If self is a qualified path, then recursive canonicalization of the qualifier may
         // cause substitutions (as above) and that could result in a non canonical qualified path


### PR DESCRIPTION
## Description

If a path is already a key to the current environment it must already be in canonical form, so don't re-canonicalize it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
