### PR TITLE
Use path length as expression size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libloading"

--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -680,7 +680,8 @@ impl AbstractValue {
     #[logfn_inputs(TRACE)]
     pub fn make_typed_unknown(var_type: ExpressionType, path: Rc<Path>) -> Rc<AbstractValue> {
         let path = path.remove_initial_value_wrapper();
-        Rc::new(make_value(Expression::Variable { path, var_type }))
+        let path_length = path.path_length() as u64;
+        AbstractValue::make_from(Expression::Variable { path, var_type }, path_length)
     }
 
     /// Creates an abstract value about which nothing is known other than its type, address and that
@@ -692,10 +693,12 @@ impl AbstractValue {
         var_type: ExpressionType,
         path: Rc<Path>,
     ) -> Rc<AbstractValue> {
-        Rc::new(make_value(Expression::InitialParameterValue {
-            path: path.remove_initial_value_wrapper(),
-            var_type,
-        }))
+        let path = path.remove_initial_value_wrapper();
+        let path_length = path.path_length() as u64;
+        AbstractValue::make_from(
+            Expression::InitialParameterValue { path, var_type },
+            path_length,
+        )
     }
 
     /// Creates an abstract value which represents the result of comparing the left operand with

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -1488,7 +1488,9 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
 
                     // At this point, we don't know that this assert is unreachable and we don't know
                     // that the condition is as expected, so we need to warn about it somewhere.
+                    check_for_early_return!(self.bv);
                     let promotable_cond_val = cond_val.extract_promotable_disjuncts(false);
+                    check_for_early_return!(self.bv);
                     let promotable_entry_cond = self
                         .bv
                         .current_environment

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -1148,7 +1148,13 @@ impl Debug for PathSelector {
                 case_index,
                 num_cases,
             } => f.write_fmt(format_args!("({:?} of {:?})", case_index, num_cases)),
-            PathSelector::Index(value) => f.write_fmt(format_args!("[{:?}]", value)),
+            PathSelector::Index(value) => {
+                if value.expression_size > 100 {
+                    f.write_fmt(format_args!("[...]"))
+                } else {
+                    f.write_fmt(format_args!("[{:?}]", value))
+                }
+            }
             PathSelector::Slice(value) => f.write_fmt(format_args!("[0..{:?}]", value)),
             PathSelector::ConstantIndex {
                 offset,


### PR DESCRIPTION
## Description

Use path length as expression size when constructing Expression::Variable and Expression::InitialParameterValue values.

Do more time-out checks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
