### PR TITLE
Suppress diagnostics about assertion failures in test methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -533,9 +533,9 @@ checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -895,6 +895,8 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                     || msg.contains("not yet implemented")
                     || msg.contains("not implemented")
                     || msg.starts_with("unrecoverable: ")
+                    || (msg.starts_with("assertion failed")
+                        && self.block_visitor.bv.cv.options.test_only)
                 {
                     // We treat unreachable!() as an assumption rather than an assertion to prove.
                     // unimplemented!() is unlikely to be a programmer mistake, so need to fixate on that either.

--- a/checker/src/fixed_point_visitor.rs
+++ b/checker/src/fixed_point_visitor.rs
@@ -9,7 +9,6 @@ use crate::body_visitor::BodyVisitor;
 use crate::environment::Environment;
 use crate::options::DiagLevel;
 use crate::{abstract_value, k_limits};
-use itertools::Itertools;
 use log_derive::*;
 use mirai_annotations::*;
 use rpds::{HashTrieMap, HashTrieSet};
@@ -319,12 +318,12 @@ impl<'fixed, 'analysis, 'compilation, 'tcx>
             let entry_condition = predecessor_states_and_conditions
                 .iter()
                 .map(|(_, c)| c.clone())
-                .fold1(|c1, c2| c1.or(c2))
+                .reduce(|c1, c2| c1.or(c2))
                 .unwrap();
             trace!("entry_condition {:?}", entry_condition);
             let mut state = predecessor_states_and_conditions
                 .into_iter()
-                .fold1(|(state1, cond1), (state2, cond2)| {
+                .reduce(|(state1, cond1), (state2, cond2)| {
                     (state2.conditional_join(state1, &cond2, &cond1), cond1)
                 })
                 .expect("one or more states to fold into something")


### PR DESCRIPTION
## Description

Suppress diagnostics about assertion failures in test methods since they tend to look for concrete results from data that
is difficult to reason about statically. Tests that are written to be MIRAI friendly, will instead use the verify! macro.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem