### PR TITLE
Simplify the workflow for using unit and integration tests as roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",

--- a/README.md
+++ b/README.md
@@ -37,14 +37,17 @@ When there are no compile errors,
 no lint errors and no test failures, you can proceed to the next step and run MIRAI. For example:
 ```
 touch src/lib.rs
-RUSTC_WRAPPER=mirai cargo build
+RUSTC_WRAPPER=mirai cargo test --no-run
 ```
+You could also just use `cargo check` if you do not have unit tests with good code coverage. The reason that 
+`cargo test` is recommended is because unit tests are good entry points for the analysis. If you use cargo check,
+also do an initial check rather than build for the dependencies that you do not want to analyze with MIRAI.
 
 The touch command (which needs to reference a real file in your project) forces Cargo to re-run rustc and to not assume
 that its cached error messages are still correct.
 
 This will likely produce some warnings, which you can then fix by adding annotations declared in this
-[crate](https://crates.io/crates/mirai-annotations). Keep re-touching and running cargo build as above until
+[crate](https://crates.io/crates/mirai-annotations). Keep running cargo as above until
 there are no more warnings.
 
 At this stage your code will be better documented and more readable. Perhaps you'll also have found and fixed a few bugs.
@@ -52,8 +55,6 @@ At this stage your code will be better documented and more readable. Perhaps you
 You can use the environment variable `MIRAI_FLAGS` to get cargo to provide command line options to MIRAI. The value is a
 string which can contain any of the following flags:
 
-- `--test_only`: instructs MIRAI to analyze only test methods in your crate. You must also provide the `--tests`
-  option to the `cargo build` command to include those tests actually into your build.
 - `--diag=default|verify|library|paranoid`: configures level of diagnostics. With `default` MIRAI
    will not report errors which are potential 'false positives'. With `verify` it will point out
    functions that may contain such errors. With `library` it will require explicit preconditions.

--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
 
     // Get any options specified via the MIRAI_FLAGS environment variable
     let mut options = Options::default();
-    let rustc_args = options.parse_from_str(&env::var("MIRAI_FLAGS").unwrap_or_default());
+    let rustc_args = options.parse_from_str(&env::var("MIRAI_FLAGS").unwrap_or_default(), false);
     info!("MIRAI options from environment: {:?}", options);
 
     // Let arguments supplied on the command line override the environment variable.
@@ -69,7 +69,7 @@ fn main() {
         args.remove(1);
     }
 
-    let mut rustc_command_line_arguments = options.parse(&args[1..]);
+    let mut rustc_command_line_arguments = options.parse(&args[1..], false);
     info!("MIRAI options modified by command line: {:?}", options);
 
     rustc_driver::install_ice_hook();
@@ -122,15 +122,6 @@ fn main() {
                     if s.ends_with(&postfix) {
                         *s = s.replace(&postfix, ".rlib");
                     }
-                }
-
-                let test: String = "--test".into();
-                if !rustc_command_line_arguments
-                    .iter()
-                    .any(|arg| arg.ends_with(&test))
-                {
-                    // Tell compiler to compile test code
-                    rustc_command_line_arguments.push(test);
                 }
             }
         }

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -149,7 +149,7 @@ fn run_directory(directory_path: PathBuf) -> Vec<(String, String)> {
 
 fn build_options() -> Options {
     let mut options = Options::default();
-    options.parse_from_str(""); // get defaults
+    options.parse_from_str("", true); // get defaults
     options.diag_level = DiagLevel::Paranoid; // override default
     options.max_analysis_time_for_body = 20;
     options.max_analysis_time_for_crate = 60;
@@ -264,7 +264,7 @@ fn invoke_driver(
         let file_content = read_to_string(&Path::new(&file_name)).unwrap();
         let options_re = Regex::new(r"(?m)^\s*//\s*MIRAI_FLAGS\s(?P<flags>.*)$").unwrap();
         if let Some(captures) = options_re.captures(&file_content) {
-            rustc_args = options.parse_from_str(&captures["flags"]); // override based on test source
+            rustc_args = options.parse_from_str(&captures["flags"], true); // override based on test source
         }
     }
 

--- a/validate.sh
+++ b/validate.sh
@@ -14,7 +14,7 @@ cargo fmt --all
 # Run lint checks
 cargo audit
 cargo clippy --all-features --all-targets -- -D warnings
-# Build
+# Build mirai (in debug mode) so that we can build the standard contracts
 cargo build
 
 # build the mirai-standard-contracts crate
@@ -39,6 +39,6 @@ cargo install --path ./checker
 
 # Run mirai on itself (using the optimized build in cargo as the bootstrap).
 cargo clean
-RUSTFLAGS="-Z always_encode_mir" cargo build
+RUSTFLAGS="-Z always_encode_mir" cargo check
 touch checker/src/lib.rs
-RUSTFLAGS="-Z always_encode_mir" RUSTC_WRAPPER=mirai RUST_BACKTRACE=full MIRAI_LOG=warn MIRAI_FLAGS="--body_analysis_timeout 10" cargo build --lib -p mirai
+RUSTFLAGS="-Z always_encode_mir" RUSTC_WRAPPER=mirai RUST_BACKTRACE=full MIRAI_LOG=warn MIRAI_FLAGS="--body_analysis_timeout 10" cargo check --lib


### PR DESCRIPTION
## Description

Get rid of the --test_only command line option (except when running MIRAI inside its own test harness). Instead, make MIRAI use test functions as entry points whenever the --test flag is passed to rustc. I.e. the preferred way to use test
entry points is now `cargo test --no-run`.

Update the documentation accordingly. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem with both `cargo check` and `cargo test`.