### PR TITLE
Filter out diagnostics about failure to resolve

### DIFF
--- a/checker/src/block_visitor.rs
+++ b/checker/src/block_visitor.rs
@@ -903,7 +903,9 @@ impl<'block, 'analysis, 'compilation, 'tcx> BlockVisitor<'block, 'analysis, 'com
                 .entry_condition
                 .extract_promotable_conjuncts(false)
             {
-                if promotable_entry_condition.as_bool_if_known().is_none() {
+                if promotable_entry_condition.as_bool_if_known().is_none()
+                    && self.bv.cv.options.diag_level != DiagLevel::Default
+                {
                     let precondition = Precondition {
                         condition: promotable_entry_condition.logical_not(),
                         message: Rc::from("incomplete analysis of call because of a nested call to a function without a MIR body"),


### PR DESCRIPTION
## Description

Filter out diagnostics about failure to resolve function calls when in default mode, since this is an issue of soundness and is less likely to be related to a real problem in the code.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem