### PR TITLE
The result of a bitwise and might be contained in an interval

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -5264,6 +5264,16 @@ impl AbstractValueTrait for Rc<AbstractValue> {
         match &self.expression {
             Expression::Top => interval_domain::BOTTOM,
             Expression::Add { left, right } => left.get_as_interval().add(&right.get_as_interval()),
+            Expression::BitAnd { left, .. } => {
+                if let Expression::CompileTimeConstant(ConstantDomain::U128(v)) = left.expression {
+                    if v < (i128::MAX as u128) && (v + 1).is_power_of_two() {
+                        let lower: IntervalDomain = 0u128.into();
+                        let upper: IntervalDomain = v.into();
+                        return lower.widen(&upper);
+                    }
+                }
+                interval_domain::BOTTOM
+            }
             Expression::Cast {
                 operand,
                 target_type,

--- a/checker/tests/run-pass/bit_vector_and_vec_push.rs
+++ b/checker/tests/run-pass/bit_vector_and_vec_push.rs
@@ -31,6 +31,8 @@ pub fn write_u32_as_uleb128(binary: &mut Vec<u8>, value: u32) {
 pub fn main() {
     let mut buf = Vec::<u8>::new();
     write_u32_as_uleb128(&mut buf, 129);
-    verify!(buf.len() == 2);
+    //todo: more simplifications might allow the verify below to succeed
+    verify!(buf.len() == 2); //~ possible false verification condition
+                             //todo: find out why the above check causes the below one to become "provable" when it is clearly not
     verify!(buf.len() == 1); //~ provably false verification condition
 }


### PR DESCRIPTION
## Description

The result of a bitwise and is contained in an interval if one of the arguments is a constant of the form (2 << n) - 1.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
