### PR TITLE
Don't always collapse widened expressions into typed unknowns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "lock_api"

--- a/documentation/DeveloperGuide.md
+++ b/documentation/DeveloperGuide.md
@@ -60,9 +60,10 @@ To run mirai on a crate, as if it were rustc, just set the `RUSTC_WRAPPER` envir
 When running `RUSTC_WRAPPER=~/mirai/target/debug/mirai cargo build` on a crate make sure to either:
 1. Set Rust to use the same nightly as MIRAI in the crate's directory (via `rustup override`, or by linking to 
     MIRAI's [rust-toolchain](https://github.com/facebookexperimental/MIRAI/blob/main/rust-toolchain) file).
-2. Or set `DYLD_LIBRARY_PATH=/Users/$USER/.rustup/toolchains/nightly-YYYY-MM-DD-x86_64-apple-darwin/lib/` before running 
+2. Or set `DYLD_LIBRARY_PATH=/Users/$USER/.rustup/toolchains/nightly-YYYY-MM-DD-TA/lib/` before running 
     `RUSTC_WRAPPER=mirai cargo build`.
-    - (Be sure to fill `YYYY-MM-DD` with the correctly nightly date.)
+    - (Be sure to fill `YYYY-MM-DD` with the correctly nightly date and to replace TA with the appropriate target
+architecture string. You can obtain that using `rustc --print sysroot`.)
 
 Failure to do so may result in the error: `dyld: Library not loaded`.
 


### PR DESCRIPTION
## Description

Don't always collapse widened expressions into typed unknowns. In particular, this is undesirable when the underlying join expression depends entirely on parameter values, because the collapsed widen becomes a local and conditions including it cannot be promoted to preconditions.

Also clarify the documentation on how to set DYLD_LIBRARY_PATH.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem