### PR TITLE
Remove incorrect assumed unreachable annotation

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1967,7 +1967,8 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                         }
                     }
                 } else {
-                    assume_unreachable!("{:?}", selector);
+                    // qualifier is an unsized struct type and selector selects the last field,
+                    // which is an unsized array
                 }
             }
             let length_path =

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1439,9 +1439,13 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                     }
                     self.current_environment.value_map = purged_map;
                 }
+            } else {
+                assume_unreachable!("Layout values should only be associated with layout paths");
             }
         } else {
-            assume_unreachable!("Layout values should only be associated with layout paths");
+            // Could get here during summary refinement because the caller state makes some
+            // paths (such as downcasts) unreachable and invalid, in which case they are replaced
+            // with BOTTOM (and hence do not have a layout selector).
         }
     }
 


### PR DESCRIPTION
## Description

Remove incorrect assumed unreachable annotation and replace with a comment on how the statement may be reached.

Fixes #1072 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
ran MIRAI over RipGrep