### PR TITLE
Support pass-through functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,9 +533,9 @@ checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",

--- a/checker/tests/run-pass/unreachable.rs
+++ b/checker/tests/run-pass/unreachable.rs
@@ -44,7 +44,8 @@ fn panic_a_bit() -> i32 {
 }
 
 pub fn foo6(x: Option<i32>) -> i32 {
-    x.unwrap_or_else(|| panic_a_bit()) //~ aaargh!
+    x.unwrap_or_else(|| panic_a_bit()) //~ possible aaargh!
 }
+//~ related location
 
 pub fn main() {}

--- a/checker/tests/run-pass/vecdeque_drain.rs
+++ b/checker/tests/run-pass/vecdeque_drain.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// A test for VecDeque::drain
+
+use std::{collections::VecDeque, sync::Mutex};
+
+pub fn main() {
+    let q: Mutex<VecDeque<i32>> = Mutex::new(VecDeque::with_capacity(10_000));
+    let mut dq = q.lock().unwrap();
+    let _v: Vec<i32> = dq.drain(..).collect();
+}


### PR DESCRIPTION
## Description

Do not give a diagnostic at a call site inside a closure that calls panic unconditionally, but which is itself called conditionally.

Do this by promoting the definitely false preconditions of unconditionally reachable calls until the caller is an analysis root.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
ran MIRAI over Diem