### PR TITLE
Do not treat deref as the call target of assume_preconditions!

### DIFF
--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2611,6 +2611,11 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
         {
             self.check_function_preconditions(function_summary);
         } else {
+            if let Some(fr) = &self.callee_func_ref {
+                if fr.summary_cache_key.ends_with(".deref") {
+                    return;
+                }
+            }
             self.block_visitor.bv.assume_preconditions_of_next_call = false;
         }
     }


### PR DESCRIPTION
## Description

A call to std::ops::Deref::deref is often implicit, so not including the next call in the scope of assume_preconditions! leads to the hard to explain failure of the annotation to assume the precondition of bar in the call foo.bar() when under the covers the call is is really foo.deref().bar().

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem