### PR TITLE
Make sure that function constant come with the right types

### DIFF
--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -175,7 +175,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
         if cfg!(DEBUG)
             && !matches!(
                 self.tcx.def_kind(self.def_id),
-                rustc_hir::def::DefKind::Variant
+                rustc_hir::def::DefKind::Struct | rustc_hir::def::DefKind::Variant
             )
         {
             let mut stdout = std::io::stdout();
@@ -872,6 +872,8 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                             }
                             .into(),
                         );
+                        self.type_visitor_mut()
+                            .set_path_rustc_type(heap_root.clone(), result_rustc_type);
                         for (path, value) in self
                             .exit_environment
                             .as_ref()


### PR DESCRIPTION
## Description

Tweak type tracking to make sure that function constant arguments always have a valid type. This matters when function constants are stored in fields of closures that are promoted constants.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem