### PR TITLE
Don't call type_of on associated items of unresolved type projections

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -143,12 +143,7 @@ impl MiraiCallbacks {
     }
 
     fn is_excluded(&self, file_name: &str) -> bool {
-        if file_name.starts_with("config/management/operational/src")
-            || file_name.starts_with("config/src")
-            || file_name.starts_with("diem-move/diem-framework/releases/src")
-            || file_name.starts_with("diem-move/transaction-replay/src")
-            || file_name.starts_with("language/tools/move-coverage/src")
-        {
+        if file_name.starts_with("language/tools/move-coverage/src") {
             return true;
         }
         false

--- a/checker/src/type_visitor.rs
+++ b/checker/src/type_visitor.rs
@@ -1037,9 +1037,15 @@ impl<'analysis, 'compilation, 'tcx> TypeVisitor<'tcx> {
                     item_def_id,
                     specialized_substs,
                 ) {
-                    let item_def_id = instance.def.def_id();
-                    let item_type = self.tcx.type_of(item_def_id);
-                    let map = self.get_generic_arguments_map(item_def_id, instance.substs, &[]);
+                    let instance_item_def_id = instance.def.def_id();
+                    if item_def_id == instance_item_def_id {
+                        return self
+                            .tcx
+                            .mk_projection(projection.item_def_id, specialized_substs);
+                    }
+                    let item_type = self.tcx.type_of(instance_item_def_id);
+                    let map =
+                        self.get_generic_arguments_map(instance_item_def_id, instance.substs, &[]);
                     if item_type == gen_arg_type && map.is_none() {
                         // Can happen if the projection just adds a life time
                         item_type


### PR DESCRIPTION
## Description

Don't call type_of on associated items of unresolved type projections. Doing so can hit a panic in type_of that is hard to avoid because there is no (accessible) way to check the specific precondition implied by the panic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem