### PR TITLE
Ignore lifetime parameters when deciding if a function is generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "camino"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35176a56fa5f5efe08df85cd5e68158471c2fa7057e85a5356ee4bd9787a6df9"
+checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
 dependencies = [
  "serde",
 ]
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
@@ -436,9 +436,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.129"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -566,15 +566,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -784,18 +784,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -345,7 +345,12 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
                 !tcx.is_mir_available(callee_defid)
                     || (!callee_defid.is_local()
                         && (self.callee_generic_arguments.is_none()
-                            || self.callee_generic_arguments.unwrap().is_empty())
+                            || self
+                                .callee_generic_arguments
+                                .unwrap()
+                                .types()
+                                .next()
+                                .is_none())
                         && func_args.is_none()),
             );
             let initial_type_cache = self.initial_type_cache.clone();

--- a/checker/tests/call_graph/static_fold.rs
+++ b/checker/tests/call_graph/static_fold.rs
@@ -102,7 +102,7 @@ commit;
       "name": "core.fmt.implement_core_fmt_Arguments.new_v1",
       "file_index": 2,
       "first_line": 390,
-      "local": true
+      "local": false
     }
   ],
   "calls": [
@@ -139,13 +139,6 @@ commit;
       17,
       5,
       2,
-      5
-    ],
-    [
-      2,
-      392,
-      13,
-      5,
       5
     ]
   ]

--- a/checker/tests/call_graph/type_relations.rs
+++ b/checker/tests/call_graph/type_relations.rs
@@ -222,7 +222,7 @@ commit;
       "name": "core.fmt.implement_core_fmt_Arguments.new_v1",
       "file_index": 1,
       "first_line": 390,
-      "local": true
+      "local": false
     },
     {
       "name": "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.into_unique",
@@ -550,13 +550,6 @@ commit;
       21,
       20,
       17
-    ],
-    [
-      1,
-      392,
-      13,
-      13,
-      13
     ],
     [
       10,

--- a/checker/tests/integration_tests.rs
+++ b/checker/tests/integration_tests.rs
@@ -412,8 +412,8 @@ fn check_call_graph_output(
             println!("Actual:\n{}", actual);
             1
             // let c = expected_regex.captures(&test_case_data).unwrap();
-            // let updated = expected_regex
-            //     .replace(&test_case_data, format!("{}\n{}\n{}", &c[1], actual, &c[3]));
+            // let updated =
+            //     expected_regex.replace(&test_case_data, format!("{}{}{}", &c[1], actual, &c[3]));
             // fs::write(Path::new(&file_name), updated.to_string()).unwrap();
             // 0
         }


### PR DESCRIPTION
## Description

Ignore lifetime parameters when deciding if a function is generic for call graph purposes. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh