### PR TITLE
Avoid running into resolve bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,9 +428,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]

--- a/checker/src/path.rs
+++ b/checker/src/path.rs
@@ -647,9 +647,8 @@ impl Path {
         }
         let qualifier_length = qualifier.path_length();
         if qualifier_length >= k_limits::MAX_PATH_LENGTH {
-            debug!("max path length exceeded {:?}.{:?}", qualifier, selector);
+            return Path::new_computed(abstract_value::BOTTOM.into());
         }
-        assume!(qualifier_length < 1_000_000_000); // We'll run out of memory long before this happens
         Rc::new(
             PathEnum::QualifiedPath {
                 qualifier,


### PR DESCRIPTION
## Description

Avoid running into rustc_middle::ty::Instance::resolve bug, using a narrower check than before.

Enforce k-limit of the maximum path length.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem
