### PR TITLE
Prefer local types over call site types if the latter are not concrete

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -166,11 +166,8 @@ impl MiraiCallbacks {
             || file_name.starts_with("language/move-prover/src") // non termination
             || file_name.starts_with("language/move-prover/boogie-backend/src") // non termination
             || file_name.starts_with("language/move-prover/bytecode/src") // non termination
-            || file_name.starts_with("language/move-prover/docgen/src") // entered unreachable code', checker/src/type_visitor.rs:880
-            || file_name.starts_with("language/move-prover/interpreter/src") // entered unreachable code', checker/src/type_visitor.rs:880:29
             || file_name.starts_with("language/move-prover/lab/src") // out of memory
             || file_name.starts_with("language/move-prover/mutation/src") // out of memory
-            || file_name.starts_with("language/move-prover/tools/spec-flatten/src") // entered unreachable code', checker/src/type_visitor.rs:880:29
             || file_name.starts_with("language/move-stdlib/src") // out of memory
             || file_name.starts_with("language/tools/move-coverage/src") // out of memory
             || file_name.starts_with("language/tools/move-unit-test/src") // non termination
@@ -235,6 +232,7 @@ impl MiraiCallbacks {
                 || file_name.starts_with("language/move-prover/docgen/src")
                 || file_name.starts_with("language/move-prover/interpreter/src")
                 || file_name.starts_with("language/move-prover/interpreter/crypto/src")
+                || file_name.starts_with("language/move-prover/tools/spec-flatten/src")
                 || file_name.starts_with("language/tools/disassembler/src")
                 || file_name.starts_with("language/transaction-builder/generator/src")
                 || file_name.starts_with("move-prover/errmapgen/src")


### PR DESCRIPTION
## Description

Prefer local types over call site types if the latter are not concrete. Incomplete types from the call site do not have enough information to allow path type inference to succeed when there are projection types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
ran MIRAI over tracing-core-0.1.21