### PR TITLE
Modify lazy_static test case to work around MIRAI limitation

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -180,8 +180,10 @@ impl MiraiCallbacks {
             || file_name.starts_with("mempool/src") // out of memory
             || file_name.starts_with("network/src") // non termination
             || file_name.starts_with("network/builder/src") // non termination
+            || file_name.starts_with("network/discovery/src") // out of memory
             || file_name.starts_with("sdk/client/src") // non termination
             || file_name.starts_with("state-sync/inter-component/event-notifications/src") // non termination
+            || file_name.starts_with("state-sync/state-sync-v1/src") // non termination
             || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
             || file_name.starts_with("storage/diemsum/src") // out of memory
             || file_name.starts_with("storage/inspector/src/") // out of memory


### PR DESCRIPTION
## Description

MIRAI only tracks the heap state of a single thread. The lazy_static test case includes code that synchronizes with other threads and updates heap state with a reference to a local memory that it expects other threads to read and modify before it returns to its caller. Since MIRAI does not model the other threads, this local state leaks to the caller and becomes part of a condition that cannot be promoted and which then results in a false diagnostic.

Update the test case to work around this using assume and assume_preconditions. Add comments to remind me why the test case is the way it is.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [x] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

