### PR TITLE
Adding set operations to TagPropagationSet

### DIFF
--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -29,11 +29,20 @@ macro_rules! abstract_value {
 pub type TagPropagationSet = u128;
 
 
-
+/// Enable this `TagPropagation` kind in this `TagPropagationSet`. This function
+/// is `const` so you are able to call it when constructing a mask for taint
+/// propagation.
 pub const fn add_propagation(set: TagPropagationSet, propagation: TagPropagation) -> TagPropagationSet {
     set | propagation.into_set()
 }
 
+/// Disable this `TagPropagation` kind in this `TagPropagationSet`. This
+/// function is `const` so you are able to call it when constructing a mask for
+/// taint propagation. 
+/// 
+/// The intended is so you can conveniently disable propagations from the set of
+/// all propagations, e.g. `remove-propagation(TAG_PROPAGATION_ALL,
+/// TagPropagation::Add)`.
 pub const fn remove_propagation(set: TagPropagationSet, propagation: TagPropagation) -> TagPropagationSet {
     set & !propagation.into_set()
 }


### PR DESCRIPTION
## Description

This adds two convenience functions for constructing taint propagation masks easier. E.g. adding and removing propagation types from existing masks

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?

I added two test cases, one for each function that verifies the basic functionality

## Checklist:

- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

