### PR TITLE
Fix issues around Z3 sorts and floating-point flags.

### DIFF
--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1139,8 +1139,12 @@ impl Z3Solver {
             Expression::TaggedExpression { operand, .. } => {
                 self.get_as_numeric_z3_ast(&operand.expression)
             }
-            Expression::Transmute { operand, .. } => {
-                self.get_as_numeric_z3_ast(&operand.expression)
+            Expression::Transmute { operand, target_type } => {
+                if target_type.is_integer() || target_type.is_floating_point_number() {
+                    self.numeric_cast(&operand.expression, *target_type)
+                } else {
+                    self.get_as_numeric_z3_ast(&operand.expression)
+                }
             }
             Expression::Top | Expression::Bottom => unsafe {
                 (

--- a/checker/src/z3_solver.rs
+++ b/checker/src/z3_solver.rs
@@ -1952,14 +1952,17 @@ impl Z3Solver {
         let right_bv = self.get_as_bv_z3_ast(&right.expression, num_bits);
         unsafe {
             let does_not_overflow = no_overflow(self.z3_context, left_bv, right_bv, is_signed);
-            if is_signed {
+            let overflows = if is_signed {
                 let does_not_underflow = no_underflow(self.z3_context, left_bv, right_bv);
                 let tmp = vec![does_not_overflow, does_not_underflow];
                 let stays_in_range = z3_sys::Z3_mk_and(self.z3_context, 2, tmp.as_ptr());
                 z3_sys::Z3_mk_not(self.z3_context, stays_in_range)
             } else {
                 z3_sys::Z3_mk_not(self.z3_context, does_not_overflow)
-            }
+            };
+            let bv_true = self.bv_constant(num_bits, &ConstantDomain::True);
+            let bv_false = self.bv_constant(num_bits, &ConstantDomain::False);
+            z3_sys::Z3_mk_ite(self.z3_context, overflows, bv_true, bv_false)
         }
     }
 


### PR DESCRIPTION
## Description
1. Properly set the floating-point flag when `get_as_numeric_z3_ast` meets the `Expression::Transmute` case, by checking the `target_type` and dispatching to `get_as_numeric_z3_ast`.
2. Fix the Z3 sort of the return type to be BitVector, not Boolean, in `bv_overflows`.

Fixes #1252.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
Analyzing `libm` failed previously. Now it works.

## Checklist:
I have run `validate.sh`.
- [x] Fork the repo and create your branch from `main`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete your CLA here: <https://code.facebook.com/cla>

