### PR TITLE
Tweak joins and fix bug in drop handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -3304,6 +3304,14 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     }
                 }
             }
+            // [x join widened(x join y)] -> widened(x join y)
+            (_, Expression::WidenedJoin { operand, .. }) => {
+                if let Expression::Join { left: x, .. } = &operand.expression {
+                    if self.eq(x) {
+                        return other.clone();
+                    }
+                }
+            }
             _ => {}
         }
         let expression_size = self.expression_size.saturating_add(other.expression_size);

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -929,7 +929,13 @@ impl Expression {
             Expression::Equals { .. } => Bool,
             Expression::GreaterOrEqual { .. } => Bool,
             Expression::GreaterThan { .. } => Bool,
-            Expression::Join { left, .. } => left.expression.infer_type(),
+            Expression::Join { left, right } => {
+                if left.is_compile_time_constant() {
+                    right.expression.infer_type()
+                } else {
+                    left.expression.infer_type()
+                }
+            }
             Expression::LessOrEqual { .. } => Bool,
             Expression::LessThan { .. } => Bool,
             Expression::LogicalNot { .. } => Bool,


### PR DESCRIPTION
## Description

Simplify: [x join widened(x join y)] -> widened(x join y)
Fix type inference of join expressions.
Fix bug introduced by first using the location of a drop statement as a dummy return result and subsequently updating the type of return values following a call in order to track actual return types.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem