### PR TITLE
update TAG_PROPAGATION_ALL

### DIFF
--- a/annotations/Cargo.toml
+++ b/annotations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mirai-annotations"
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Herman Venter <herman_venter@msn.com>"]
 description = "Macros that provide source code annotations for MIRAI"
 repository = "https://github.com/facebookexperimental/MIRAI"

--- a/annotations/src/lib.rs
+++ b/annotations/src/lib.rs
@@ -182,6 +182,7 @@ pub const TAG_PROPAGATION_ALL: TagPropagationSet = tag_propagation_set!(
     TagPropagation::SubComponent,
     TagPropagation::SubOverflows,
     TagPropagation::SuperComponent,
+    TagPropagation::Transmute,
     TagPropagation::UninterpretedCall
 );
 


### PR DESCRIPTION
## Description

PR #764 Added TagPropagation::Transmute but did not update the constant TAG_PROPAGATION_ALL to included this value. Thanks to @mimoo for pointing this out in #1225.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
CI