### PR TITLE
Tweak precondition promotion

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2642,6 +2642,20 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         continue;
                     }
 
+                    if (self.block_visitor.bv.treat_as_foreign
+                        || !self.block_visitor.bv.def_id.is_local())
+                        && !matches!(
+                            self.block_visitor.bv.cv.options.diag_level,
+                            DiagLevel::Paranoid
+                        )
+                        && precondition.message.contains("result unwrap failed")
+                    {
+                        // When foreign code unwraps a result, it is unlikely to be a parameter check.
+                        // Instead, let's assume that the code intends a panic to happen if the
+                        // result is not OK.
+                        continue;
+                    }
+
                     let mut stacked_spans = vec![self.block_visitor.bv.current_span];
                     stacked_spans.append(&mut precondition.spans.clone());
                     let promoted_precondition = Precondition {

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -337,7 +337,8 @@ impl Path {
             PathEnum::Parameter { .. } => false,
             // In a post condition, a function result does not count as a local variable of the function
             PathEnum::Result => !is_post_condition,
-            PathEnum::StaticVariable { .. } => false,
+            // A caller will not know anything about a static variable that is not known locally
+            PathEnum::StaticVariable { .. } => true,
             PathEnum::PhantomData => false,
             PathEnum::PromotedConstant { .. } => true,
             PathEnum::QualifiedPath {


### PR DESCRIPTION
## Description

Do not promote preconditions that rely on the values of static variables, since the caller will not know more about those values than the callee.

Also, if a callee in foreign code calls unwrap on a result value (instead of returning it to its caller), it is either a parameter validation check or an explicit contract with the caller that a panic is expected when the result is not OK.
It seems unlikely that calling unwrap on result values is a common pattern for parameter validation, so in non paranoid mode, no diagnostic will be generated about the panic and the caller will not be expected to prove that it will never happen.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem