### PR TITLE
Make more use the factory function to make deref paths

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -3509,15 +3509,13 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                     } else if type_visitor.is_slice_pointer(ty.kind()) {
                         // Deref the thin pointer part of the slice pointer
                         ty = type_visitor.get_dereferenced_type(ty);
-                        let thin_pointer_path = Path::new_field(result, 0);
-                        let deref_path =
-                            Path::new_deref(thin_pointer_path, ExpressionType::from(ty.kind()));
-                        type_visitor.set_path_rustc_type(deref_path.clone(), ty);
-                        result = deref_path;
-                        continue;
+                        result = Path::new_field(result, 0);
                     } else {
                         ty = type_visitor.get_dereferenced_type(ty);
                     }
+                    result = Path::new_deref(result, ExpressionType::from(ty.kind()));
+                    type_visitor.set_path_rustc_type(result.clone(), ty);
+                    continue;
                 }
                 mir::ProjectionElem::Field(_, field_ty) => {
                     ty = self.type_visitor().specialize_generic_argument_type(

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -467,27 +467,9 @@ impl Path {
     /// Creates a path to the target memory of a reference value.
     #[logfn_inputs(TRACE)]
     pub fn new_deref(address_path: Rc<Path>, target_type: ExpressionType) -> Rc<Path> {
-        if target_type != ExpressionType::NonPrimitive {
-            if let PathEnum::Computed { value } = &address_path.value {
-                if let Expression::ConditionalExpression {
-                    condition,
-                    consequent,
-                    alternate,
-                } = &value.expression
-                {
-                    if let (Expression::Reference(c_path), Expression::Reference(a_path)) =
-                        (&consequent.expression, &alternate.expression)
-                    {
-                        let consequent =
-                            AbstractValue::make_typed_unknown(target_type, c_path.clone());
-                        let alternate =
-                            AbstractValue::make_typed_unknown(target_type, a_path.clone());
-                        return Path::new_computed(
-                            condition.conditional_expression(consequent, alternate),
-                        );
-                    }
-                }
-            }
+        if let PathEnum::Computed { value } = &address_path.value {
+            let deref_value = value.dereference(target_type);
+            return Path::get_as_path(deref_value);
         }
         let selector = Rc::new(PathSelector::Deref);
         Self::new_qualified(address_path, selector)

--- a/checker/tests/run-pass/tag_vectors.rs
+++ b/checker/tests/run-pass/tag_vectors.rs
@@ -91,8 +91,7 @@ pub mod propagation_for_vectors {
             add_tag!(foo, SecretTaint);
         }
         for foo in bar.iter() {
-            // todo: fix this
-            verify!(has_tag!(foo, SecretTaint)); //~ provably false verification condition
+            verify!(has_tag!(foo, SecretTaint)); //~ possible false verification condition
         }
     }
 


### PR DESCRIPTION
## Description

Clean up and generalize the construction of deref paths to better normalize them and to simplify conditional paths where one branch is impossible.

There are still places where this normalization does not take place, but they are more difficult to fix because the necessary type information is not available. Fixing these will have to wait a bit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem