### PR TITLE
Don't move heap model leaves that are reached via indirections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -528,7 +528,7 @@ version = "1.1.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
- "clap 3.2.14",
+ "clap 3.2.15",
  "contracts",
  "env_logger 0.9.0",
  "fs2",
@@ -645,9 +645,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -34,41 +34,57 @@ macro_rules! abstract_value {
 /// particular propagation.
 pub type TagPropagationSet = u128;
 
-
 /// Enable this `TagPropagation` kind in this `TagPropagationSet`. This function
 /// is `const` so you are able to call it when constructing a mask for taint
 /// propagation.
-/// 
+///
 /// This function is a no-op if this propagation is already enabled.
-pub const fn add_propagation(set: TagPropagationSet, propagation: TagPropagation) -> TagPropagationSet {
+pub const fn add_propagation(
+    set: TagPropagationSet,
+    propagation: TagPropagation,
+) -> TagPropagationSet {
     set | propagation.into_set()
 }
 
 /// Disable this `TagPropagation` kind in this `TagPropagationSet`. This
 /// function is `const` so you are able to call it when constructing a mask for
-/// taint propagation. 
-/// 
+/// taint propagation.
+///
 /// This function is a no-op if this propagation is already disabled.
-/// 
+///
 /// The intended is so you can conveniently disable propagations from the set of
 /// all propagations, e.g. `remove_propagation(TAG_PROPAGATION_ALL,
 /// TagPropagation::Add)`.
-pub const fn remove_propagation(set: TagPropagationSet, propagation: TagPropagation) -> TagPropagationSet {
+pub const fn remove_propagation(
+    set: TagPropagationSet,
+    propagation: TagPropagation,
+) -> TagPropagationSet {
     set & !propagation.into_set()
 }
 
 #[test]
 fn test_rem_prop() {
-    assert!(remove_propagation(tag_propagation_set!(TagPropagation::Add), TagPropagation::Add) == 0);
-    assert!(remove_propagation(TAG_PROPAGATION_ALL, TagPropagation::SuperComponent) & TagPropagation::SuperComponent.into_set() == 0)
+    assert!(
+        remove_propagation(
+            tag_propagation_set!(TagPropagation::Add),
+            TagPropagation::Add
+        ) == 0
+    );
+    assert!(
+        remove_propagation(TAG_PROPAGATION_ALL, TagPropagation::SuperComponent)
+            & TagPropagation::SuperComponent.into_set()
+            == 0
+    )
 }
 
 #[test]
 fn test_add_prop() {
     assert!(add_propagation(TAG_PROPAGATION_ALL, TagPropagation::Add) == TAG_PROPAGATION_ALL);
-    assert!(add_propagation(0, TagPropagation::SuperComponent) == TagPropagation::SuperComponent.into_set())
+    assert!(
+        add_propagation(0, TagPropagation::SuperComponent)
+            == TagPropagation::SuperComponent.into_set()
+    )
 }
-
 
 /// An enum type of controllable operations for MIRAI tag types.
 /// In general, the result of the operation corresponding to an enum value will

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -2489,7 +2489,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                 let qualified_path = path
                     .replace_root(&source_path, target_path.clone())
                     .canonicalize(&env);
-                if move_elements {
+                if move_elements && !path.contains_deref() {
                     trace!("moving child {:?} to {:?}", value, qualified_path);
                     self.current_environment.value_map =
                         self.current_environment.value_map.remove(path);


### PR DESCRIPTION
## Description

When moving a structure, only move leaves that are reachable without an indirection. This matters when there are other aliases for such leaves, since those will become unknown after the move.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
validate.sh