### PR TITLE
Tweak simplification of (val == widened)

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2496,7 +2496,7 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     Rc::new(FALSE)
                 } else {
                     self.equals(AbstractValue::make_typed_unknown(
-                        self.expression.infer_type(),
+                        other.expression.infer_type(),
                         path.clone(),
                     ))
                 };

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -182,6 +182,7 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/tools/move-coverage/src") // out of memory
             || file_name.starts_with("language/tools/move-unit-test/src") // non termination
             || file_name.starts_with("language/tools/read-write-set/src")  // non termination
+            || file_name.starts_with("language/tools/vm-genesis/src") // out of memory
             || file_name.starts_with("language/transaction-builder/generator/src") // out of memory
             || file_name.starts_with("mempool/src") // out of memory
             || file_name.starts_with("network/src") // non termination


### PR DESCRIPTION
## Description

Tweak simplification of (val == widened) to not lose any type information that may be in widened.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem