### PR TITLE
Apply k-limit checks when calling expand_slice

### DIFF
--- a/checker/src/callbacks.rs
+++ b/checker/src/callbacks.rs
@@ -142,10 +142,7 @@ impl MiraiCallbacks {
         false
     }
 
-    fn is_excluded(&self, file_name: &str) -> bool {
-        if file_name.starts_with("language/tools/move-coverage/src") {
-            return true;
-        }
+    fn is_excluded(&self, _file_name: &str) -> bool {
         false
     }
 

--- a/checker/src/k_limits.rs
+++ b/checker/src/k_limits.rs
@@ -6,8 +6,8 @@
 // Somewhat arbitrary constants used to limit things in the abstract interpreter that may
 // take too long or use too much memory.
 
-/// The maximum number of elements in a byte array that will be individually tracked.
-pub const MAX_BYTE_ARRAY_LENGTH: usize = 100;
+/// The maximum number of elements in a collection that will be individually tracked.
+pub const MAX_ELEMENTS_TO_TRACK: usize = 100;
 
 /// Helps to limit the size of summaries.
 pub const MAX_INFERRED_PRECONDITIONS: usize = 50;


### PR DESCRIPTION
## Description

Apply k-limit checks when calling expand_slice (because sometimes slices can have huge sizes and tracking each element separately causes exponential algorithms to blow up and effectively never terminate).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem