### PR TITLE
Fix building the checker with stable rust

### DIFF
--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -307,7 +307,7 @@ fn append_mangled_type<'tcx>(str: &mut String, ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) 
         }
         Param(param_ty) => {
             str.push_str("generic_par_");
-            str.push_str(param_ty.name.as_str());
+            str.push_str(&param_ty.name.as_str());
         }
         Projection(projection_ty) => {
             append_mangled_type(str, projection_ty.self_ty(), tcx);

--- a/documentation/Linux.md
+++ b/documentation/Linux.md
@@ -4,7 +4,7 @@ In order to use MIRAI, you need to install Rust, install Z3, and install MIRAI i
 
 ## Installing Rust
 
-You should install Rust using rustup. See [here](https://doc.rust-lang.org/book/ch01-01-installation.html) 
+You should install Rust using rustup. See [here](https://doc.rust-lang.org/book/ch01-01-installation.html)
 for instructions.
 
 ## Installing Z3
@@ -41,6 +41,12 @@ Next, make sure that the correct version of rustc is installed, along with some 
 Then build and install MIRAI into cargo:
 ```
 cargo install  --path ./checker
+```
+
+On Fedora, z3-sys is currently unable to find the `z3.h` header file, so
+you may need to specify the path to it as follows:
+```
+CPATH=/usr/include/z3 cargo install  --path ./checker
 ```
 
 ## Contributing to MIRAI


### PR DESCRIPTION
## Description

Stable rustc is capable of building the checker tool; no nightly compiler appears to be needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ x ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

On Fedora laptop:
```
rustup update stable
CPATH=/usr/include/z3 cargo install  --path ./checker
CPATH=/usr/include/z3 cargo test  # this had errors on both nightly and stable 1.58
```

## Checklist:

- [ x ] Fork the repo and create your branch from `main`.
- [ x ] If you've added code that should be tested, add tests.
- [ x ] If you've changed APIs, update the documentation.
- [ x ] Ensure the test suite passes.
- [ x ] Make sure your code lints.
- [ x ] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

