### PR TITLE
Suppress diagnostics that are hard to deal with via source annotations

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2635,6 +2635,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                     _ => Rc::new(abstract_value::FALSE),
                 };
                 if promoted_condition.as_bool_if_known().is_none() {
+                    if self.block_visitor.bv.current_span.in_derive_expansion() {
+                        info!("derive macro has warning: {:?}", precondition.message);
+                        // do not propagate preconditions across derive macros since
+                        // derived code is pretty much foreign code.
+                        continue;
+                    }
+
                     let mut stacked_spans = vec![self.block_visitor.bv.current_span];
                     stacked_spans.append(&mut precondition.spans.clone());
                     let promoted_precondition = Precondition {


### PR DESCRIPTION
## Description

Suppress diagnostics that are hard to deal with via source annotations (for example because a precondition of a drop handler is not satisfied by the call site, which has no source code). Although this is unsound, the downside of having false positives that cannot be suppressed by simple annotations in the source code, outweigh the safety concern. In well-tested code, it seems reasonable to expect that other, explicit entry points (such as unit tests) will reach the same code and, if the diagnostic is a false positive, it can be reviewed and suppressed in those places.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem