### PR TITLE
Make mirai_on_mirai CI test work on Ubuntu

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,50 +3,78 @@ on: push
 name: Continuous Integration
 
 jobs:
-#  grcov:
-#    runs-on: macos-latest
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: Install toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          override: true
-#          profile: minimal
-#          components: clippy, rustc-dev, llvm-tools-preview
-#
-#      - name: Install Z3
-#        run: |
-#          cp binaries/libz3.dylib /usr/local/lib
-#          cp include/*.h /usr/local/include
-#
-#      - name: Run Clippy
-#        uses: actions-rs/clippy@master
-#        with:
-#          args: --all-features --all-targets -- -D warnings
-#
-#      - name: Execute tests
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: test
-#          args: --all -- --test-threads=1
-#        env:
-#          CARGO_INCREMENTAL: 0
-#          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
-#      - uses: actions-rs/grcov@v0.1
-#
-#      - name: Run grcov
-#        run: |
-#          zip -0 cov.zip $(find . -name "mirai*.gc*" -print)
-#          grcov cov.zip -s . -t lcov --llvm --ignore-not-existing --ignore "/*" -o lcov.info
-#
-#      - name: Upload coverage data to codecov.io
-#        uses: codecov/codecov-action@v1
-#        with:
-#          files: "lcov.info"
+  grcov:
+    runs-on: macos-latest
 
-  mirai_on_mirai:
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          components: clippy, rustc-dev, llvm-tools-preview
+
+      - name: Install Z3
+        run: |
+          cp binaries/libz3.dylib /usr/local/lib
+          cp include/*.h /usr/local/include
+
+      - name: Run Clippy
+        uses: actions-rs/clippy@master
+        with:
+          args: --all-features --all-targets -- -D warnings
+
+      - name: Execute tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all -- --test-threads=1
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
+      - uses: actions-rs/grcov@v0.1
+
+      - name: Run grcov
+        run: |
+          zip -0 cov.zip $(find . -name "mirai*.gc*" -print)
+          grcov cov.zip -s . -t lcov --llvm --ignore-not-existing --ignore "/*" -o lcov.info
+
+      - name: Upload coverage data to codecov.io
+        uses: codecov/codecov-action@v1
+        with:
+          files: "lcov.info"
+
+  mirai_on_mirai_macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          components: clippy, rustc-dev, llvm-tools-preview
+
+      - name: Install Z3
+        run: |
+          cp binaries/libz3.dylib /usr/local/lib
+          cp include/*.h /usr/local/include
+
+      - name: Install MIRAI
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --path ./checker
+
+      - name: Run MIRAI on MIRAI
+        run: |
+          cargo mirai
+
+  mirai_on_mirai_ubuntu:
     runs-on: ubuntu-latest
 
     steps:
@@ -61,7 +89,6 @@ jobs:
 
       - name: Install Z3
         run: |
-          apt list --installed
           sudo apt-get install libz3-dev
 
       - name: Install MIRAI

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,51 +3,51 @@ on: push
 name: Continuous Integration
 
 jobs:
-  grcov:
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          components: clippy, rustc-dev, llvm-tools-preview
-          
-      - name: Install Z3
-        run: |
-          cp binaries/libz3.dylib /usr/local/lib
-          cp include/*.h /usr/local/include
-
-      - name: Run Clippy
-        uses: actions-rs/clippy@master
-        with:
-          args: --all-features --all-targets -- -D warnings
-
-      - name: Execute tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all -- --test-threads=1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"          
-      - uses: actions-rs/grcov@v0.1
-
-      - name: Run grcov        
-        run: |
-          zip -0 cov.zip $(find . -name "mirai*.gc*" -print)
-          grcov cov.zip -s . -t lcov --llvm --ignore-not-existing --ignore "/*" -o lcov.info
-      
-      - name: Upload coverage data to codecov.io
-        uses: codecov/codecov-action@v1
-        with:
-          files: "lcov.info"
+#  grcov:
+#    runs-on: macos-latest
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Install toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          override: true
+#          profile: minimal
+#          components: clippy, rustc-dev, llvm-tools-preview
+#
+#      - name: Install Z3
+#        run: |
+#          cp binaries/libz3.dylib /usr/local/lib
+#          cp include/*.h /usr/local/include
+#
+#      - name: Run Clippy
+#        uses: actions-rs/clippy@master
+#        with:
+#          args: --all-features --all-targets -- -D warnings
+#
+#      - name: Execute tests
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: test
+#          args: --all -- --test-threads=1
+#        env:
+#          CARGO_INCREMENTAL: 0
+#          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
+#      - uses: actions-rs/grcov@v0.1
+#
+#      - name: Run grcov
+#        run: |
+#          zip -0 cov.zip $(find . -name "mirai*.gc*" -print)
+#          grcov cov.zip -s . -t lcov --llvm --ignore-not-existing --ignore "/*" -o lcov.info
+#
+#      - name: Upload coverage data to codecov.io
+#        uses: codecov/codecov-action@v1
+#        with:
+#          files: "lcov.info"
 
   mirai_on_mirai:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -61,8 +61,8 @@ jobs:
 
       - name: Install Z3
         run: |
-          cp binaries/libz3.dylib /usr/local/lib
-          cp include/*.h /usr/local/include
+          apt list --installed
+          sudo apt-get install libz3-dev
 
       - name: Install MIRAI
         uses: actions-rs/cargo@v1

--- a/checker/build.rs
+++ b/checker/build.rs
@@ -5,5 +5,7 @@
 //
 
 fn main() {
-    println!("cargo:rustc-link-search=binaries");
+    if cfg!(windows) {
+        println!("cargo:rustc-link-search=binaries");
+    }
 }


### PR DESCRIPTION
## Description

Make mirai_on_mirai CI test work on Ubuntu by changing build.rs to not refer to the binaries bundled with MIRAI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
this PR