### PR TITLE
Guard call to upvar_tys

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2048,6 +2048,17 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             }
         }
 
+        // [if c { true join (c || d) } else { e }] -> c || e
+        if let Expression::Join { left, right } = &consequent.expression {
+            if left.as_bool_if_known().unwrap_or(false) {
+                if let Expression::Or { left, .. } = &right.expression {
+                    if self.eq(left) {
+                        return self.or(alternate);
+                    }
+                }
+            }
+        }
+
         // if self { consequent } else { alternate } implies self in the consequent and !self in the alternate
         if !matches!(self.expression, Expression::Or { .. }) {
             if consequent.expression_size <= k_limits::MAX_EXPRESSION_SIZE / 10 {

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -456,14 +456,19 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                                 }
                             }
                             TyKind::Closure(def_id, substs) => {
-                                return substs
-                                    .as_closure()
-                                    .upvar_tys()
-                                    .nth(*ordinal)
-                                    .unwrap_or_else(|| {
-                                        info!("closure field not found {:?} {:?}", def_id, ordinal);
-                                        self.tcx.types.never
-                                    });
+                                let closure_substs = substs.as_closure();
+                                if closure_substs.is_valid() {
+                                    return closure_substs
+                                        .upvar_tys()
+                                        .nth(*ordinal)
+                                        .unwrap_or_else(|| {
+                                            info!(
+                                                "closure field not found {:?} {:?}",
+                                                def_id, ordinal
+                                            );
+                                            self.tcx.types.never
+                                        });
+                                }
                             }
                             TyKind::Generator(def_id, substs, _) => {
                                 let mut tuple_types =


### PR DESCRIPTION
## Description

Add a simplification rule:
[if c { true join (c || d) } else { e }] -> c || e
(There is already a more general rule that covers this, but is performance sensitive and k-limited, so it does not reliably kick in.)

Fix a latent crash that resurfaced because of the increased precision enabled by the simplification, by guarding the call to ClosureSubsts::upvar_tys with a call to is_valid.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
/.validate.sh
ran MIRAI over Diem