### PR TITLE
old(a[i]) expressions can contain local variables in i.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,22 @@ MIRAI is an abstract interpreter for the [Rust](https://www.rust-lang.org/) comp
 representation](https://github.com/rust-lang/rfcs/blob/main/text/1211-mir.md) (MIR).
 It is intended to become a widely used static analysis tool for Rust.
 
-## Using MIRAI
+## Who should use MIRAI
+
+MIRAI can be used as a linter that finds panics that may be unintentional or are not the best way to terminate a
+program. This use case generally requires no annotations and is best realized by integrating MIRAI into a CI pipeline.
+
+MIRAI can also be used to verify correctness properties. Such properties need to be encoded into annotations of the
+source program.
+
+A related use is to better document an API via explicit precondition annotations and then use MIRAI to check that 
+the annotations match the code.
+
+Finally, MIRAI can be used to look for security bugs via taint analysis (information leaks, code injection bugs, etc.)
+and constant time analysis (information leaks via side channels). Unintentional (or ill-considered) panics can also
+become security problems (denial of service, undefined behavior).
+
+## How to use MIRAI
 
 You'll need to install MIRAI as described here for [MacOS and Windows](https://github.com/facebookexperimental/MIRAI/blob/main/documentation/InstallationGuide.md)
 and here for [Linux](https://github.com/facebookexperimental/MIRAI/blob/main/documentation/Linux.md).

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1113,17 +1113,18 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
             .session
             .struct_span_warn(span, diagnostic.as_ref());
         for pc_span in precondition.spans.iter() {
-            let span_str = self
-                .bv
-                .tcx
-                .sess
-                .source_map()
-                .span_to_diagnostic_string(*pc_span);
-            if span_str.starts_with("/rustc/") {
-                warning.span_note(*pc_span, &format!("related location {}", span_str));
-            } else {
+            let snippet = self.bv.tcx.sess.source_map().span_to_snippet(*pc_span);
+            if snippet.is_ok() {
                 warning.span_note(*pc_span, "related location");
-            };
+            } else {
+                let span_str = self
+                    .bv
+                    .tcx
+                    .sess
+                    .source_map()
+                    .span_to_diagnostic_string(*pc_span);
+                warning.span_note(*pc_span, &format!("related location {}", span_str));
+            }
         }
         self.bv.emit_diagnostic(warning);
     }

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -704,6 +704,9 @@ impl Expression {
                         .expression
                         .contains_local_variable(is_post_condition)
             }
+            Expression::InitialParameterValue { path, .. } => {
+                path.contains_local_variable(is_post_condition)
+            }
             Expression::Join { left, right, .. } => {
                 left.expression.contains_local_variable(is_post_condition)
                     || right.expression.contains_local_variable(is_post_condition)
@@ -723,7 +726,6 @@ impl Expression {
                 .expression
                 .contains_local_variable(is_post_condition),
             Expression::Reference(path) => path.contains_local_variable(is_post_condition),
-            Expression::InitialParameterValue { .. } => false,
             Expression::Switch {
                 discriminator,
                 cases,


### PR DESCRIPTION
## Description

old(a[i]) expressions can contain local variables in i, so fix contains_local_variable to check for this.

Generalize check for related locations without source code snippets.

Add use cases to readme.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem