### PR TITLE
Fix casting of enum discriminant value to integer

### DIFF
--- a/checker/tests/run-pass/enum_cast.rs
+++ b/checker/tests/run-pass/enum_cast.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test that casts an enum value to an unsigned integer value
+
+use mirai_annotations::*;
+
+enum Foo {
+    BarOne = 1,
+    BarTwo = 2,
+}
+
+fn t1a(foo: Foo) -> u8 {
+    foo as u8
+}
+
+fn t1b(b: bool) -> u8 {
+    if b {
+        t1a(Foo::BarOne)
+    } else {
+        t1a(Foo::BarTwo)
+    }
+}
+
+pub fn t1() {
+    let n = t1b(true);
+    verify!(n == 1);
+}
+
+pub fn main() {}


### PR DESCRIPTION
## Description

When an enum value is cast to an integer, it implicitly accesses the discriminant value field. The latter is explicitly modeled in the heap model, so the result value of the cast must reflect this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem