### PR TITLE
Apply k-limits to simplification of equality operations

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -2563,10 +2563,14 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     alternate: v2,
                     ..
                 },
-            ) if !v1.is_top() && !v2.is_top() => {
+            ) if !v1.is_top()
+                && v1.expression_size < k_limits::MAX_EXPRESSION_SIZE / 10
+                && !v2.is_top()
+                && v2.expression_size < k_limits::MAX_EXPRESSION_SIZE / 10 =>
+            {
                 let self_eq_v2 = self.equals(v2.clone()).as_bool_if_known().unwrap_or(false);
-                if v1
-                    .not_equals(self.clone())
+                if self
+                    .not_equals(v1.clone())
                     .as_bool_if_known()
                     .unwrap_or(false)
                     && self_eq_v2
@@ -3793,20 +3797,25 @@ impl AbstractValueTrait for Rc<AbstractValue> {
                     alternate: v2,
                     ..
                 },
-            ) if !v1.is_top() && !v2.is_top() => {
-                let v2_ne_self = v2
-                    .not_equals(self.clone())
+            ) if !v1.is_top()
+                && v1.expression_size < k_limits::MAX_EXPRESSION_SIZE / 10
+                && !v2.is_top()
+                && v2.expression_size < k_limits::MAX_EXPRESSION_SIZE / 10 =>
+            {
+                // Don't make self the second operand, since it might be a constant
+                let v2_ne_self = self
+                    .not_equals(v2.clone())
                     .as_bool_if_known()
                     .unwrap_or(false);
-                if v1.equals(self.clone()).as_bool_if_known().unwrap_or(false) && v2_ne_self {
+                if self.equals(v1.clone()).as_bool_if_known().unwrap_or(false) && v2_ne_self {
                     return c.logical_not();
                 }
-                if v1
-                    .not_equals(self.clone())
+                if self
+                    .not_equals(v1.clone())
                     .as_bool_if_known()
                     .unwrap_or(false)
                 {
-                    if v2.equals(self.clone()).as_bool_if_known().unwrap_or(false) {
+                    if self.equals(v2.clone()).as_bool_if_known().unwrap_or(false) {
                         return c.clone();
                     } else if v2_ne_self {
                         return Rc::new(TRUE);


### PR DESCRIPTION
## Description

Apply k-limits to simplification of equality operations. This fixes a performance bug that surfaced recently because of other changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
