### PR TITLE
Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
 dependencies = [
  "cfg-if",
 ]

--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -2840,10 +2840,13 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
         self.type_visitor_mut()
             .set_path_rustc_type(target_path.clone(), ty);
         match ty.kind() {
+            TyKind::Adt(adt_def, _) if adt_def.is_enum() => {
+                //todo: deserialize the enum
+                bytes
+            }
             TyKind::Adt(def, substs) => {
                 trace!("deserializing {:?} {:?}", def, substs);
                 let mut bytes_left_deserialize = bytes;
-                // todo: if there is more than one variant we need to use union fields
                 for variant in def.variants.iter() {
                     trace!("deserializing variant {:?}", variant);
                     bytes_left_deserialize = bytes;

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -192,6 +192,13 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             return;
         }
         if let Some(gen_args) = self.callee_generic_arguments {
+            if let Some(ty) = self.actual_argument_types.get(0) {
+                if !utils::is_concrete(ty.kind()) {
+                    // rustc_middle::ty::Instance::resolve panics if the type of arg 0 does not
+                    // have a vtable with a slot for self.callee_def_id
+                    return;
+                }
+            }
             // The parameter environment of the caller provides a resolution context for the callee.
             let param_env = rustc_middle::ty::ParamEnv::reveal_all();
             trace!(

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1721,6 +1721,13 @@ impl Z3Solver {
                 let path_symbol = self.get_symbol_for(path);
                 z3_sys::Z3_mk_const(self.z3_context, path_symbol, self.bool_sort)
             },
+            Expression::Switch {
+                discriminator,
+                cases,
+                default,
+            } => self.general_switch(discriminator, cases, default, |e| {
+                self.get_as_bool_z3_ast(e)
+            }),
             Expression::Top | Expression::Bottom => unsafe {
                 z3_sys::Z3_mk_fresh_const(self.z3_context, self.empty_str, self.bool_sort)
             },


### PR DESCRIPTION
## Description

Add a temporary work-around for deserializing enum values embedded inside serialized structs.
Guard against calling Instance::Resolve when the self argument type is not concrete (lest resolve panics).
Fix Z3 encoding of switch expressions used in a boolean context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI against Diem