### PR TITLE
Actually produce a bit vector when calling bv_constant on float consts

### DIFF
--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1989,12 +1989,16 @@ impl Z3Solver {
                 z3_sys::Z3_mk_numeral(self.z3_context, c_string.into_raw(), sort)
             },
             ConstantDomain::F32(v) => unsafe {
-                let fv = f32::from_bits(*v);
-                z3_sys::Z3_mk_fpa_numeral_float(self.z3_context, fv, self.f32_sort)
+                let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
+                let num_str = format!("{}", (*v as u32));
+                let c_string = CString::new(num_str).unwrap();
+                z3_sys::Z3_mk_numeral(self.z3_context, c_string.into_raw(), sort)
             },
             ConstantDomain::F64(v) => unsafe {
-                let fv = f64::from_bits(*v);
-                z3_sys::Z3_mk_fpa_numeral_double(self.z3_context, fv, self.f64_sort)
+                let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);
+                let num_str = format!("{}", (*v as u64));
+                let c_string = CString::new(num_str).unwrap();
+                z3_sys::Z3_mk_numeral(self.z3_context, c_string.into_raw(), sort)
             },
             ConstantDomain::I128(v) => unsafe {
                 let sort = z3_sys::Z3_mk_bv_sort(self.z3_context, num_bits);


### PR DESCRIPTION
## Description

When converting floating point literals to bit vectors, use the bits in integer guise, rather than the bits in floating point guise.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem