### PR TITLE
Add check for path cycle

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -637,6 +637,9 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
         precondition!(self.actual_argument_types.len() == 1);
         if let TyKind::Ref(_, t, _) = self.actual_argument_types[0].kind() {
             if let TyKind::Adt(def, substs) = t.kind() {
+                if def.variants.is_empty() {
+                    return false;
+                }
                 let variant_0 = VariantIdx::from_u32(0);
                 if Some(def.variants[variant_0].def_id)
                     == self.block_visitor.bv.tcx.lang_items().option_none_variant()


### PR DESCRIPTION
## Description

Add a check to prevent endless exploration of circular paths from roots to functions. (The circularity arises from over approximating the possible paths.)

Add a check to prevent getting variant 0 of an ADT with no variants.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem