### PR TITLE
Apply body analysis timeout to inclusive rather than exclusive time

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ instruction to determine which version to use. If you forget to do that or use t
 you'll see an error message complaining about a dynamic load library not being found.
 
 The easiest way to get started is to first build your project in the normal way (with one exception:
- set `RUSTFLAGS="-Z always_encode_mir"` to force the rust compiler to include MIR into its compiled output).
+ set `RUSTFLAGS="-Z always_encode_mir --cfg="mirai"` to force the rust compiler to include MIR into its compiled output 
+and enable any MIRAI annotations that are present in the source code).
 Refer to [this link](https://doc.rust-lang.org/stable/book/ch01-00-getting-started.html) for details
 on compiling a cargo project.
 When there are no compile errors,
 no lint errors and no test failures, you can proceed to the next step and run MIRAI. For example:
 ```
 touch src/lib.rs
-RUSTFLAGS="-Z always_encode_mir" RUSTC_WRAPPER=mirai cargo build
+RUSTC_WRAPPER=mirai cargo build
 ```
 
 The touch command (which needs to reference a real file in your project) forces Cargo to re-run rustc and to not assume

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -13,7 +13,6 @@ use rustc_target::abi::VariantIdx;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
-use std::time::Instant;
 
 use crate::abstract_value::{AbstractValue, AbstractValueTrait};
 use crate::block_visitor::BlockVisitor;
@@ -131,7 +130,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         .set_path_rustc_type(p.clone(), *t);
                 }
             }
-            let elapsed_time = self.block_visitor.bv.start_instant.elapsed();
             let mut summary = body_visitor.visit_body(self.function_constant_args);
             trace!("summary {:?} {:?}", self.callee_def_id, summary);
             if let Some(func_ref) = &self.callee_func_ref {
@@ -162,7 +160,6 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                         summary.clone(),
                     );
             }
-            self.block_visitor.bv.start_instant = Instant::now() - elapsed_time;
             return summary;
         }
         if !self.block_visitor.bv.tcx.is_static(self.callee_def_id)

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -8,7 +8,7 @@ use crate::call_graph::CallGraph;
 use crate::constant_domain::ConstantValueCache;
 use crate::crate_visitor::CrateVisitor;
 use crate::known_names::KnownNamesCache;
-use crate::options::{DiagLevel, Options};
+use crate::options::Options;
 use crate::summaries::PersistentSummaryCache;
 
 use crate::type_visitor::TypeCache;
@@ -143,119 +143,10 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(&self, file_name: &str) -> bool {
-        // Exclude crates that crash or don't terminate. All of these currently take longer than 2 minutes to analyze.
-        if file_name.starts_with("client/faucet/src") // non termination
-            || file_name.starts_with("config/management/genesis/src") // out of memory
-            || file_name.starts_with("config/management/operational/src") // non termination
-            || file_name.starts_with("crypto/crypto-derive/src") // out of memory
-            || file_name.starts_with("diem-move/df-cli/src") // non termination
-            || file_name.starts_with("diem-move/diem-framework/src") // non termination
-            || file_name.starts_with("diem-move/diem-framework/DPN/releases/src") // non termination
-            || file_name.starts_with("diem-move/diem-framework/releases/src") // non termination
-            || file_name.starts_with("diem-move/diem-vm") // non termination
-            || file_name.starts_with("diem-move/transaction-replay/src") // out of memory
-            || file_name.starts_with("diem-move/vm-genesis/src") // Not a type: DefIndex(3250)
-            || file_name.starts_with("diem-move/writeset-transaction-generator/src")  // out of memory
-            || file_name.starts_with("execution/db-bootstrapper/src") // Not a type: DefIndex(3250)
-            || file_name.starts_with("language/compiler/src") // out of memory
-            || file_name.starts_with("language/move-lang/src") // non termination
-            || file_name.starts_with("language/move-model/src") // non termination
-            || file_name.starts_with("language/tools/move-bytecode-viewer/src") // out of memory
-            || file_name.starts_with("language/tools/move-cli/src") // non termination
-            || file_name.starts_with("language/tools/move-package/src") // non termination
-            || file_name.starts_with("language/move-prover/src") // non termination
-            || file_name.starts_with("language/move-prover/boogie-backend/src") // non termination
-            || file_name.starts_with("language/move-prover/bytecode/src") // non termination
-            || file_name.starts_with("language/move-prover/lab/src") // out of memory
-            || file_name.starts_with("language/move-prover/mutation/src") // out of memory
-            || file_name.starts_with("language/move-prover/tools/spec-flatten/src") // out of memory
-            || file_name.starts_with("language/move-stdlib/src") // out of memory
-            || file_name.starts_with("language/tools/move-coverage/src") // out of memory
-            || file_name.starts_with("language/tools/move-unit-test/src") // non termination
-            || file_name.starts_with("language/tools/read-write-set/src")  // non termination
-            || file_name.starts_with("language/transaction-builder/generator/src") // out of memory
-            || file_name.starts_with("mempool/src") // out of memory
-            || file_name.starts_with("network/src") // non termination
-            || file_name.starts_with("network/builder/src") // non termination
-            || file_name.starts_with("network/discovery/src") // out of memory
-            || file_name.starts_with("sdk/client/src") // non termination
-            || file_name.starts_with("state-sync/inter-component/event-notifications/src") // non termination
-            || file_name.starts_with("state-sync/state-sync-v1/src") // non termination
-            || file_name.starts_with("storage/backup/backup-cli/src") // out of memory
-            || file_name.starts_with("storage/diemsum/src") // out of memory
-            || file_name.starts_with("storage/inspector/src/") // out of memory
-             || file_name.starts_with("types/src")
-        // out of memory
-        {
-            return true;
-        }
-
-        // Conditionally exclude crates that currently slow down testing too much because they take longer than 2 minutes to analyze
-        if self.options.diag_level == DiagLevel::Default
-            && (file_name.starts_with("api/src")
-                || file_name.starts_with("api/types")
-                || file_name.starts_with("client/assets-proof/src")
-                || file_name.starts_with("common/logger/src")
-                || file_name.starts_with("common/num-variants/src")
-                || file_name.starts_with("common/rate-limiter/src")
-                || file_name.starts_with("config/src")
-                || file_name.starts_with("config/management/src")
-                || file_name.starts_with("config/management/network-address-encryption/src")
-                || file_name.starts_with("config/seed-peer-generator/src")
-                || file_name.starts_with("consensus/src")
-                || file_name.starts_with("consensus/consensus-types/src")
-                || file_name.starts_with("consensus/safety-rules/src")
-                || file_name.starts_with("common/debug-interface/src")
-                || file_name.starts_with("crypto/crypto/src")
-                || file_name.starts_with("diem-node/src")
-                || file_name.starts_with("diem-move/df-cli/src")
-                || file_name.starts_with("diem-move/diem-events-fetcher/src")
-                || file_name.starts_with("diem-move/diem-framework/src")
-                || file_name.starts_with("diem-move/diem-framework/DPN/releases/src")
-                || file_name.starts_with("diem-move/diem-framework/releases/src")
-                || file_name.starts_with("diem-move/diem-vm")
-                || file_name.starts_with("diem-move/transaction-replay/src")
-                || file_name.starts_with("diem-move/diem-validator-interface")
-                || file_name.starts_with("diem-move/vm-genesis/src")
-                || file_name.starts_with("diem-move/writeset-transaction-generator/src")
-                || file_name.starts_with("execution/db-bootstrapper/src")
-                || file_name.starts_with("execution/execution-correctness/src")
-                || file_name.starts_with("execution/executor/src")
-                || file_name.starts_with("json-rpc/src")
-                || file_name.starts_with("json-rpc/types/src")
-                || file_name.starts_with("language/bytecode-verifier/src")
-                || file_name.starts_with("language/compiler/ir-to-bytecode/src")
-                || file_name.starts_with("language/compiler/ir-to-bytecode/syntax/src")
-                || file_name.starts_with("language/move-binary-format/src")
-                || file_name.starts_with("language/move-core/types/src")
-                || file_name.starts_with("language/move-ir/types/src/")
-                || file_name.starts_with("language/move-prover/abigen/src")
-                || file_name.starts_with("language/move-prover/docgen/src")
-                || file_name.starts_with("language/move-prover/interpreter/src")
-                || file_name.starts_with("language/move-prover/interpreter/crypto/src")
-                || file_name.starts_with("language/move-prover/tools/spec-flatten/src")
-                || file_name.starts_with("language/tools/disassembler/src")
-                || file_name.starts_with("language/transaction-builder/generator/src")
-                || file_name.starts_with("move-prover/errmapgen/src")
-                || file_name.starts_with("network/netcore/src")
-                || file_name.starts_with("network/discovery/src")
-                || file_name.starts_with("network/simple-onchain-discovery/src")
-                || file_name.starts_with("sdk/src")
-                || file_name.starts_with("sdk/transaction-builder/src")
-                || file_name.starts_with("secure/key-manager/src")
-                || file_name.starts_with("secure/net/src")
-                || file_name.starts_with("secure/storage/src")
-                || file_name.starts_with("secure/storage/github/src")
-                || file_name.starts_with("secure/storage/vault/src")
-                || file_name.starts_with("state-sync/src")
-                || file_name.starts_with("state-sync/inter-component/event-notifications/src")
-                || file_name.starts_with("state-sync/state-sync-v1/src")
-                || file_name.starts_with("storage/backup/backup-service/src")
-                || file_name.starts_with("storage/diemdb/src")
-                || file_name.starts_with("storage/schemadb/src")
-                || file_name.starts_with("storage/storage-client/src")
-                || file_name.starts_with("types/src")
-                || file_name.starts_with("vm-validator/src"))
+        if file_name.starts_with("diem-move/diem-framework/releases/src")
+            || file_name.starts_with("language/tools/move-coverage/src")
+            || file_name.starts_with("language/move-prover/bytecode/src")
+            || file_name.starts_with("storage/backup/backup-cli/src")
         {
             return true;
         }

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -41,9 +41,15 @@ fn make_options_parser<'a>() -> App<'a, 'a> {
     .arg(Arg::with_name("body_analysis_timeout")
         .long("body_analysis_timeout")
         .takes_value(true)
-        .default_value("40")
+        .default_value("30")
         .help("The maximum number of seconds that MIRAI will spend analyzing a function body.")
-        .long_help("The default is 40 seconds."))
+        .long_help("The default is 30 seconds."))
+    .arg(Arg::with_name("crate_analysis_timeout")
+        .long("crate_analysis_timeout")
+        .takes_value(true)
+        .default_value("240")
+        .help("The maximum number of seconds that MIRAI will spend analyzing a function body.")
+        .long_help("The default is 240 seconds."))
     .arg(Arg::with_name("statistics")
         .long("statistics")
         .short("stats")
@@ -65,6 +71,7 @@ pub struct Options {
     pub diag_level: DiagLevel,
     pub constant_time_tag_name: Option<String>,
     pub max_analysis_time_for_body: u64,
+    pub max_analysis_time_for_crate: u64,
     pub statistics: bool,
     pub call_graph_config: Option<String>,
 }
@@ -181,6 +188,18 @@ impl Options {
                     Err(_) => early_error(
                         ErrorOutputType::default(),
                         "--body_analysis_timeout expects an integer",
+                    ),
+                },
+                None => assume_unreachable!(),
+            }
+        }
+        if matches.is_present("crate_analysis_timeout") {
+            self.max_analysis_time_for_crate = match matches.value_of("crate_analysis_timeout") {
+                Some(s) => match s.parse::<u64>() {
+                    Ok(v) => v,
+                    Err(_) => early_error(
+                        ErrorOutputType::default(),
+                        "--crate_analysis_timeout expects an integer",
                     ),
                 },
                 None => assume_unreachable!(),

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -151,7 +151,8 @@ fn build_options() -> Options {
     let mut options = Options::default();
     options.parse_from_str(""); // get defaults
     options.diag_level = DiagLevel::Paranoid; // override default
-    options.max_analysis_time_for_body = 40;
+    options.max_analysis_time_for_body = 20;
+    options.max_analysis_time_for_crate = 60;
     options
 }
 


### PR DESCRIPTION
## Description

Apply body analysis timeout to inclusive rather than exclusive time. Add a timeout for the total analysis of a crate.
Update crate exclusion list.
Tweak readme.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem