### PR TITLE
Add simplification rules

### DIFF
--- a/checker/tests/run-pass/bit_vector_and_vec_push.rs
+++ b/checker/tests/run-pass/bit_vector_and_vec_push.rs
@@ -31,6 +31,6 @@ pub fn write_u32_as_uleb128(binary: &mut Vec<u8>, value: u32) {
 pub fn main() {
     let mut buf = Vec::<u8>::new();
     write_u32_as_uleb128(&mut buf, 129);
-    verify!(buf.len() == 2);
+    verify!(buf.len() == 2); //~ possible false verification condition
     verify!(buf.len() == 1); //~ provably false verification condition
 }


### PR DESCRIPTION
## Description

Add more simplification rules to help deal with new code generation patterns in the rustc compiler.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
