### PR TITLE
Run continuous integration actions when a pull request is created

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-on: push
+on: pull_request
 
 name: Continuous Integration
 

--- a/documentation/Linux.md
+++ b/documentation/Linux.md
@@ -4,7 +4,7 @@ In order to use MIRAI, you need to install Rust, install Z3, and install MIRAI i
 
 ## Installing Rust
 
-You should install Rust using rustup. See [here](https://doc.rust-lang.org/book/ch01-01-installation.html) 
+You should install Rust using rustup. See [here](https://doc.rust-lang.org/book/ch01-01-installation.html)
 for instructions.
 
 ## Installing Z3
@@ -41,6 +41,12 @@ Next, make sure that the correct version of rustc is installed, along with some 
 Then build and install MIRAI into cargo:
 ```
 cargo install  --path ./checker
+```
+
+On Fedora, z3-sys is currently unable to find the `z3.h` header file, so
+you may need to specify the path to it as follows:
+```
+CPATH=/usr/include/z3 cargo install  --path ./checker
 ```
 
 ## Contributing to MIRAI


### PR DESCRIPTION
## Description

Run continuous integration actions when a pull request is created. Running it instead when a branch is pushed does not
work when the PR is created from a branch on a fork.

Also update documentation as per PR #1123.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
This PR