### PR TITLE
Add workflow to update actions

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -1,0 +1,23 @@
+name: GitHub Actions Version Updater
+
+# Controls when the action will run.
+on:
+  schedule:
+    # Automatically run at 12 AM on every Saturday
+    - cron:  '0 0 * * 6'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.7.4
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
## Description

Keep work flow action versions up to date. This PR adds a workflow that runs on 12 am every Saturday and creates a PR to update action versions if a new version becomes available.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
It will test itself.
