### PR TITLE
Make is_bit_vector support joins and conditional expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",

--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -144,6 +144,7 @@ impl MiraiCallbacks {
 
     fn is_excluded(&self, file_name: &str) -> bool {
         if file_name.starts_with("diem-move/diem-framework/releases/src")
+            || file_name.starts_with("diem-move/transaction-replay/src")
             || file_name.starts_with("language/tools/move-coverage/src")
             || file_name.starts_with("language/move-prover/bytecode/src")
             || file_name.starts_with("storage/backup/backup-cli/src")

--- a/checker/src/expression.rs
+++ b/checker/src/expression.rs
@@ -978,10 +978,20 @@ impl Expression {
     /// Determines if the given expression is the result of a non constant binary bitwise operation.
     #[logfn_inputs(TRACE)]
     pub fn is_bit_vector(&self) -> bool {
-        matches!(
-            self,
-            Expression::BitAnd { .. } | Expression::BitOr { .. } | Expression::BitXor { .. }
-        )
+        match self {
+            Expression::BitAnd { .. } | Expression::BitOr { .. } | Expression::BitXor { .. } => {
+                true
+            }
+            Expression::ConditionalExpression {
+                consequent: left,
+                alternate: right,
+                ..
+            }
+            | Expression::Join { left, right } => {
+                left.expression.is_bit_vector() || right.expression.is_bit_vector()
+            }
+            _ => false,
+        }
     }
 
     /// True if the expression involves a comparison operator (= != > >= < <=)


### PR DESCRIPTION
## Description

Tweak is_bit_vector to make the Z3 encoding more robust.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem