### PR TITLE
Give diagnostic in default mode when a root function has call with false precondition and unknown path cond

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,9 +879,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/checker/src/body_visitor.rs
+++ b/checker/src/body_visitor.rs
@@ -1614,7 +1614,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
             if cond_as_bool.unwrap_or(false)
                 || self.current_environment.entry_condition.implies(cond_val)
             {
-                return (Some(true), None);
+                return (Some(true), entry_cond_as_bool);
             }
             if !cond_as_bool.unwrap_or(true)
                 || self
@@ -1622,7 +1622,7 @@ impl<'analysis, 'compilation, 'tcx> BodyVisitor<'analysis, 'compilation, 'tcx> {
                     .entry_condition
                     .implies_not(cond_val)
             {
-                return (Some(false), None);
+                return (Some(false), entry_cond_as_bool);
             }
             // The abstract domains are unable to decide if the entry condition is always true.
             // (If it could decide that the condition is always false, we wouldn't be here.)

--- a/checker/src/call_visitor.rs
+++ b/checker/src/call_visitor.rs
@@ -2651,10 +2651,14 @@ impl<'call, 'block, 'analysis, 'compilation, 'tcx>
             let warn;
             if !refined_precondition_as_bool.unwrap_or(true) {
                 // The precondition is definitely false.
-                if entry_cond_as_bool.unwrap_or(false)
-                    && self.block_visitor.bv.function_being_analyzed_is_root()
-                {
-                    // We always get to this call and we are at the analysis root
+                if !entry_cond_as_bool.unwrap_or(true) {
+                    // The call is unreachable, so the precondition does not matter
+                    continue;
+                }
+                if self.block_visitor.bv.function_being_analyzed_is_root() {
+                    // This diagnostic says that the precondition is false and since
+                    // we know for certain that it will be false, should this call be reached,
+                    // it seems appropriate to issue an error message rather than a warning.
                     self.issue_diagnostic_for_call(precondition, &refined_condition, false);
                     return;
                 } else {

--- a/checker/tests/run-pass/false_precon.rs
+++ b/checker/tests/run-pass/false_precon.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// MIRAI_FLAGS --diag=default
+
+// A test that calls a function with a false precondition unconditionally from an analysis root
+
+#![cfg_attr(mirai, allow(incomplete_features), feature(generic_const_exprs))]
+
+use mirai_annotations::*;
+
+struct SecretTaintKind<const MASK: TagPropagationSet> {}
+const MASK: TagPropagationSet = TAG_PROPAGATION_ALL;
+type SecretTaint = SecretTaintKind<MASK>;
+
+fn foo(v: &Vec<i32>) {
+    // This precondition should never be true.
+    precondition!(does_not_have_tag!(&v[0], SecretTaint) && has_tag!(&v[0], SecretTaint));
+    //~ related location
+}
+
+pub fn main() {
+    let v = vec![1, 2, 3];
+    add_tag!(&v, SecretTaint);
+    foo(&v); //~ unsatisfied precondition
+}


### PR DESCRIPTION
## Description

When an analysis root calls a function with precondition that is know to be false, give a diagnostic about it even when in default mode and with uncertainty about whether the call will be reached or not.

In the test case derived from the repro in issue #1176, the call looks like it is deterministically reachable, but the implementation of `vec![1, 2, 3]` is sufficiently complicated that the analysis is unable to conclude that no path inside it will crash, which gives it a post condition that is not known to be true, which leaks into the path condition for the call, which ends up as `false join true` and make this analysis uncertain that the path condition is feasible. The code dealing with false preconditions did not to issue diagnostics in root functions unless the path condition is known to be true. It now issues a diagnostic unless the path condition is known to be false.

Fixes #1176 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh with additional test case
