### PR TITLE
Connect assume_preconditions

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -471,6 +471,7 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             }
             KnownNames::MiraiAssumePreconditions => {
                 checked_assume!(self.actual_args.is_empty());
+                self.use_entry_condition_as_exit_condition();
                 self.block_visitor.bv.assume_preconditions_of_next_call = true;
                 return true;
             }


### PR DESCRIPTION
## Description

Connect a basic block that ends on a call to mirai_assume_preconditions, to the block following the call. Not doing this can make the following block show up as unreachable, which is all sorts of wrong.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem