### PR TITLE
Make it possible to explicitly treat code as foreign

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -116,6 +116,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                 self.block_visitor.bv.active_calls_map,
                 self.block_visitor.bv.cv.type_cache.clone(),
             );
+            body_visitor.treat_as_foreign = self.block_visitor.bv.treat_as_foreign
+                || self.block_visitor.bv.assume_preconditions_of_next_call;
             body_visitor.type_visitor_mut().actual_argument_types =
                 self.actual_argument_types.clone();
             body_visitor.type_visitor_mut().generic_arguments = self.callee_generic_arguments;


### PR DESCRIPTION
## Description

In non paranoid mode, MIRAI suppresses diagnostics that can only be addressed by changing code that is not part of the project being analyzed (since doing so is usually not possible).

This also applies to code that is injected locally by means of derive macros. (Such code can rely on very complicated/subtle invariants and changing the code would need changes to the third party derive macros.)

Ideally, the derive macro has generated the code in such a way that the source locations of the generated code knows that the code is injected (derived). MIRAI has long suppressed diagnostics in such code. There are, however, derive macros that do not behave in such a reasonable manner. In such cases the diagnostics surface and there was no way to suppress them by annotating code in the project under analysis.

With this change, attaching assume_preconditions!() to a function will not only suppress messages about unsatisfied preconditions of the called function, but also suppress messages about potential panics in code that is reachable from the call (and which can't be promoted to preconditions because their reachability cannot be controlled entirely by parameter values).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem

